### PR TITLE
OCPBUGS-8249: add support for multinode service for http moving from 4.13 to 4.12

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,12 +1,15 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
 	"flag"
 	"io/ioutil"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -16,6 +19,8 @@ import (
 	"github.com/openshift/linuxptp-daemon/pkg/config"
 	"github.com/openshift/linuxptp-daemon/pkg/daemon"
 	ptpclient "github.com/openshift/ptp-operator/pkg/client/clientset/versioned"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 type cliParams struct {
@@ -60,6 +65,7 @@ func main() {
 
 	// The name of NodePtpDevice CR for this node is equal to the node name
 	nodeName := os.Getenv("NODE_NAME")
+	podName := os.Getenv("POD_NAME")
 	if nodeName == "" {
 		glog.Error("cannot find NODE_NAME environment variable")
 		return
@@ -84,6 +90,9 @@ func main() {
 		glog.Errorf("failed to create a ptp config update: %v", err)
 		return
 	}
+
+	// label the current linux-ptp-daemon pod with a nodeName label
+	labelPod(kubeClient, nodeName, podName)
 
 	go daemon.New(
 		nodeName,
@@ -133,5 +142,37 @@ func main() {
 			glog.Info("signal received, shutting down", sig)
 			return
 		}
+	}
+}
+
+type patchStringValue struct {
+	Op    string `json:"op"`
+	Path  string `json:"path"`
+	Value string `json:"value"`
+}
+
+func labelPod(kubeClient *kubernetes.Clientset, nodeName, podName string) {
+	pod, err := kubeClient.CoreV1().Pods(daemon.PtpNamespace).Get(context.TODO(), podName, metav1.GetOptions{})
+	if err != nil {
+		glog.Error(err)
+	}
+	if pod == nil {
+		glog.Info("Could not find linux-ptp-daemon pod to label")
+		return
+	}
+	if nodeName != "" && strings.Contains(nodeName, ".") {
+		nodeName = strings.Split(nodeName, ".")[0]
+	}
+
+	payload := []patchStringValue{{
+		Op:    "replace",
+		Path:  "/metadata/labels/nodeName",
+		Value: nodeName,
+	}}
+	payloadBytes, _ := json.Marshal(payload)
+
+	_, err = kubeClient.CoreV1().Pods(pod.GetNamespace()).Patch(context.TODO(), pod.GetName(), types.JSONPatchType, payloadBytes, metav1.PatchOptions{})
+	if err == nil {
+		glog.Infof("Pod %s labelled successfully.", pod.GetName())
 	}
 }


### PR DESCRIPTION
This PR adds  first part of nodename as label to daemon pod. Which is needed for http  events service to work on multi node.
http is not supported  in 4.13 but need to back port to 4.12
Need to back port  https://github.com/openshift/ptp-operator/pull/282 to support multi node.
