### PR TITLE
OCPBUGS-17094: Allow customizing DPLL settings through e810 plugin

### DIFF
--- a/addons/intel/e810.go
+++ b/addons/intel/e810.go
@@ -8,6 +8,7 @@ import (
 	ptpv1 "github.com/openshift/ptp-operator/api/v1"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 )
 
@@ -15,6 +16,7 @@ type E810Opts struct {
 	EnableDefaultConfig bool                         `json:"enableDefaultConfig"`
 	UblxCmds            []E810UblxCmds               `json:"ublxCmds"`
 	DevicePins          map[string]map[string]string `json:"pins"`
+	DpllSettings        map[string]int64             `json:"settings"`
 }
 
 type E810UblxCmds struct {
@@ -81,6 +83,14 @@ func OnPTPConfigChangeE810(data *interface{}, nodeProfile *ptpv1.PtpProfile) err
 							glog.Error("e810 failed to write " + value + " to " + pinPath + ": " + err.Error())
 						}
 					}
+				}
+			}
+			for k, v := range e810Opts.DpllSettings {
+				if (*nodeProfile).PtpSettings == nil {
+					(*nodeProfile).PtpSettings = make(map[string]string)
+				}
+				if _, ok := (*nodeProfile).PtpSettings[k]; !ok {
+					(*nodeProfile).PtpSettings[k] = strconv.FormatInt(v, 10)
 				}
 			}
 		}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -469,7 +469,26 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 			gpsPipeDaemon.CmdInit()
 			dprocess.depProcess = append(dprocess.depProcess, gpsPipeDaemon)
 			// init dpll
-			dpllDaemon := dpll.NewDpll(dpll.LocalMaxHoldoverOffSet, dpll.LocalHoldoverTimeout, dpll.MaxInSpecOffset,
+			// TODO: Try to inject DPLL depProcess via plugin ?
+			var localMaxHoldoverOffSet int64 = dpll.LocalMaxHoldoverOffSet
+			var localHoldoverTimeout int64 = dpll.LocalHoldoverTimeout
+			var maxInSpecOffset int64 = dpll.MaxInSpecOffset
+			for k, v := range (*nodeProfile).PtpSettings {
+				i, err := strconv.ParseInt(v, 10, 64)
+				if err != nil {
+					continue
+				}
+				if k == dpll.LocalMaxHoldoverOffSetStr {
+					localMaxHoldoverOffSet = i
+				}
+				if k == dpll.LocalHoldoverTimeoutStr {
+					localHoldoverTimeout = i
+				}
+				if k == dpll.MaxInSpecOffsetStr {
+					maxInSpecOffset = i
+				}
+			}
+			dpllDaemon := dpll.NewDpll(localMaxHoldoverOffSet, localHoldoverTimeout, maxInSpecOffset,
 				gmInterface, []event.EventSource{event.GNSS})
 			dprocess.depProcess = append(dprocess.depProcess, dpllDaemon)
 		}

--- a/pkg/dpll/dpll.go
+++ b/pkg/dpll/dpll.go
@@ -24,6 +24,10 @@ const (
 	LocalHoldoverTimeout   = 14400 //secs
 	MaxInSpecOffset        = 100   //ns
 	monitoringInterval     = 1 * time.Second
+
+	LocalMaxHoldoverOffSetStr = "LocalMaxHoldoverOffSet"
+	LocalHoldoverTimeoutStr   = "LocalHoldoverTimeout"
+	MaxInSpecOffsetStr        = "MaxInSpecOffset"
 )
 
 type DpllConfig struct {
@@ -79,6 +83,7 @@ func (d *DpllConfig) CmdRun(stdToSocket bool) {
 
 func NewDpll(localMaxHoldoverOffSet, localHoldoverTimeout, maxInSpecOffset int64,
 	iface string, dependingState []event.EventSource) *DpllConfig {
+	glog.Infof("Calling NewDpll with localMaxHoldoverOffSet=%d, localHoldoverTimeout=%d, maxInSpecOffset=%d, iface=%s", localMaxHoldoverOffSet, localHoldoverTimeout, maxInSpecOffset, iface)
 	d := &DpllConfig{
 		LocalMaxHoldoverOffSet: localMaxHoldoverOffSet,
 		LocalHoldoverTimeout:   localHoldoverTimeout,


### PR DESCRIPTION
Allow customizing DPLL settings through e810 plugin

spec:
  profile:
  - name: grandmaster
    plugins:
      e810:
        settings:
          LocalMaxHoldoverOffSet: 1500
          LocalHoldoverTimeout: 14400
          MaxInSpecOffset: 100