### PR TITLE
OCPBUGS-13875: Add initial hwconfig population

### DIFF
--- a/addons/generic/generic.go
+++ b/addons/generic/generic.go
@@ -11,7 +11,7 @@ func onPTPConfigChangeGeneric(*ptpv1.PtpProfile) error {
 	return nil
 }
 
-func PopulateHwConfigGeneric(hwconfig *ptpv1.HwConfig) error {
+func PopulateHwConfigGeneric(hwconfigs *[]ptpv1.HwConfig) error {
 	return nil
 }
 

--- a/addons/intel/e810.go
+++ b/addons/intel/e810.go
@@ -56,6 +56,13 @@ func OnPTPConfigChangeE810(nodeProfile *ptpv1.PtpProfile) error {
 	return nil
 }
 
+func PopulateHwConfigE810(hwconfigs *[]ptpv1.HwConfig) error {
+	//hwConfig := ptpv1.HwConfig{}
+	//hwConfig.DeviceID = "e810"
+	//*hwconfigs = append(*hwconfigs, hwConfig)
+	return nil
+}
+
 func E810(name string) *plugin.Plugin {
 	if name != "e810" {
 		glog.Errorf("Plugin must be initialized as 'e810'")
@@ -64,5 +71,6 @@ func E810(name string) *plugin.Plugin {
 	glog.Infof("registering e810 plugin")
 	return &plugin.Plugin{Name: "e810",
 		OnPTPConfigChange: OnPTPConfigChangeE810,
+		PopulateHwConfig:  PopulateHwConfigE810,
 	}
 }

--- a/pkg/daemon/plugin.go
+++ b/pkg/daemon/plugin.go
@@ -44,3 +44,9 @@ func (pm *PluginManager) OnPTPConfigChange(nodeProfile *ptpv1.PtpProfile) {
 		pluginObject.OnPTPConfigChange(nodeProfile)
 	}
 }
+
+func (pm *PluginManager) PopulateHwConfig(hwconfigs *[]ptpv1.HwConfig) {
+	for _, pluginObject := range pm.plugins {
+		pluginObject.PopulateHwConfig(hwconfigs)
+	}
+}

--- a/pkg/daemon/ptpdev.go
+++ b/pkg/daemon/ptpdev.go
@@ -11,6 +11,14 @@ import (
 	ptpnetwork "github.com/openshift/linuxptp-daemon/pkg/network"
 )
 
+func populateNodePTPDevices(nodePTPDev *ptpv1.NodePtpDevice, hwconfigs *[]ptpv1.HwConfig) (*ptpv1.NodePtpDevice, error) {
+	nodePTPDev.Status.Hwconfig = []ptpv1.HwConfig{}
+	for _, hw := range *hwconfigs {
+		nodePTPDev.Status.Hwconfig = append(nodePTPDev.Status.Hwconfig, hw)
+	}
+	return nodePTPDev, nil
+}
+
 func GetDevStatusUpdate(nodePTPDev *ptpv1.NodePtpDevice) (*ptpv1.NodePtpDevice, error) {
 	hostDevs, err := ptpnetwork.DiscoverPTPDevices()
 	if err != nil {
@@ -27,7 +35,7 @@ func GetDevStatusUpdate(nodePTPDev *ptpv1.NodePtpDevice) (*ptpv1.NodePtpDevice, 
 	return nodePTPDev, nil
 }
 
-func runDeviceStatusUpdate(ptpClient *ptpclient.Clientset, nodeName string) {
+func runDeviceStatusUpdate(ptpClient *ptpclient.Clientset, nodeName string, hwconfigs *[]ptpv1.HwConfig) {
 	// Discover PTP capable devices
 	// Don't return in case of discover failure
 	ptpDevs, err := ptpnetwork.DiscoverPTPDevices()
@@ -49,6 +57,12 @@ func runDeviceStatusUpdate(ptpClient *ptpclient.Clientset, nodeName string) {
 		glog.Errorf("failed to get device status: %v", err)
 	}
 
+	//Populate hwconfig
+	ptpDev, err = populateNodePTPDevices(ptpDev, hwconfigs)
+	if err != nil {
+		glog.Errorf("failed to populate node ptp devices: %v", err)
+	}
+
 	// Update NodePtpDevice CR
 	_, err = ptpClient.PtpV1().NodePtpDevices(PtpNamespace).UpdateStatus(context.TODO(), ptpDev, metav1.UpdateOptions{})
 	if err != nil {
@@ -56,7 +70,7 @@ func runDeviceStatusUpdate(ptpClient *ptpclient.Clientset, nodeName string) {
 	}
 }
 
-func RunDeviceStatusUpdate(ptpClient *ptpclient.Clientset, nodeName string) {
+func RunDeviceStatusUpdate(ptpClient *ptpclient.Clientset, nodeName string, hwconfigs *[]ptpv1.HwConfig) {
 	glog.Info("run device status update function")
-	runDeviceStatusUpdate(ptpClient, nodeName)
+	runDeviceStatusUpdate(ptpClient, nodeName, hwconfigs)
 }

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -6,7 +6,7 @@ import (
 
 type New func(string) *Plugin
 type OnPTPConfigChange func(*ptpv1.PtpProfile) error
-type PopulateHwConfig func(*ptpv1.HwConfig) error
+type PopulateHwConfig func(*[]ptpv1.HwConfig) error
 
 type Plugin struct {
 	Name              string


### PR DESCRIPTION
/hold
initial example for testing purposes.  Currently populates with irrelevant data.  Need to integrate with plugin framework before this merges.