### PR TITLE
Bug 1993854: add metrics for multi interface

### DIFF
--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -84,7 +84,7 @@ var (
 		prometheus.GaugeOpts{
 			Namespace: PTPNamespace,
 			Subsystem: PTPSubsystem,
-			Name:      "frequency_adjustment",
+			Name:      "frequency_adjustment_from_master",
 			Help:      "",
 		}, []string{"process", "node", "iface"})
 
@@ -93,6 +93,22 @@ var (
 			Namespace: PTPNamespace,
 			Subsystem: PTPSubsystem,
 			Name:      "delay_from_master",
+			Help:      "",
+		}, []string{"process", "node", "iface"})
+
+	DelayFromSystem = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: PTPNamespace,
+			Subsystem: PTPSubsystem,
+			Name:      "delay_from_system",
+			Help:      "",
+		}, []string{"process", "node", "iface"})
+
+	FrequencyAdjustmentFromSystem = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: PTPNamespace,
+			Subsystem: PTPSubsystem,
+			Name:      "frequency_adjustment_from_system",
 			Help:      "",
 		}, []string{"process", "node", "iface"})
 
@@ -123,6 +139,8 @@ func RegisterMetrics(nodeName string) {
 		prometheus.MustRegister(MaxOffsetFromMaster)
 		prometheus.MustRegister(FrequencyAdjustment)
 		prometheus.MustRegister(DelayFromMaster)
+		prometheus.MustRegister(FrequencyAdjustmentFromSystem)
+		prometheus.MustRegister(DelayFromSystem)
 		prometheus.MustRegister(OffsetFromSystem)
 		prometheus.MustRegister(MaxOffsetFromSystem)
 		prometheus.MustRegister(InterfaceRole)
@@ -159,10 +177,10 @@ func updatePTPSystemMetrics(process, iface string, offsetFromMaster, maxOffsetFr
 	MaxOffsetFromSystem.With(prometheus.Labels{
 		"process": process, "node": NodeName, "iface": iface}).Set(maxOffsetFromMaster)
 
-	FrequencyAdjustment.With(prometheus.Labels{
+	FrequencyAdjustmentFromSystem.With(prometheus.Labels{
 		"process": process, "node": NodeName, "iface": iface}).Set(frequencyAdjustment)
 
-	DelayFromMaster.With(prometheus.Labels{
+	DelayFromSystem.With(prometheus.Labels{
 		"process": process, "node": NodeName, "iface": iface}).Set(delayFromMaster)
 }
 

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -24,6 +24,25 @@ const (
 
 	ptp4lProcessName   = "ptp4l"
 	phc2sysProcessName = "phc2sys"
+	clockRealTime      = "CLOCK_REALTIME"
+	master             = "master"
+)
+
+const (
+	//LOCKED ...
+	LOCKED string = "LOCKED"
+	//FREERUN ...
+	FREERUN = "FREERUN"
+)
+
+type ptpPortRole int
+
+const (
+	PASSIVE ptpPortRole = iota
+	SLAVE
+	MASTER
+	FAULTY
+	UNKNOWN
 )
 
 var (
@@ -45,6 +64,22 @@ var (
 			Help:      "",
 		}, []string{"process", "node", "iface"})
 
+	OffsetFromSystem = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: PTPNamespace,
+			Subsystem: PTPSubsystem,
+			Name:      "offset_from_system",
+			Help:      "",
+		}, []string{"process", "node", "iface"})
+
+	MaxOffsetFromSystem = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: PTPNamespace,
+			Subsystem: PTPSubsystem,
+			Name:      "max_offset_from_system",
+			Help:      "",
+		}, []string{"process", "node", "iface"})
+
 	FrequencyAdjustment = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: PTPNamespace,
@@ -60,6 +95,24 @@ var (
 			Name:      "delay_from_master",
 			Help:      "",
 		}, []string{"process", "node", "iface"})
+
+	// ClockState metrics to show current clock state
+	ClockState = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: PTPNamespace,
+			Subsystem: PTPSubsystem,
+			Name:      "clock_state",
+			Help:      "0 = FREERUN, 1 = LOCKED, 2 = HOLDOVER",
+		}, []string{"process", "node", "iface"})
+
+	// Threshold metrics to show current ptp threshold
+	InterfaceRole = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: PTPNamespace,
+			Subsystem: PTPSubsystem,
+			Name:      "ptp_interface_role",
+			Help:      "0 = PASSIVE 1 = SLAVE 2 = MASTER 3 = FAULTY",
+		}, []string{"process", "node", "iface"})
 )
 
 var registerMetrics sync.Once
@@ -70,6 +123,10 @@ func RegisterMetrics(nodeName string) {
 		prometheus.MustRegister(MaxOffsetFromMaster)
 		prometheus.MustRegister(FrequencyAdjustment)
 		prometheus.MustRegister(DelayFromMaster)
+		prometheus.MustRegister(OffsetFromSystem)
+		prometheus.MustRegister(MaxOffsetFromSystem)
+		prometheus.MustRegister(InterfaceRole)
+		prometheus.MustRegister(ClockState)
 
 		// Including these stats kills performance when Prometheus polls with multiple targets
 		prometheus.Unregister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
@@ -94,48 +151,96 @@ func updatePTPMetrics(process, iface string, offsetFromMaster, maxOffsetFromMast
 		"process": process, "node": NodeName, "iface": iface}).Set(delayFromMaster)
 }
 
+// updatePTPSystemMetrics ...
+func updatePTPSystemMetrics(process, iface string, offsetFromMaster, maxOffsetFromMaster, frequencyAdjustment, delayFromMaster float64) {
+	OffsetFromSystem.With(prometheus.Labels{
+		"process": process, "node": NodeName, "iface": iface}).Set(offsetFromMaster)
+
+	MaxOffsetFromSystem.With(prometheus.Labels{
+		"process": process, "node": NodeName, "iface": iface}).Set(maxOffsetFromMaster)
+
+	FrequencyAdjustment.With(prometheus.Labels{
+		"process": process, "node": NodeName, "iface": iface}).Set(frequencyAdjustment)
+
+	DelayFromMaster.With(prometheus.Labels{
+		"process": process, "node": NodeName, "iface": iface}).Set(delayFromMaster)
+}
+
 // extractMetrics ...
-func extractMetrics(processName, iface, output string) {
+func extractMetrics(configName, processName string, ifaces []string, output string) {
 	if strings.Contains(output, " max ") {
-		offsetFromMaster, maxOffsetFromMaster, frequencyAdjustment, delayFromMaster := extractSummaryMetrics(processName, output)
-		updatePTPMetrics(processName, iface, offsetFromMaster, maxOffsetFromMaster, frequencyAdjustment, delayFromMaster)
+		ifaceName, offsetFromMaster, maxOffsetFromMaster, frequencyAdjustment, delayFromMaster := extractSummaryMetrics(configName, processName, output)
+		if ifaceName != "" {
+			if ifaceName == clockRealTime || ifaceName == master {
+				updatePTPMetrics(processName, ifaceName, offsetFromMaster, maxOffsetFromMaster, frequencyAdjustment, delayFromMaster)
+			} else {
+				updatePTPSystemMetrics(processName, ifaceName, offsetFromMaster, maxOffsetFromMaster, frequencyAdjustment, delayFromMaster)
+			}
+		}
+
 	} else if strings.Contains(output, " offset ") {
-		offsetFromMaster, maxOffsetFromMaster, frequencyAdjustment, delayFromMaster := extractRegularMetrics(processName, output)
-		updatePTPMetrics(processName, iface, offsetFromMaster, maxOffsetFromMaster, frequencyAdjustment, delayFromMaster)
+		ifaceName, clockstate, offsetFromMaster, maxOffsetFromMaster, frequencyAdjustment, delayFromMaster := extractRegularMetrics(configName, processName, output)
+		if ifaceName != "" {
+			if ifaceName == clockRealTime || ifaceName == master {
+				updatePTPMetrics(processName, ifaceName, offsetFromMaster, maxOffsetFromMaster, frequencyAdjustment, delayFromMaster)
+			} else {
+				updatePTPSystemMetrics(processName, ifaceName, offsetFromMaster, maxOffsetFromMaster, frequencyAdjustment, delayFromMaster)
+			}
+			updateClockStateMetrics(processName, ifaceName, clockstate)
+		}
+	}
+	if processName == ptp4lProcessName {
+		if portId, role := extractPTP4lEventState(output); portId > 0 {
+			if len(ifaces) >= portId-1 {
+				UpdateInterfaceRoleMetrics(processName, ifaces[portId-1], role)
+			}
+		}
 	}
 }
 
-func extractSummaryMetrics(processName, output string) (offsetFromMaster, maxOffsetFromMaster, frequencyAdjustment, delayFromMaster float64) {
+func extractSummaryMetrics(configName, processName, output string) (iface string, offsetFromMaster, maxOffsetFromMaster, frequencyAdjustment, delayFromMaster float64) {
 	// remove everything before the rms string
 	// This makes the out to equals
+
 	indx := strings.Index(output, "rms")
+	if indx < 0 {
+		return
+	}
+
+	replacer := strings.NewReplacer("[", " ", "]", " ", ":", " ")
+	output = replacer.Replace(output)
+
+	indx = strings.Index(output, configName)
 	output = output[indx:]
 	fields := strings.Fields(output)
 
-	if len(fields) < 5 {
+	//ptp4l.0.config CLOCK_REALTIME rms   31 max   31 freq -77331 +/-   0 delay  1233 +/-   0
+	if len(fields) < 8 {
 		glog.Errorf("%s failed to parse output %s: unexpected number of fields", processName, output)
 		return
 	}
 
-	offsetFromMaster, err := strconv.ParseFloat(fields[1], 64)
+	iface = fields[1]
+
+	offsetFromMaster, err := strconv.ParseFloat(fields[3], 64)
 	if err != nil {
-		glog.Errorf("%s failed to parse offset from master output %s error %v", processName, fields[1], err)
+		glog.Errorf("%s failed to parse offset from master output %s error %v", processName, fields[3], err)
 	}
 
-	maxOffsetFromMaster, err = strconv.ParseFloat(fields[3], 64)
+	maxOffsetFromMaster, err = strconv.ParseFloat(fields[5], 64)
 	if err != nil {
-		glog.Errorf("%s failed to parse max offset from master output %s error %v", processName, fields[3], err)
+		glog.Errorf("%s failed to parse max offset from master output %s error %v", processName, fields[5], err)
 	}
 
-	frequencyAdjustment, err = strconv.ParseFloat(fields[5], 64)
+	frequencyAdjustment, err = strconv.ParseFloat(fields[7], 64)
 	if err != nil {
-		glog.Errorf("%s failed to parse frequency adjustment output %s error %v", processName, fields[5], err)
+		glog.Errorf("%s failed to parse frequency adjustment output %s error %v", processName, fields[7], err)
 	}
 
-	if len(fields) >= 10 {
-		delayFromMaster, err = strconv.ParseFloat(fields[9], 64)
+	if len(fields) >= 11 {
+		delayFromMaster, err = strconv.ParseFloat(fields[11], 64)
 		if err != nil {
-			glog.Errorf("%s failed to parse delay from master output %s error %v", processName, fields[9], err)
+			glog.Errorf("%s failed to parse delay from master output %s error %v", processName, fields[11], err)
 		}
 	} else {
 		// If there is no delay from master this mean we are out of sync
@@ -145,44 +250,120 @@ func extractSummaryMetrics(processName, output string) (offsetFromMaster, maxOff
 	return
 }
 
-func extractRegularMetrics(processName, output string) (offsetFromMaster, maxOffsetFromMaster, frequencyAdjustment, delayFromMaster float64) {
+func extractRegularMetrics(configName, processName, output string) (iface, clockState string, offsetFromMaster, maxOffsetFromMaster, frequencyAdjustment, delayFromMaster float64) {
 	// remove everything before the rms string
 	// This makes the out to equals
-	output = strings.Replace(output, "path", "", 1)
 	indx := strings.Index(output, "offset")
-	output = output[indx:]
+	if indx < 0 {
+		return
+	}
+
+	output = strings.Replace(output, "path", "", 1)
+	replacer := strings.NewReplacer("[", " ", "]", " ", ":", " ", "phc", "")
+	output = replacer.Replace(output)
+
+	index := strings.Index(output, configName)
+	if index == -1 {
+		return
+	}
+	output = output[index:]
 	fields := strings.Fields(output)
 
-	if len(fields) < 5 {
+	if len(fields) < 7 {
 		glog.Errorf("%s failed to parse output %s: unexpected number of fields", processName, output)
 		return
 	}
 
-	offsetFromMaster, err := strconv.ParseFloat(fields[1], 64)
+	iface = fields[1]
+
+	//ptp4l.0.config master offset   -2162130 s2 freq +22451884 path delay    374976
+	offsetFromMaster, err := strconv.ParseFloat(fields[3], 64)
 	if err != nil {
 		glog.Errorf("%s failed to parse offset from master output %s error %v", processName, fields[1], err)
 	}
 
-	maxOffsetFromMaster, err = strconv.ParseFloat(fields[1], 64)
+	maxOffsetFromMaster, err = strconv.ParseFloat(fields[3], 64)
 	if err != nil {
 		glog.Errorf("%s failed to parse max offset from master output %s error %v", processName, fields[1], err)
 	}
 
-	frequencyAdjustment, err = strconv.ParseFloat(fields[4], 64)
-	if err != nil {
-		glog.Errorf("%s failed to parse frequency adjustment output %s error %v", processName, fields[4], err)
+	switch fields[4] {
+	case "s0":
+		clockState = FREERUN
+	case "s1":
+		clockState = FREERUN
+	case "s2":
+		clockState = LOCKED
+	default:
+		clockState = FREERUN
 	}
 
-	if len(fields) >= 7 {
-		delayFromMaster, err = strconv.ParseFloat(fields[6], 64)
+	frequencyAdjustment, err = strconv.ParseFloat(fields[6], 64)
+	if err != nil {
+		glog.Errorf("%s failed to parse frequency adjustment output %s error %v", processName, fields[6], err)
+	}
+
+	if len(fields) > 8 {
+		delayFromMaster, err = strconv.ParseFloat(fields[8], 64)
 		if err != nil {
-			glog.Errorf("%s failed to parse delay from master output %s error %v", processName, fields[6], err)
+			glog.Errorf("%s failed to parse delay from master output %s error %v", processName, fields[8], err)
 		}
 	} else {
 		// If there is no delay from master this mean we are out of sync
 		glog.Warningf("no delay from master process %s out of sync", processName)
 	}
 
+	return
+}
+
+// updateClockStateMetrics ...
+func updateClockStateMetrics(process, iface string, state string) {
+	if state == LOCKED {
+		ClockState.With(prometheus.Labels{
+			"process": process, "node": NodeName, "iface": iface}).Set(1)
+	} else {
+		ClockState.With(prometheus.Labels{
+			"process": process, "node": NodeName, "iface": iface}).Set(0)
+	}
+}
+
+func UpdateInterfaceRoleMetrics(process string, iface string, role ptpPortRole) {
+	InterfaceRole.With(prometheus.Labels{
+		"process": process, "node": NodeName, "iface": iface}).Set(float64(role))
+}
+
+func extractPTP4lEventState(output string) (portId int, role ptpPortRole) {
+	replacer := strings.NewReplacer("[", " ", "]", " ", ":", " ")
+	output = replacer.Replace(output)
+
+	index := strings.Index(output, " port ")
+	if index == -1 {
+		return
+	}
+	output = output[index:]
+	fields := strings.Fields(output)
+	portIndex := fields[1]
+	role = UNKNOWN
+	var e error
+	portId, e = strconv.Atoi(portIndex)
+	if e != nil {
+		glog.Errorf("error parsing port id %s", e)
+		portId = 0
+		return
+	}
+
+	if strings.Contains(output, "UNCALIBRATED to SLAVE") {
+		role = SLAVE
+	} else if strings.Contains(output, "UNCALIBRATED to PASSIVE") || strings.Contains(output, "MASTER to PASSIVE") ||
+		strings.Contains(output, "SLAVE to PASSIVE") {
+		role = PASSIVE
+	} else if strings.Contains(output, "UNCALIBRATED to MASTER") || strings.Contains(output, "LISTENING to MASTER") {
+		role = MASTER
+	} else if strings.Contains(output, "FAULT_DETECTED") || strings.Contains(output, "SYNCHRONIZATION_FAULT") {
+		role = FAULTY
+	} else {
+		portId = 0
+	}
 	return
 }
 


### PR DESCRIPTION
This PR fixes Prometheus  metrics for multi interface and single interface case.
Last PR added config filename  to the log instead of interface and and then extract metrics method signature was changed to send   list of interfaces to parse and match the port id from the role to determine the interface role.
This PR uses those changes to update Prometheus metrics , by adding new metrics and updating existing now.
Introduced following metrics 
openshift_ptp_clock_state{iface="master",node="cnfde7.ptp.lab.eng.bos.redhat.com",process="ptp4l"}
openshift_ptp_ptp_interface_role{iface="ens5f1",node="cnfde7.ptp.lab.eng.bos.redhat.com",process="ptp4l"} 1
openshift_ptp_delay_from_system{iface="ens7f1",node="cnfde7.ptp.lab.eng.bos.redhat.com",process="phc2sys"} 2720

Single interface Metrics 
```
# HELP openshift_ptp_clock_state 0 = FREERUN, 1 = LOCKED, 2 = HOLDOVER
# TYPE openshift_ptp_clock_state gauge
openshift_ptp_clock_state{iface="master",node="cnfde7.ptp.lab.eng.bos.redhat.com",process="ptp4l"} 1
// linux ptp daemon uses summary update (rms) for logs , hence there is no lock state for CLOCK_REALTIME. The side car discourages -u and hence its avilable in sidecar
# HELP openshift_ptp_delay_from_master 
# TYPE openshift_ptp_delay_from_master gauge
openshift_ptp_delay_from_master{iface="CLOCK_REALTIME",node="cnfde7.ptp.lab.eng.bos.redhat.com",process="phc2sys"} 1234
openshift_ptp_delay_from_master{iface="master",node="cnfde7.ptp.lab.eng.bos.redhat.com",process="ptp4l"} 80
# HELP openshift_ptp_frequency_adjustment 
# TYPE openshift_ptp_frequency_adjustment gauge
openshift_ptp_frequency_adjustment{iface="CLOCK_REALTIME",node="cnfde7.ptp.lab.eng.bos.redhat.com",process="phc2sys"} -77549
openshift_ptp_frequency_adjustment{iface="master",node="cnfde7.ptp.lab.eng.bos.redhat.com",process="ptp4l"} -2011
# HELP openshift_ptp_max_offset_from_master 
# TYPE openshift_ptp_max_offset_from_master gauge
openshift_ptp_max_offset_from_master{iface="CLOCK_REALTIME",node="cnfde7.ptp.lab.eng.bos.redhat.com",process="phc2sys"} 0
openshift_ptp_max_offset_from_master{iface="master",node="cnfde7.ptp.lab.eng.bos.redhat.com",process="ptp4l"} 3
# HELP openshift_ptp_offset_from_master 
# TYPE openshift_ptp_offset_from_master gauge
openshift_ptp_offset_from_master{iface="CLOCK_REALTIME",node="cnfde7.ptp.lab.eng.bos.redhat.com",process="phc2sys"} 0
openshift_ptp_offset_from_master{iface="master",node="cnfde7.ptp.lab.eng.bos.redhat.com",process="ptp4l"} 3
# HELP openshift_ptp_ptp_interface_role 0 = PASSIVE 1 = SLAVE 2 = MASTER 3 = FAULTY
# TYPE openshift_ptp_ptp_interface_role gauge
openshift_ptp_ptp_interface_role{iface="ens5f1",node="cnfde7.ptp.lab.eng.bos.redhat.com",process="ptp4l"} 1
```
Faulty interface
```
# HELP openshift_ptp_ptp_interface_role 0 = PASSIVE 1 = SLAVE 2 = MASTER 3 = FAULTY
# TYPE openshift_ptp_ptp_interface_role gauge
openshift_ptp_ptp_interface_role{iface="ens5f1",node="cnfde7.ptp.lab.eng.bos.redhat.com",process="ptp4l"} 3
```
but this will still stay locked as the known last state (will be more accurate with event frame aka sidecar) 

```
openshift_ptp_clock_state{iface="master",node="cnfde7.ptp.lab.eng.bos.redhat.com",process="ptp4l"} 1

```
Now for multi interface 
```
# HELP openshift_ptp_clock_state 0 = FREERUN, 1 = LOCKED, 2 = HOLDOVER
# TYPE openshift_ptp_clock_state gauge
openshift_ptp_clock_state{iface="master",node="cnfde7.ptp.lab.eng.bos.redhat.com",process="ptp4l"} 1
# HELP openshift_ptp_delay_from_master 
# TYPE openshift_ptp_delay_from_master gauge
openshift_ptp_delay_from_master{iface="CLOCK_REALTIME",node="cnfde7.ptp.lab.eng.bos.redhat.com",process="phc2sys"} 1400
openshift_ptp_delay_from_master{iface="ens5f0",node="cnfde7.ptp.lab.eng.bos.redhat.com",process="phc2sys"} 2771
openshift_ptp_delay_from_master{iface="ens7f1",node="cnfde7.ptp.lab.eng.bos.redhat.com",process="phc2sys"} 2720
openshift_ptp_delay_from_master{iface="master",node="cnfde7.ptp.lab.eng.bos.redhat.com",process="ptp4l"} 81
# HELP openshift_ptp_frequency_adjustment 
# TYPE openshift_ptp_frequency_adjustment gauge
openshift_ptp_frequency_adjustment{iface="CLOCK_REALTIME",node="cnfde7.ptp.lab.eng.bos.redhat.com",process="phc2sys"} -2.034256e+06
openshift_ptp_frequency_adjustment{iface="ens5f0",node="cnfde7.ptp.lab.eng.bos.redhat.com",process="phc2sys"} -1948
openshift_ptp_frequency_adjustment{iface="ens7f1",node="cnfde7.ptp.lab.eng.bos.redhat.com",process="phc2sys"} -3972
openshift_ptp_frequency_adjustment{iface="master",node="cnfde7.ptp.lab.eng.bos.redhat.com",process="ptp4l"} -1952
# HELP openshift_ptp_max_offset_from_master 
# TYPE openshift_ptp_max_offset_from_master gauge
openshift_ptp_max_offset_from_master{iface="CLOCK_REALTIME",node="cnfde7.ptp.lab.eng.bos.redhat.com",process="phc2sys"} 2.115298e+06
openshift_ptp_max_offset_from_master{iface="master",node="cnfde7.ptp.lab.eng.bos.redhat.com",process="ptp4l"} 12
# HELP openshift_ptp_max_offset_from_system 
# TYPE openshift_ptp_max_offset_from_system gauge
openshift_ptp_max_offset_from_system{iface="ens5f0",node="cnfde7.ptp.lab.eng.bos.redhat.com",process="phc2sys"} 15
openshift_ptp_max_offset_from_system{iface="ens7f1",node="cnfde7.ptp.lab.eng.bos.redhat.com",process="phc2sys"} 3
# HELP openshift_ptp_offset_from_master 
# TYPE openshift_ptp_offset_from_master gauge
openshift_ptp_offset_from_master{iface="CLOCK_REALTIME",node="cnfde7.ptp.lab.eng.bos.redhat.com",process="phc2sys"} 2.115298e+06
openshift_ptp_offset_from_master{iface="master",node="cnfde7.ptp.lab.eng.bos.redhat.com",process="ptp4l"} 12
# HELP openshift_ptp_offset_from_system 
# TYPE openshift_ptp_offset_from_system gauge
openshift_ptp_offset_from_system{iface="ens5f0",node="cnfde7.ptp.lab.eng.bos.redhat.com",process="phc2sys"} 15
openshift_ptp_offset_from_system{iface="ens7f1",node="cnfde7.ptp.lab.eng.bos.redhat.com",process="phc2sys"} 3
# HELP openshift_ptp_ptp_interface_role 0 = PASSIVE 1 = SLAVE 2 = MASTER 3 = FAULTY
# TYPE openshift_ptp_ptp_interface_role gauge
openshift_ptp_ptp_interface_role{iface="ens5f0",node="cnfde7.ptp.lab.eng.bos.redhat.com",process="ptp4l"} 2
openshift_ptp_ptp_interface_role{iface="ens5f1",node="cnfde7.ptp.lab.eng.bos.redhat.com",process="ptp4l"} 1
```
