### PR TITLE
update standalone deployment manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ bin/
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 .idea/
+
+# Configmap data - output of hack/gen-configmap-data-source.sh
+linuxptp-configmap

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY . .
 RUN make clean && make
 
 FROM quay.io/openshift/origin-base:4.12
-RUN yum -y update && yum --setopt=skip_missing_names_on_install=False -y install linuxptp ethtool hwdata && yum clean all
+RUN yum -y update && yum --setopt=skip_missing_names_on_install=False -y install linuxptp ethtool hwdata strace nmap-nc && yum clean all
 COPY --from=builder /go/src/github.com/openshift/linuxptp-daemon/bin/ptp /usr/local/bin/
 
 CMD ["/usr/local/bin/ptp"]

--- a/deploy/00-ns.yaml
+++ b/deploy/00-ns.yaml
@@ -5,3 +5,6 @@ metadata:
   name: openshift-ptp
   labels:
     name: openshift-ptp
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged 
+    pod-security.kubernetes.io/warn: privileged

--- a/deploy/02-rbac.yaml
+++ b/deploy/02-rbac.yaml
@@ -1,21 +1,27 @@
----
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: linuxptp-daemon
+  namespace: openshift-ptp
 rules:
-- apiGroups: ["ptp.openshift.io"]
-  resources: ["*"]
-  verbs: ["*"]
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: linuxptp-daemon
+  namespace: openshift-ptp
 roleRef:
-  kind: ClusterRole
-  name: linuxptp-daemon
   apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: linuxptp-daemon
 subjects:
 - kind: ServiceAccount
   name: linuxptp-daemon

--- a/deploy/linuxptp-daemon.yaml
+++ b/deploy/linuxptp-daemon.yaml
@@ -26,11 +26,15 @@ spec:
       - name: linuxptp-daemon-container
         securityContext:
           privileged: true
-        image: openshift.io/linuxptp-daemon
+        image: quay.io/vgrinber/linuxptp-daemon:2
         command: [ "/bin/bash", "-c", "--" ]
         args: [ "/usr/local/bin/ptp --alsologtostderr" ]
-        imagePullPolicy: IfNotPresent
+        # command: [ "/bin/sleep" ]
+        # args: [ "inf" ]
+        imagePullPolicy: Always
         env:
+        # - name: LOGS_TO_SOCKET
+        #   value: "true"
         - name: NODE_NAME
           valueFrom:
             fieldRef:

--- a/hack/build-image.sh
+++ b/hack/build-image.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker build -t openshift.io/linuxptp-daemon -f ./Dockerfile .
+docker build -t quay.io/vgrinber/linuxptp-daemon:2 -f ./Dockerfile .

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -166,7 +166,9 @@ func (dn *Daemon) applyNodePTPProfiles() error {
 	// TODO:
 	// compare nodeProfile with previous config,
 	// only apply when nodeProfile changes
-
+	if dn.isHighAvailability() {
+		glog.Info("operate in high availability mode")
+	}
 	glog.Infof("updating NodePTPProfiles to:")
 	runID := 0
 	for _, profile := range dn.ptpUpdate.NodeProfiles {

--- a/pkg/daemon/mode.go
+++ b/pkg/daemon/mode.go
@@ -1,0 +1,21 @@
+package daemon
+
+import "github.com/golang/glog"
+
+func (dn *Daemon) isHighAvailability() bool {
+	for i, profile := range dn.ptpUpdate.NodeProfiles {
+		glog.Infof("Validating profile %d", i)
+		if profile.Ptp4lOpts != nil {
+			glog.Infof("Ptp4lOpts-%d: %s", i, *profile.Ptp4lOpts)
+		} else {
+			glog.Infof("No Ptp4lOpts in profile %d", i)
+		}
+		if profile.Phc2sysOpts != nil {
+			glog.Infof("Phc2sysOpts-%d: %s", i, *profile.Phc2sysOpts)
+		} else {
+			glog.Infof("No Phc2sysOpts in profile %d", i)
+		}
+
+	}
+	return true
+}


### PR DESCRIPTION
This PR fixes manifests for daemon standalone deployment.
- Switch from cluster role to namespaced role
- Label the namespace for pod-security compliance
In addition adds development artifacts to .gitignore.
All together makes standalone deployment compatible with the repository README.md
/assign @aneeshkp 
/cc @josephdrichard 