### PR TITLE
Bug 2024731:Remove ethtool status check loop

### DIFF
--- a/pkg/daemon/ptpdev.go
+++ b/pkg/daemon/ptpdev.go
@@ -2,8 +2,6 @@ package daemon
 
 import (
 	"context"
-	"time"
-
 	"github.com/golang/glog"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -59,10 +57,6 @@ func runDeviceStatusUpdate(ptpClient *ptpclient.Clientset, nodeName string) {
 }
 
 func RunDeviceStatusUpdate(ptpClient *ptpclient.Clientset, nodeName string) {
-	t := time.Tick(1 * time.Minute)
-	for {
-		glog.Info("run device status update function")
-		runDeviceStatusUpdate(ptpClient, nodeName)
-		<-t
-	}
+	glog.Info("run device status update function")
+	runDeviceStatusUpdate(ptpClient, nodeName)
 }


### PR DESCRIPTION
runDeviceStatusUpdate was called every minute to check PTP capabilities of the nic and update the nodePtpDevice CR status.
This was causing CPU usage to spike every minute.
The change will remove the loop and call it only once and update the CR with the status as shown below.
```
 status:
    devices:
    - name: eno1
    - name: eno2
    - name: ens5f0
    - name: ens5f1
    - name: ens7f0
    - name: ens7f1
```
Signed-off-by: Aneesh Puttur <aneeshputtur@gmail.com>