### PR TITLE
BUG OCPBUGS-2073: remove logging error for unrelated parsing of log string

### DIFF
--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -245,7 +245,6 @@ func extractSummaryMetrics(configName, processName, output string) (iface string
 	// 0                1            2     3 4      5  6    7      8    9  10     11
 	//ptp4l.0.config CLOCK_REALTIME rms   31 max   31 freq -77331 +/-   0 delay  1233 +/-   0
 	if len(fields) < 8 {
-		glog.Errorf("%s failed to parse output %s: unexpected number of fields", processName, output)
 		return
 	}
 


### PR DESCRIPTION
remove noise from the log
glog.Errorf("%s failed to parse output %s: unexpected number of fields", processName, output)
Signed-off-by: Aneesh Puttur <aneeshputtur@gmail.com>