### PR TITLE
Bug 1999185: with master summary_interval phc2sys adds sys to the log

### DIFF
--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -26,6 +26,9 @@ const (
 	phc2sysProcessName = "phc2sys"
 	clockRealTime      = "CLOCK_REALTIME"
 	master             = "master"
+
+	offset = "offset"
+	rms    = "rms"
 )
 
 const (
@@ -222,7 +225,7 @@ func extractSummaryMetrics(configName, processName, output string) (iface string
 	// phc2sys[3560354.300]: [ptp4l.0.config] CLOCK_REALTIME rms    4 max    4 freq -76829 +/-   0 delay  1085 +/-   0
 	// ptp4l[74737.942]: [ptp4l.0.config] rms   53 max   74 freq -16642 +/-  40 delay  1089 +/-  20
 
-	indx := strings.Index(output, "rms")
+	indx := strings.Index(output, rms)
 	if indx < 0 {
 		return
 	}
@@ -245,7 +248,7 @@ func extractSummaryMetrics(configName, processName, output string) (iface string
 	}
 
 	// when ptp4l log is missing interface name
-	if fields[1] == "rms" {
+	if fields[1] == rms {
 		fields = append(fields, "") // Making space for the new element
 		//  0             1     2
 		//ptp4l.0.config rms   53 max   74 freq -16642 +/-  40 delay  1089 +/-  20
@@ -285,7 +288,7 @@ func extractSummaryMetrics(configName, processName, output string) (iface string
 }
 
 func extractRegularMetrics(configName, processName, output string) (iface, clockState string, offsetFromMaster, maxOffsetFromMaster, frequencyAdjustment, delayFromMaster float64) {
-	indx := strings.Index(output, "offset")
+	indx := strings.Index(output, offset)
 	if indx < 0 {
 		return
 	}
@@ -306,6 +309,19 @@ func extractRegularMetrics(configName, processName, output string) (iface, clock
 	//ptp4l.0.config master offset   -2162130 s2 freq +22451884  delay 374976
 	if len(fields) < 7 {
 		glog.Errorf("%s failed to parse output %s: unexpected number of fields", processName, output)
+		return
+	}
+
+	//    0           1      2      3            4      5   6            7     8
+	//ptp4l.0.config master offset -2162130      s2    freq +22451884  delay 374976
+	//ptp4l.0.config eno1   sys    offset        13     s2   freq      +6010 delay    468
+	//offset generally seen at index 2, if it is at index 3 then move it to index 2
+	if fields[3] == offset {
+		fields = append(fields[:3], fields[4:]...)
+	}
+
+	if fields[2] != offset {
+		glog.Errorf("%s failed to parse offset from master output %s error %", processName, fields[1], "offset is not in right order")
 		return
 	}
 

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -294,7 +294,7 @@ func extractRegularMetrics(configName, processName, output string) (iface, clock
 	}
 
 	output = strings.Replace(output, "path", "", 1)
-	replacer := strings.NewReplacer("[", " ", "]", " ", ":", " ", "phc", "")
+	replacer := strings.NewReplacer("[", " ", "]", " ", ":", " ", "phc", "", "sys", "")
 	output = replacer.Replace(output)
 
 	index := strings.Index(output, configName)
@@ -310,14 +310,6 @@ func extractRegularMetrics(configName, processName, output string) (iface, clock
 	if len(fields) < 7 {
 		glog.Errorf("%s failed to parse output %s: unexpected number of fields", processName, output)
 		return
-	}
-
-	//    0           1      2      3            4      5   6            7     8
-	//ptp4l.0.config master offset -2162130      s2    freq +22451884  delay 374976
-	//ptp4l.0.config eno1   sys    offset        13     s2   freq      +6010 delay    468
-	//offset generally seen at index 2, if it is at index 3 then move it to index 2
-	if fields[3] == offset {
-		fields = append(fields[:3], fields[4:]...)
 	}
 
 	if fields[2] != offset {

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -313,7 +313,7 @@ func extractRegularMetrics(configName, processName, output string) (iface, clock
 	}
 
 	if fields[2] != offset {
-		glog.Errorf("%s failed to parse offset from master output %s error %", processName, fields[1], "offset is not in right order")
+		glog.Errorf("%s failed to parse offset from master output %s error %s", processName, fields[1], "offset is not in right order")
 		return
 	}
 


### PR DESCRIPTION
log out put 
```
ptp4l.0.config master offset -2162130      s2    freq +22451884  delay 374976
ptp4l.0.config eno1   sys    offset        13     s2   freq      +6010 delay    468
```
Offset generally seen at index 2, if it is at index 3 then move it to index 2, but for some setup log adds sys field which throws an parsing error .
This PR makes sure the 2nd field is always offset. If it is found  at field 3 then  log an error
