### PR TITLE
Stop using fedora in non-rhel Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,10 @@
-FROM fedora:34 AS builder
-
-RUN yum install -y make golang
-
-ENV GOPATH="/go"
+FROM golang:1.18 AS builder
 WORKDIR /go/src/github.com/openshift/linuxptp-daemon
-
 COPY . .
 RUN make clean && make
 
-FROM fedora:33
-RUN yum install -y linuxptp ethtool make hwdata
-COPY --from=builder /go/src/github.com/openshift/linuxptp-daemon/bin/ptp /usr/local/bin/ptp
+FROM quay.io/openshift/origin-base:4.12
+RUN yum -y update && yum --setopt=skip_missing_names_on_install=False -y install linuxptp ethtool hwdata && yum clean all
+COPY --from=builder /go/src/github.com/openshift/linuxptp-daemon/bin/ptp /usr/local/bin/
 
 CMD ["/usr/local/bin/ptp"]


### PR DESCRIPTION
Fedora is significantly different than ocp builder image, and so testing in fedora image may not be valid for standard production image. Switch to using ocp builder image in Dockerfile.