### PR TITLE
Bug 1914303: Add cmd stderr redirection to os.Stderr

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -244,6 +244,10 @@ func cmdRun(p *ptpProcess) {
 		p.exitCh <- true
 	}()
 
+	//
+	// don't discard process stderr output
+	//
+	p.cmd.Stderr = os.Stderr
 	cmdReader, err := p.cmd.StdoutPipe()
 	if err != nil {
 		glog.Errorf("cmdRun() error creating StdoutPipe for %s: %v", p.name, err)


### PR DESCRIPTION
Short fix for https://bugzilla.redhat.com/show_bug.cgi?id=1914303

It is helpful to get all ptp4l and phc2sys log output (stdout and stderr) for troubleshooting purpose.
