### PR TITLE
Run device discovery in a loop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,14 @@ FROM fedora:30 AS builder
 
 RUN yum install -y make golang
 
-RUN mkdir /usr/src/linuxptp-daemon
-WORKDIR /usr/src/linuxptp-daemon
-
-COPY go.mod .
-COPY go.sum .
-
-RUN go mod download
+ENV GOPATH="/go"
+WORKDIR /go/src/github.com/openshift/linuxptp-daemon
 
 COPY . .
-
-RUN make clean && go build -tags no_openssl -o bin/ptp ./cmd
+RUN make clean && make
 
 FROM fedora:30
 RUN yum install -y linuxptp ethtool make hwdata
-COPY --from=builder /usr/src/linuxptp-daemon/bin/ptp /usr/local/bin/ptp
+COPY --from=builder /go/src/github.com/openshift/linuxptp-daemon/bin/ptp /usr/local/bin/ptp
 
 CMD ["/usr/local/bin/ptp"]

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,12 +1,10 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
-ADD . /usr/src/linuxptp-daemon
-
-WORKDIR /usr/src/linuxptp-daemon
-ENV GO111MODULE=off
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
+WORKDIR /go/src/github.com/openshift/linuxptp-daemon
+COPY . .
 RUN make clean && make
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 RUN yum -y update && yum --setopt=skip_missing_names_on_install=False -y install linuxptp ethtool hwdata && yum clean all
-COPY --from=builder /usr/src/linuxptp-daemon/bin/ptp /usr/local/bin/
+COPY --from=builder /go/src/github.com/openshift/linuxptp-daemon/bin/ptp /usr/local/bin/
 
 CMD ["/usr/local/bin/ptp"]

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-# go mod
-# go build -o bin/ptp ./cmd
-
-echo "Building ptp binary without go module"
-
 ORG_PATH="github.com/openshift"
 REPO_PATH="${ORG_PATH}/linuxptp-daemon"
 
@@ -16,5 +11,4 @@ fi
 export GO15VENDOREXPERIMENT=1
 export GOBIN=${PWD}/bin
 export GOPATH=${PWD}/.gopath
-go build -tags no_openssl "$@" -o bin/ptp ${REPO_PATH}/cmd
-
+go build --mod=vendor -tags no_openssl "$@" -o bin/ptp ${REPO_PATH}/cmd

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,37 +6,37 @@ import (
 	"os/user"
 	"path/filepath"
 
-        "k8s.io/client-go/rest"
-        "k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 const (
 	DefaultUpdateInterval = 30
-	DefaultProfilePath = "/etc/linuxptp"
+	DefaultProfilePath    = "/etc/linuxptp"
 )
 
 func GetKubeConfig() (*rest.Config, error) {
-        configFromFlags := func(kubeConfig string) (*rest.Config, error) {
-                if _, err := os.Stat(kubeConfig); err != nil {
-                        return nil, fmt.Errorf("Cannot stat kubeconfig '%s'", kubeConfig)
-                }
-                return clientcmd.BuildConfigFromFlags("", kubeConfig)
-        }
+	configFromFlags := func(kubeConfig string) (*rest.Config, error) {
+		if _, err := os.Stat(kubeConfig); err != nil {
+			return nil, fmt.Errorf("Cannot stat kubeconfig '%s'", kubeConfig)
+		}
+		return clientcmd.BuildConfigFromFlags("", kubeConfig)
+	}
 
-        // If an env variable is specified with the config location, use that
-        kubeConfig := os.Getenv("KUBECONFIG")
-        if len(kubeConfig) > 0 {
-                return configFromFlags(kubeConfig)
-        }
-        // If no explicit location, try the in-cluster config
-        if c, err := rest.InClusterConfig(); err == nil {
-                return c, nil
-        }
-        // If no in-cluster config, try the default location in the user's home directory
-        if usr, err := user.Current(); err == nil {
-                kubeConfig := filepath.Join(usr.HomeDir, ".kube", "config")
-                return configFromFlags(kubeConfig)
-        }
+	// If an env variable is specified with the config location, use that
+	kubeConfig := os.Getenv("KUBECONFIG")
+	if len(kubeConfig) > 0 {
+		return configFromFlags(kubeConfig)
+	}
+	// If no explicit location, try the in-cluster config
+	if c, err := rest.InClusterConfig(); err == nil {
+		return c, nil
+	}
+	// If no in-cluster config, try the default location in the user's home directory
+	if usr, err := user.Current(); err == nil {
+		kubeConfig := filepath.Join(usr.HomeDir, ".kube", "config")
+		return configFromFlags(kubeConfig)
+	}
 
-        return nil, fmt.Errorf("Could not locate a kubeconfig")
+	return nil, fmt.Errorf("Could not locate a kubeconfig")
 }

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -22,7 +22,7 @@ const (
 	PTPNamespace = "openshift"
 	PTPSubsystem = "ptp"
 
-	ptp4lProcessName = "ptp4l"
+	ptp4lProcessName   = "ptp4l"
 	phc2sysProcessName = "phc2sys"
 )
 
@@ -33,33 +33,33 @@ var (
 		prometheus.GaugeOpts{
 			Namespace: PTPNamespace,
 			Subsystem: PTPSubsystem,
-			Name: "offset_from_master",
-			Help: "",
-		},[]string{"process","node"})
+			Name:      "offset_from_master",
+			Help:      "",
+		}, []string{"process", "node"})
 
 	MaxOffsetFromMaster = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: PTPNamespace,
 			Subsystem: PTPSubsystem,
-			Name: "max_offset_from_master",
-			Help: "",
-		},[]string{"process","node"})
+			Name:      "max_offset_from_master",
+			Help:      "",
+		}, []string{"process", "node"})
 
 	FrequencyAdjustment = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: PTPNamespace,
 			Subsystem: PTPSubsystem,
-			Name: "frequency_adjustment",
-			Help: "",
-		},[]string{"process","node"})
+			Name:      "frequency_adjustment",
+			Help:      "",
+		}, []string{"process", "node"})
 
 	DelayFromMaster = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: PTPNamespace,
 			Subsystem: PTPSubsystem,
-			Name: "delay_from_master",
-			Help: "",
-		},[]string{"process","node"})
+			Name:      "delay_from_master",
+			Help:      "",
+		}, []string{"process", "node"})
 )
 
 var registerMetrics sync.Once
@@ -82,23 +82,23 @@ func RegisterMetrics(nodeName string) {
 // updatePTPMetrics ...
 func updatePTPMetrics(process string, offsetFromMaster, maxOffsetFromMaster, frequencyAdjustment, delayFromMaster float64) {
 	OffsetFromMaster.With(prometheus.Labels{
-	"process": process,"node": NodeName}).Set(offsetFromMaster)
+		"process": process, "node": NodeName}).Set(offsetFromMaster)
 
 	MaxOffsetFromMaster.With(prometheus.Labels{
-	"process": process,"node": NodeName}).Set(maxOffsetFromMaster)
+		"process": process, "node": NodeName}).Set(maxOffsetFromMaster)
 
 	FrequencyAdjustment.With(prometheus.Labels{
-		"process": process,"node": NodeName}).Set(frequencyAdjustment)
+		"process": process, "node": NodeName}).Set(frequencyAdjustment)
 
 	DelayFromMaster.With(prometheus.Labels{
-		"process": process,"node": NodeName}).Set(delayFromMaster)
+		"process": process, "node": NodeName}).Set(delayFromMaster)
 }
 
 // extractMetrics ...
-func extractMetrics(processName, output string){
-	if strings.Contains(output,"max") {
-		offsetFromMaster, maxOffsetFromMaster, frequencyAdjustment, delayFromMaster := extractSummaryMetrics(processName,output)
-		updatePTPMetrics(processName,offsetFromMaster, maxOffsetFromMaster, frequencyAdjustment, delayFromMaster)
+func extractMetrics(processName, output string) {
+	if strings.Contains(output, "max") {
+		offsetFromMaster, maxOffsetFromMaster, frequencyAdjustment, delayFromMaster := extractSummaryMetrics(processName, output)
+		updatePTPMetrics(processName, offsetFromMaster, maxOffsetFromMaster, frequencyAdjustment, delayFromMaster)
 	}
 }
 
@@ -109,20 +109,19 @@ func extractSummaryMetrics(processName, output string) (offsetFromMaster, maxOff
 	output = output[indx:]
 	fields := strings.Fields(output)
 
-
 	offsetFromMaster, err := strconv.ParseFloat(fields[1], 64)
 	if err != nil {
-		glog.Errorf("%s failed to parse offset from master output %s error %v",processName,fields[1], err)
+		glog.Errorf("%s failed to parse offset from master output %s error %v", processName, fields[1], err)
 	}
 
 	maxOffsetFromMaster, err = strconv.ParseFloat(fields[3], 64)
 	if err != nil {
-		glog.Errorf("%s failed to parse max offset from master output %s error %v",processName,fields[3], err)
+		glog.Errorf("%s failed to parse max offset from master output %s error %v", processName, fields[3], err)
 	}
 
 	frequencyAdjustment, err = strconv.ParseFloat(fields[5], 64)
 	if err != nil {
-		glog.Errorf("%s failed to parse frequency adjustment output %s error %v",processName,fields[5], err)
+		glog.Errorf("%s failed to parse frequency adjustment output %s error %v", processName, fields[5], err)
 	}
 
 	if len(fields) >= 10 {
@@ -141,27 +140,27 @@ func extractSummaryMetrics(processName, output string) (offsetFromMaster, maxOff
 func addFlagsForMonitor(nodeProfile *ptpv1.PtpProfile) {
 	// If output doesn't exist we add it for the prometheus exporter
 	if nodeProfile.Phc2sysOpts != nil {
-		if !strings.Contains(*nodeProfile.Phc2sysOpts,"-m") {
+		if !strings.Contains(*nodeProfile.Phc2sysOpts, "-m") {
 			glog.Info("adding -m to print messages to stdout for phc2sys to use prometheus exporter")
-			*nodeProfile.Phc2sysOpts = fmt.Sprintf("%s -m",*nodeProfile.Phc2sysOpts)
+			*nodeProfile.Phc2sysOpts = fmt.Sprintf("%s -m", *nodeProfile.Phc2sysOpts)
 		}
 
-		if !strings.Contains(*nodeProfile.Phc2sysOpts,"-u") {
+		if !strings.Contains(*nodeProfile.Phc2sysOpts, "-u") {
 			glog.Info("adding -u 1 to print summary messages to stdout for phc2sys to use prometheus exporter")
-			*nodeProfile.Phc2sysOpts = fmt.Sprintf("%s -u 1",*nodeProfile.Phc2sysOpts)
+			*nodeProfile.Phc2sysOpts = fmt.Sprintf("%s -u 1", *nodeProfile.Phc2sysOpts)
 		}
 	}
 
 	// If output doesn't exist we add it for the prometheus exporter
 	if nodeProfile.Ptp4lOpts != nil {
-		if !strings.Contains(*nodeProfile.Ptp4lOpts,"-m") {
+		if !strings.Contains(*nodeProfile.Ptp4lOpts, "-m") {
 			glog.Info("adding -m to print messages to stdout for ptp4l to use prometheus exporter")
-			*nodeProfile.Ptp4lOpts = fmt.Sprintf("%s -m",*nodeProfile.Ptp4lOpts)
+			*nodeProfile.Ptp4lOpts = fmt.Sprintf("%s -m", *nodeProfile.Ptp4lOpts)
 		}
 
-		if !strings.Contains(*nodeProfile.Ptp4lOpts,"--summary_interval") {
+		if !strings.Contains(*nodeProfile.Ptp4lOpts, "--summary_interval") {
 			glog.Info("adding --summary_interval 1 to print summary messages to stdout for ptp4l to use prometheus exporter")
-			*nodeProfile.Ptp4lOpts = fmt.Sprintf("%s --summary_interval 1",*nodeProfile.Ptp4lOpts)
+			*nodeProfile.Ptp4lOpts = fmt.Sprintf("%s --summary_interval 1", *nodeProfile.Ptp4lOpts)
 		}
 	}
 }

--- a/pkg/daemon/ptpdev.go
+++ b/pkg/daemon/ptpdev.go
@@ -2,7 +2,12 @@ package daemon
 
 import (
 	"github.com/golang/glog"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"time"
+
 	ptpv1 "github.com/openshift/ptp-operator/pkg/apis/ptp/v1"
+	ptpclient "github.com/openshift/ptp-operator/pkg/client/clientset/versioned"
+
 	ptpnetwork "github.com/openshift/linuxptp-daemon/pkg/network"
 )
 
@@ -27,4 +32,42 @@ func GetDevStatusUpdate(nodePTPDev *ptpv1.NodePtpDevice) (*ptpv1.NodePtpDevice, 
 		}
 	}
 	return nodePTPDev, nil
+}
+
+func runDeviceStatusUpdate(ptpClient *ptpclient.Clientset, nodeName string) {
+	// Discover PTP capable devices
+	// Don't return in case of discover failure
+	ptpDevs, err := ptpnetwork.DiscoverPTPDevices()
+	if err != nil {
+		glog.Errorf("discover PTP devices failed: %v", err)
+	}
+	glog.Infof("PTP capable NICs: %v", ptpDevs)
+
+	// Assume NodePtpDevice CR for this particular node
+	// is already created manually or by PTP-Operator.
+	ptpDev, err := ptpClient.PtpV1().NodePtpDevices(PtpNamespace).Get(nodeName, metav1.GetOptions{})
+	if err != nil {
+		glog.Errorf("failed to get NodePtpDevice CR for node %s: %v", nodeName, err)
+	}
+
+	// Render status of NodePtpDevice CR by inspecting PTP capability of node network devices
+	ptpDev, err = GetDevStatusUpdate(ptpDev)
+	if err != nil {
+		glog.Errorf("failed to get device status: %v", err)
+	}
+
+	// Update NodePtpDevice CR
+	_, err = ptpClient.PtpV1().NodePtpDevices(PtpNamespace).UpdateStatus(ptpDev)
+	if err != nil {
+		glog.Errorf("failed to update Node PTP device CR: %v", err)
+	}
+}
+
+func RunDeviceStatusUpdate(ptpClient *ptpclient.Clientset, nodeName string) {
+	t := time.Tick(1 * time.Minute)
+	for {
+		glog.Info("run device status update function")
+		runDeviceStatusUpdate(ptpClient, nodeName)
+		<-t
+	}
 }


### PR DESCRIPTION
Create a loop for the device discovery.

This PR also changes the Dockerfiles to use the vendor folder on the build and not fetch the modules.

Related to the follow error:
```
PTP capable NICs: [eno1 eno2]
E0418 22:40:28.559220    4744 main.go:84] failed to get NodePtpDevice CR for node cnfd1-worker-0.fci1.kni.lab.eng.bos.redhat.com: Get https://172.30.0.1:443/apis/ptp.openshift.io/v1/namespac
es/openshift-ptp/nodeptpdevices/cnfd1-worker-0.fci1.kni.lab.eng.bos.redhat.com: dial tcp 172.30.0.1:443: i/o timeout
I0418 22:40:28.587016    4744 ptpdev.go:15] PTP capable NICs: [eno1 eno2]
E0418 22:40:28.587075    4744 main.go:93] failed to update Node PTP device CR: resource name may not be empty
I0418 22:40:58.589483    4744 main.go:122] ticker pull
```
