### PR TITLE
[release-4.11] Bug OCPBUGS-2074: Remove noise from the log when parsing ptp4l logs

### DIFF
--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -245,7 +245,6 @@ func extractSummaryMetrics(configName, processName, output string) (iface string
 	// 0                1            2     3 4      5  6    7      8    9  10     11
 	//ptp4l.0.config CLOCK_REALTIME rms   31 max   31 freq -77331 +/-   0 delay  1233 +/-   0
 	if len(fields) < 8 {
-		glog.Errorf("%s failed to parse output %s: unexpected number of fields", processName, output)
 		return
 	}
 
@@ -314,7 +313,6 @@ func extractRegularMetrics(configName, processName, output string) (err error, i
 	//       0         1      2          3    4   5    6          7     8
 	//ptp4l.0.config master offset          4 s2 freq   -3964 path delay        91
 	if len(fields) < 7 {
-		err = fmt.Errorf("%s failed to parse output %s: unexpected number of fields", processName, output)
 		return
 	}
 


### PR DESCRIPTION
remove noise from the logs
glog.Errorf("%s failed to parse output %s: unexpected number of fields", processName, output)
Signed-off-by: Aneesh Puttur <aneeshputtur@gmail.com>