### PR TITLE
Bug 2047308 : Remove metrics and events for master port offsets

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -23,7 +23,6 @@ const (
 	PTP4L_CONF_FILE_PATH    = "/etc/ptp4l.conf"
 	PTP4L_CONF_DIR          = "/ptp4l-conf"
 	connectionRetryInterval = 1 * time.Second
-	processRestartInterval  = 1 * time.Second
 	eventSocket             = "/cloud-native/events.sock"
 )
 
@@ -357,7 +356,7 @@ func cmdRun(p *ptpProcess, stdoutToSocket bool) {
 					fmt.Printf("%s", out)
 					_, err := c.Write([]byte(out))
 					if err != nil {
-						glog.Errorf("Write error:", err)
+						glog.Errorf("Write error %s:", err)
 						goto connect
 					}
 				}


### PR DESCRIPTION
Signed-off-by: Aneesh Puttur <aneeshputtur@gmail.com>
The PR removes all events for master ports.
Only shows events for CLOCK_REALTIME and master offset for PHC clock 
example:
following logs will only calculate offset events for master offset and CLOCK_REALTIME only  and ignore ens7f0 in all metrics and events
Log output 
```
phc2sys[619569.614]: [ptp4l.0.config] CLOCK_REALTIME rms 1525 max 1525 freq -79792 +/-   0 delay   405 +/-   0
phc2sys[619569.614]: [ptp4l.0.config] ens7f0 rms 3936 max 3936 freq  -6428 +/-   0 delay  3040 +/-   0
ptp4l[619569.636]: [ptp4l.0.config] master offset       -571 s2 freq   -4212 path delay        92
```
Metrics
```
# HELP openshift_ptp_max_offset_ns 
# TYPE openshift_ptp_max_offset_ns gauge
openshift_ptp_max_offset_ns{from="master",iface="ens7fx",node="cnfde7.ptp.lab.eng.bos.redhat.com",process="ptp4l"} 5
openshift_ptp_max_offset_ns{from="phc",iface="CLOCK_REALTIME",node="cnfde7.ptp.lab.eng.bos.redhat.com",process="phc2sys"} 8

```

