### PR TITLE
BUG OCPBUGS-15584: leap-seconds.list file included as part of linuxptp-daemon container expired on June 28, 2023

### DIFF
--- a/extra/leap-seconds.list
+++ b/extra/leap-seconds.list
@@ -204,10 +204,10 @@
 #	current -- the update time stamp, the data and the name of the file
 #	will not change.
 #
-#	Updated through IERS Bulletin C64
-#	File expires on:  28 June 2023
+#	Updated through IERS Bulletin C65
+#	File expires on:  28 December 2023
 #
-#@	3896899200
+#@	3912710400
 #
 2272060800	10	# 1 Jan 1972
 2287785600	11	# 1 Jul 1972
@@ -252,4 +252,4 @@
 #	the hash line is also ignored in the
 #	computation.
 #
-#h 	2c413af9 124e1031 f165174 ff527c6b 756ae00b
+#h 	e76a99dc 65f15cc7 e613e040 f5078b5e b23834fe


### PR DESCRIPTION
update leap file to latest 