### PR TITLE
Bug 1901200: Fix metrics expose on debug level

### DIFF
--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -96,10 +96,10 @@ func updatePTPMetrics(process, iface string, offsetFromMaster, maxOffsetFromMast
 
 // extractMetrics ...
 func extractMetrics(processName, iface, output string) {
-	if strings.Contains(output, "max") {
+	if strings.Contains(output, " max ") {
 		offsetFromMaster, maxOffsetFromMaster, frequencyAdjustment, delayFromMaster := extractSummaryMetrics(processName, output)
 		updatePTPMetrics(processName, iface, offsetFromMaster, maxOffsetFromMaster, frequencyAdjustment, delayFromMaster)
-	} else if strings.Contains(output, "offset") {
+	} else if strings.Contains(output, " offset ") {
 		offsetFromMaster, maxOffsetFromMaster, frequencyAdjustment, delayFromMaster := extractRegularMetrics(processName, output)
 		updatePTPMetrics(processName, iface, offsetFromMaster, maxOffsetFromMaster, frequencyAdjustment, delayFromMaster)
 	}


### PR DESCRIPTION
This commit fix the debug logs level for the ptp4l.

```
ptp4l[76012.431]: [ens5f0] config item (null).free_running is 0
ptp4l[76012.431]: [ens5f0] config item (null).freq_est_interval is 1
ptp4l[76012.431]: [ens5f0] config item (null).gmCapable is 1
ptp4l[76012.432]: [ens5f0] config item (null).kernel_leap is 1
ptp4l[76012.432]: [ens5f0] config item (null).utc_offset is 37
E1124 15:48:57.058232 3935542 metrics.go:157] ptp4l failed to parse output offset is 37: unexpected number of fields
ptp4l[76012.432]: [ens5f0] config item (null).timeSource is 160
ptp4l[76012.432]: [ens5f0] config item (null).pi_proportional_const is 0.000000
ptp4l[76012.432]: [ens5f0] config item (null).pi_integral_const is 0.000000
ptp4l[76012.432]: [ens5f0] config item (null).pi_proportional_scale is 0.000000
ptp4l[76012.432]: [ens5f0] config item (null).pi_proportional_exponent is -0.300000
ptp4l[76012.432]: [ens5f0] config item (null).pi_proportional_norm_max is 0.700000
panic: runtime error: slice bounds out of range [-1:]

goroutine 161 [running]:
github.com/openshift/linuxptp-daemon/pkg/daemon.extractSummaryMetrics(0x13ea89e, 0x5, 0xc00008a900, 0x52, 0x43, 0x0, 0xc0002491e0, 0x0)
	/go/src/github.com/openshift/linuxptp-daemon/pkg/daemon/metrics.go:112 +0x895
github.com/openshift/linuxptp-daemon/pkg/daemon.extractMetrics(0x13ea89e, 0x5, 0xc000305930, 0x6, 0xc00008a900, 0x52)
	/go/src/github.com/openshift/linuxptp-daemon/pkg/daemon/metrics.go:100 +0x85
github.com/openshift/linuxptp-daemon/pkg/daemon.cmdRun.func2(0xc0002def80, 0xc000201db0, 0xc00008aea0)
	/go/src/github.com/openshift/linuxptp-daemon/pkg/daemon/daemon.go:260 +0x11e
created by github.com/openshift/linuxptp-daemon/pkg/daemon.cmdRun
	/go/src/github.com/openshift/linuxptp-daemon/pkg/daemon/daemon.go:256 +0x3b6

```

Signed-off-by: Sebastian Sch <sebassch@gmail.com>