### PR TITLE
OCPBUGS-560: Fix passing interface in ptpconfig through API field

### DIFF
--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -114,7 +114,10 @@ func (output *ptp4lConf) populatePtp4lConf(config *string) error {
 	globalIsDefined := false
 
 	for _, line := range lines {
-		if strings.HasPrefix(line, "[") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "#") {
+			continue
+		} else if strings.HasPrefix(line, "[") {
 			if currentSectionName != "" {
 				output.sections = append(output.sections, currentSection)
 			}
@@ -153,7 +156,7 @@ func (conf *ptp4lConf) renderPtp4lConf() (string, string) {
 	conf.mapping = nil
 
 	for _, section := range conf.sections {
-		configOut = fmt.Sprintf("%s\n %s", configOut, section.sectionName)
+		configOut = fmt.Sprintf("%s\n%s", configOut, section.sectionName)
 		if section.sectionName != "[global]" {
 			iface := section.sectionName
 			iface = strings.ReplaceAll(iface, "[", "")
@@ -161,7 +164,7 @@ func (conf *ptp4lConf) renderPtp4lConf() (string, string) {
 			conf.mapping = append(conf.mapping, iface)
 		}
 		for k, v := range section.options {
-			configOut = fmt.Sprintf("%s\n %s %s", configOut, k, v)
+			configOut = fmt.Sprintf("%s\n%s %s", configOut, k, v)
 		}
 	}
 	return configOut, strings.Join(conf.mapping, ",")

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -260,7 +260,7 @@ func (dn *Daemon) addProfileConfig(socketPath string, configFile string, nodePro
 	output.profile_name = *nodeProfile.Name
 
 	if nodeProfile.Interface != nil && *nodeProfile.Interface != "" {
-		output.sections = append(output.sections, ptp4lConfSection{options: map[string]string{}})
+		output.sections = append([]ptp4lConfSection{{options: map[string]string{}, sectionName: fmt.Sprintf("[%s]", *nodeProfile.Interface)}}, output.sections...)
 	} else {
 		iface := string("")
 		nodeProfile.Interface = &iface


### PR DESCRIPTION
Fix an issue introduced by iface ordering change, where Interfaces only
passed in through interface field in ptpconfig API would not be added to
ptp4l config file.

Also add support for commenting out lines in ptpconfig.

Also remove ' ' at start of every line in generated config file.