### PR TITLE
Fix crash on update if no policy exist

### DIFF
--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -53,6 +53,13 @@ func (l *LinuxPTPConfUpdate) UpdateConfig(nodeProfilesJson []byte) error {
 	}
 
 	if nodeProfiles, ok := tryToLoadOldConfig(nodeProfilesJson); ok {
+		// Support empty old config
+		// '{"name":null,"interface":null}'
+		if nodeProfiles[0].Name == nil || nodeProfiles[0].Interface == nil {
+			glog.Infof("Skip no profile %+v", nodeProfiles[0])
+			return nil
+		}
+
 		glog.Info("load profiles using old method")
 		l.appliedNodeProfileJson = nodeProfilesJson
 		l.NodeProfiles = nodeProfiles


### PR DESCRIPTION
This commit this a crash when there is no policy before the upgrade

```
I1122 12:36:17.903050 1546704 ptpdev.go:21] PTP capable NICs: [eno1 eno2]
I1122 12:36:47.820480 1546704 main.go:98] ticker pull
I1122 12:36:47.820680 1546704 config.go:56] load profiles using old method
I1122 12:36:47.820699 1546704 daemon.go:110] in applyNodePTPProfiles
I1122 12:36:47.820703 1546704 daemon.go:132] updating NodePTPProfiles to:
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1198e56]

goroutine 122 [running]:
github.com/openshift/linuxptp-daemon/pkg/daemon.(*Daemon).addProfileConfig(0xc0002f8080, 0xc000042180, 0x17, 0xc00064feb0)
	/go/src/github.com/openshift/linuxptp-daemon/pkg/daemon/daemon.go:210 +0x146
github.com/openshift/linuxptp-daemon/pkg/daemon.(*Daemon).applyNodePtpProfile(0xc0002f8080, 0x0, 0xc00064feb0, 0x1c, 0x0)
	/go/src/github.com/openshift/linuxptp-daemon/pkg/daemon/daemon.go:158 +0xef
github.com/openshift/linuxptp-daemon/pkg/daemon.(*Daemon).applyNodePTPProfiles(0xc0002f8080, 0xc00064ff58, 0x2)
	/go/src/github.com/openshift/linuxptp-daemon/pkg/daemon/daemon.go:135 +0x2da
github.com/openshift/linuxptp-daemon/pkg/daemon.(*Daemon).Run(0xc0002f8080)
	/go/src/github.com/openshift/linuxptp-daemon/pkg/daemon/daemon.go:86 +0xc8
created by main.main
	/go/src/github.com/openshift/linuxptp-daemon/cmd/main.go:79 +0x584

```

Signed-off-by: Sebastian Sch <sebassch@gmail.com>