### PR TITLE
Bug 1955196: ethtool output change

### DIFF
--- a/pkg/network/utils.go
+++ b/pkg/network/utils.go
@@ -16,9 +16,6 @@ const (
 	_ETHTOOL_HARDWARE_RECEIVE_CAP   = "hardware-receive"
 	_ETHTOOL_HARDWARE_TRANSMIT_CAP  = "hardware-transmit"
 	_ETHTOOL_HARDWARE_RAW_CLOCK_CAP = "hardware-raw-clock"
-	_ETHTOOL_RX_HARDWARE_FLAG       = "(SOF_TIMESTAMPING_RX_HARDWARE)"
-	_ETHTOOL_TX_HARDWARE_FLAG       = "(SOF_TIMESTAMPING_TX_HARDWARE)"
-	_ETHTOOL_RAW_HARDWARE_FLAG      = "(SOF_TIMESTAMPING_RAW_HARDWARE)"
 )
 
 func ethtoolInstalled() bool {
@@ -37,13 +34,13 @@ func netParseEthtoolTimeStampFeature(cmdOut *bytes.Buffer) bool {
 		line := strings.TrimPrefix(scanner.Text(), "\t")
 		parts := strings.Fields(line)
 		if parts[0] == _ETHTOOL_HARDWARE_RECEIVE_CAP {
-			hardRxEnabled = parts[1] == _ETHTOOL_RX_HARDWARE_FLAG
+			hardRxEnabled = true
 		}
 		if parts[0] == _ETHTOOL_HARDWARE_TRANSMIT_CAP {
-			hardTxEnabled = parts[1] == _ETHTOOL_TX_HARDWARE_FLAG
+			hardTxEnabled = true
 		}
 		if parts[0] == _ETHTOOL_HARDWARE_RAW_CLOCK_CAP {
-			hardRawEnabled = parts[1] == _ETHTOOL_RAW_HARDWARE_FLAG
+			hardRawEnabled = true
 		}
 	}
 	return hardRxEnabled && hardTxEnabled && hardRawEnabled


### PR DESCRIPTION
This commit fix the linuxptp to work with the latest ethtool version on rhcos

ethtool output on old version:
```
ethtool.x86_64                     2:5.4-1.fc30                     @updates
Time stamping parameters for eno1:
Capabilities:
	hardware-transmit     (SOF_TIMESTAMPING_TX_HARDWARE)
	software-transmit     (SOF_TIMESTAMPING_TX_SOFTWARE)
	hardware-receive      (SOF_TIMESTAMPING_RX_HARDWARE)
	software-receive      (SOF_TIMESTAMPING_RX_SOFTWARE)
	software-system-clock (SOF_TIMESTAMPING_SOFTWARE)
	hardware-raw-clock    (SOF_TIMESTAMPING_RAW_HARDWARE)
PTP Hardware Clock: 0
Hardware Transmit Timestamp Modes:
	off                   (HWTSTAMP_TX_OFF)
	on                    (HWTSTAMP_TX_ON)
Hardware Receive Filter Modes:
	none                  (HWTSTAMP_FILTER_NONE)
	ptpv1-l4-event        (HWTSTAMP_FILTER_PTP_V1_L4_EVENT)
	ptpv2-l4-event        (HWTSTAMP_FILTER_PTP_V2_L4_EVENT)
	ptpv2-l2-event        (HWTSTAMP_FILTER_PTP_V2_L2_EVENT)
```

ethtool output on latest version:
```
ethtool.x86_64                                2:5.8-5.el8                          @rhel-8-baseos-rpms-x86_64
Time stamping parameters for eno1:
Capabilities:
	hardware-transmit
	hardware-receive
	hardware-raw-clock
PTP Hardware Clock: 2
Hardware Transmit Timestamp Modes:
	off
	on
Hardware Receive Filter Modes:
	none
	all
```

panic:
```
I0429 09:44:03.041764  157851 utils.go:68] grabbing NIC timestamp capability for ede735fcddbb336
I0429 09:44:03.042305  157851 utils.go:34] cmd output for Time stamping parameters for ede735fcddbb336:
Capabilities:
	software-transmit
	software-receive
	software-system-clock
PTP Hardware Clock: none
Hardware Transmit Timestamp Modes: none
Hardware Receive Filter Modes: none
I0429 09:44:03.042315  157851 utils.go:68] grabbing NIC timestamp capability for eno1
I0429 09:44:03.042919  157851 utils.go:34] cmd output for Time stamping parameters for eno1:
Capabilities:
	hardware-transmit
	hardware-receive
	hardware-raw-clock
PTP Hardware Clock: 2
Hardware Transmit Timestamp Modes:
	off
	on
Hardware Receive Filter Modes:
	none
	all
panic: runtime error: index out of range [1] with length 1

goroutine 80 [running]:
github.com/openshift/linuxptp-daemon/pkg/network.netParseEthtoolTimeStampFeature(0xc000806000, 0x0)
	/go/src/github.com/openshift/linuxptp-daemon/pkg/network/utils.go:43 +0x4ba
github.com/openshift/linuxptp-daemon/pkg/network.DiscoverPTPDevices(0x0, 0x12dfca0, 0xc0001aa410, 0xc0000e7ef0, 0x4e)
	/go/src/github.com/openshift/linuxptp-daemon/pkg/network/utils.go:76 +0x2e5
github.com/openshift/linuxptp-daemon/pkg/daemon.runDeviceStatusUpdate(0xc000591c10, 0xc00004604a, 0x27)
	/go/src/github.com/openshift/linuxptp-daemon/pkg/daemon/ptpdev.go:34 +0x34
github.com/openshift/linuxptp-daemon/pkg/daemon.RunDeviceStatusUpdate(0xc000591c10, 0xc00004604a, 0x27)
	/go/src/github.com/openshift/linuxptp-daemon/pkg/daemon/ptpdev.go:64 +0xc5
created by main.main
	/go/src/github.com/openshift/linuxptp-daemon/cmd/main.go:68 +0x4aa
```

Signed-off-by: Sebastian Sch <sebassch@gmail.com>