### PR TITLE
Add leap-seconds.list to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN make clean && make
 
 FROM quay.io/openshift/origin-base:4.12
 RUN yum -y update && yum --setopt=skip_missing_names_on_install=False -y install linuxptp ethtool hwdata && yum clean all
+RUN wget https://www.ietf.org/timezones/data/leap-seconds.list -O /usr/share/zoneinfo/leap-seconds.list
 COPY --from=builder /go/src/github.com/openshift/linuxptp-daemon/bin/ptp /usr/local/bin/
 
 CMD ["/usr/local/bin/ptp"]

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -5,6 +5,7 @@ RUN make clean && make
 
 FROM registry.ci.openshift.org/ocp/4.13:base
 RUN yum -y update && yum --setopt=skip_missing_names_on_install=False -y install linuxptp ethtool hwdata && yum clean all
+RUN wget https://www.ietf.org/timezones/data/leap-seconds.list -O /usr/share/zoneinfo/leap-seconds.list
 COPY --from=builder /go/src/github.com/openshift/linuxptp-daemon/bin/ptp /usr/local/bin/
 
 CMD ["/usr/local/bin/ptp"]


### PR DESCRIPTION
Workaround for missing leap-seconds.list.  Ideally this would be fixed in RHEL, but workaround for now.