### PR TITLE
Bug OCPBUGS-8112: Delay closing ptp4lSocket

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -543,13 +543,6 @@ func cmdStop(p *ptpProcess) {
 		p.cmd.Process.Signal(syscall.SIGTERM)
 	}
 
-	if p.ptp4lSocketPath != "" {
-		err := os.Remove(p.ptp4lSocketPath)
-		if err != nil {
-			glog.Errorf("failed to remove ptp4l socket path %s: %v", p.ptp4lSocketPath, err)
-		}
-	}
-
 	if p.ptp4lConfigPath != "" {
 		err := os.Remove(p.ptp4lConfigPath)
 		if err != nil {


### PR DESCRIPTION
Multiple processes (e.g. ptp4l and phc2sys) can use same ptp4lSocket, so wait to close until none are still using it.

/hold until testing is done