### PR TITLE
OCPBUGS-16220: Replace Ublox with direct call to default gpsd  for monitoring and  reduce CPU usage 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require github.com/openshift/ptp-operator v0.0.0-20230207052655-ede9197d99ca
 
 require (
+	github.com/aneeshkp/go-gpsd v0.0.0-20230804165302-4a2d069c566a
 	github.com/facebook/time v0.0.0-20230529151911-512b3b30ab23
 	github.com/golang/glog v1.0.0
 	github.com/google/goexpect v0.0.0-20210430020637-ab937bf7fd6f

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/aneeshkp/go-gpsd v0.0.0-20230804165302-4a2d069c566a h1:G/5ndAJGj+/qaEfHd+9N/Twl53zP1uiuIhQRR5ii4vQ=
+github.com/aneeshkp/go-gpsd v0.0.0-20230804165302-4a2d069c566a/go.mod h1:uMichzyUnEF3EitsmDInRf0EXlFIISVE80HKF9R76Ds=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -390,14 +390,14 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 				section.options["message_tag"] = messageTag
 				section.options["uds_address"] = socketPath
 				if gnssSerialPort, ok := section.options["ts2phc.nmea_serialport"]; ok {
-					output.gnss_serial_port = gnssSerialPort
+					output.gnss_serial_port = strings.TrimSpace(gnssSerialPort)
 					section.options["ts2phc.nmea_serialport"] = GPSPIPE_SERIALPORT
 				}
 				output.sections[index] = section
 			}
 		}
 
-		// This add the flags needed for monitor
+		// This adds the flags needed for monitor
 		addFlagsForMonitor(p, configOpts, output, dn.stdoutToSocket)
 
 		configOutput, ifaces = output.renderPtp4lConf()

--- a/pkg/daemon/gpsd.go
+++ b/pkg/daemon/gpsd.go
@@ -10,11 +10,11 @@ import (
 	"syscall"
 	"time"
 
+	gpsdlib "github.com/aneeshkp/go-gpsd"
+	"github.com/golang/glog"
 	"github.com/openshift/linuxptp-daemon/pkg/config"
 	"github.com/openshift/linuxptp-daemon/pkg/event"
 	"github.com/openshift/linuxptp-daemon/pkg/ublox"
-
-	"github.com/golang/glog"
 )
 
 const (
@@ -23,22 +23,26 @@ const (
 )
 
 type gpsd struct {
-	name          string
-	execMutex     sync.Mutex
-	cmd           *exec.Cmd
-	serialPort    string
-	exitCh        chan struct{}
-	stopped       bool
-	state         event.PTPState
-	offset        int64
-	processConfig config.ProcessConfig
-	gmInterface   string
-	messageTag    string
+	name                 string
+	execMutex            sync.Mutex
+	cmd                  *exec.Cmd
+	serialPort           string
+	exitCh               chan struct{}
+	stopped              bool
+	state                event.PTPState
+	noFixStateOccurrence int // number of times no fix state has occurred
+	offset               int64
+	processConfig        config.ProcessConfig
+	gmInterface          string
+	messageTag           string
+	ublxTool             *ublox.UBlox
+	gpsdSession          *gpsdlib.Session
+	gpsdDoneCh           chan bool
 }
 
 // MonitorProcess ... Monitor gpsd process
 func (g *gpsd) MonitorProcess(p config.ProcessConfig) {
-	go g.monitorGNSSEvents(p, "E810")
+	go g.MonitorGNSSEventsWithGPSD(p, "E810")
 }
 
 // Name ... Process name
@@ -89,7 +93,7 @@ func (g *gpsd) CmdStop() {
 	glog.Infof("Process %s (%d) terminated", g.name, g.cmd.Process.Pid)
 }
 
-// CmdInit .... ubxtool -w 5 -v 1 -p MON-VER -P 29.20
+// CmdInit ... initialize gpsd
 func (g *gpsd) CmdInit() {
 	if g.name == "" {
 		g.name = GPSD_PROCESSNAME
@@ -110,7 +114,6 @@ func (g *gpsd) CmdRun(stdoutToSocket bool) {
 		glog.Infof("%s cmd: %+v", g.Name(), g.cmd)
 		g.cmd.Stderr = os.Stderr
 		var err error
-
 		if err != nil {
 			glog.Errorf("CmdRun() error creating StdoutPipe for %s: %v", g.Name(), err)
 			break
@@ -134,8 +137,110 @@ func (g *gpsd) CmdRun(stdoutToSocket bool) {
 	}
 }
 
-// monitorGNSSEvents ... monitor gnss events
-func (g *gpsd) monitorGNSSEvents(processCfg config.ProcessConfig, pluginName string) error {
+// MonitorGNSSEventsWithGPSD ... monitor GNSS events
+func (g *gpsd) MonitorGNSSEventsWithGPSD(processCfg config.ProcessConfig, pluginName string) {
+	// close the session if it is already open
+	defer func() {
+		if g.gpsdSession != nil {
+			g.gpsdSession.Close()
+		}
+	}()
+	g.processConfig = processCfg
+	g.offset = 5 // default to 5 nano secs
+	var err error
+	noFixThreshold := 3 // default
+	if g.ublxTool, err = ublox.NewUblox(); err != nil {
+		glog.Errorf("failed to initialize GNSS monitoring via ublox %s", err)
+		g.ublxTool = nil
+	}
+retry:
+	if g.gpsdSession, err = gpsdlib.Dial(gpsdlib.DefaultAddress); err != nil {
+		glog.Errorf("Failed to connect to GPSD: %s, retrying", err)
+		time.Sleep(2 * time.Second)
+		goto retry
+	}
+	// TPV data like gps state
+	g.gpsdSession.AddFilter("TPV", func(r interface{}) {
+		tpv := r.(*gpsdlib.TPVReport)
+		// gate it to the serial port
+		if strings.TrimSpace(tpv.Device) != strings.TrimSpace(g.serialPort) {
+			glog.Infof("Device %s is not %s set for monitoring", tpv.Device, g.serialPort)
+			return // do not send event
+		}
+		// prevent noise, wait for 3 occurrence of no fix state
+		if tpv.Mode == gpsdlib.NoFix || tpv.Mode == gpsdlib.NoValueSeen {
+			g.noFixStateOccurrence++
+		} else {
+			g.noFixStateOccurrence = 0
+		}
+
+		if g.noFixStateOccurrence > noFixThreshold {
+			g.state = event.PTP_FREERUN
+		} else if tpv.Mode == gpsdlib.Mode2D || tpv.Mode == gpsdlib.Mode3D {
+			if g.isOffsetInRange() {
+				g.state = event.PTP_LOCKED
+			} else {
+				g.state = event.PTP_FREERUN
+			}
+		} else {
+			return // do not send event yet
+		}
+		processCfg.EventChannel <- event.EventChannel{
+			ProcessName: event.GNSS,
+			State:       g.state,
+			CfgName:     processCfg.ConfigName,
+			IFace:       g.gmInterface,
+			Values: map[event.ValueType]int64{
+				event.GPS_STATUS: int64(tpv.Mode),
+				event.OFFSET:     g.offset,
+			},
+			ClockType:  processCfg.ClockType,
+			Time:       time.Now().Unix(),
+			WriteToLog: true,
+			Reset:      false,
+		}
+	})
+	g.gpsdDoneCh = g.gpsdSession.Watch()
+	for {
+		select {
+		case <-g.exitCh:
+			glog.Infof("GPSD Monitor() exitCh")
+			goto exit
+		case <-g.gpsdDoneCh:
+			glog.Infof("GPSD Monitor() gpsdDone closed")
+			g.gpsdDoneCh = g.gpsdSession.Watch()
+		default:
+			// do nothing
+			time.Sleep(250 * time.Millisecond)
+		}
+	}
+exit:
+	processCfg.EventChannel <- event.EventChannel{
+		ProcessName: event.GNSS,
+		CfgName:     processCfg.ConfigName,
+		ClockType:   processCfg.ClockType,
+		Time:        time.Now().Unix(),
+		Reset:       true,
+	}
+
+}
+func (g *gpsd) getUbloxOffset() {
+	if g.ublxTool == nil {
+		return
+	}
+	if offsetS, err := g.ublxTool.GetNavOffset(); err != nil {
+		glog.Errorf("failed to get nav offset %s", err)
+		g.offset = 99999999
+	} else {
+		if g.offset, err = strconv.ParseInt(offsetS, 10, 64); err != nil {
+			glog.Errorf("failed to parse offset %s", err)
+			g.offset = 99999999
+		}
+	}
+}
+
+// MonitorGNSSEventsWithUblox ... monitor GNSS events with ublox
+func (g *gpsd) MonitorGNSSEventsWithUblox(processCfg config.ProcessConfig, pluginName string) {
 	//done := make(chan struct{}) // Done setting up logging.  Go ahead and wait for process
 	// var currentNavStatus int64
 	g.processConfig = processCfg
@@ -153,10 +258,10 @@ retry:
 	} else {
 		//TODO: monitor on 1PPS  events trigger
 		ticker := time.NewTicker(GNSSMONITOR_INTERVAL)
-		var lastState int64
-		var lastOffset int64
-		lastState = -1
-		lastOffset = -1
+		//var lastState int64
+		//var lastOffset int64
+		//lastState = -1
+		//	lastOffset = -1
 		nStatus := int64(0)
 		offsetS := "99999999"
 		var err error
@@ -179,24 +284,24 @@ retry:
 				} else {
 					g.state = event.PTP_FREERUN
 				}
-				if lastState != nStatus || lastOffset != g.offset {
-					lastState = nStatus
-					lastOffset = g.offset
-					processCfg.EventChannel <- event.EventChannel{
-						ProcessName: event.GNSS,
-						State:       g.state,
-						CfgName:     processCfg.ConfigName,
-						IFace:       g.gmInterface,
-						Values: map[event.ValueType]int64{
-							event.GPS_STATUS: nStatus,
-							event.OFFSET:     g.offset,
-						},
-						ClockType:  processCfg.ClockType,
-						Time:       time.Now().Unix(),
-						WriteToLog: true,
-						Reset:      false,
-					}
+				//if lastState != nStatus || lastOffset != g.offset {
+				//lastState = nStatus
+				//lastOffset = g.offset
+				processCfg.EventChannel <- event.EventChannel{
+					ProcessName: event.GNSS,
+					State:       g.state,
+					CfgName:     processCfg.ConfigName,
+					IFace:       g.gmInterface,
+					Values: map[event.ValueType]int64{
+						event.GPS_STATUS: nStatus,
+						event.OFFSET:     g.offset,
+					},
+					ClockType:  processCfg.ClockType,
+					Time:       time.Now().Unix(),
+					WriteToLog: true,
+					Reset:      false,
 				}
+				//}
 			case <-g.exitCh:
 				processCfg.EventChannel <- event.EventChannel{
 					ProcessName: event.GNSS,
@@ -206,14 +311,15 @@ retry:
 					Reset:       true,
 				}
 				ticker.Stop()
-				return nil
+				return // exit
 			}
 		}
 	}
 }
 
+// isOffsetInRange ... check if offset is in range
 func (g *gpsd) isOffsetInRange() bool {
-	if g.offset < g.processConfig.GMThreshold.Max && g.offset >= g.processConfig.GMThreshold.Min {
+	if g.offset <= g.processConfig.GMThreshold.Max && g.offset >= g.processConfig.GMThreshold.Min {
 		return true
 	}
 	return false

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -107,7 +107,7 @@ var (
 			Help:      "0 = FREERUN, 1 = LOCKED, 2 = HOLDOVER",
 		}, []string{"process", "node", "iface"})
 
-	// Threshold metrics to show current ptp GMThreshold
+	// InterfaceRole metrics to show current interface role
 	InterfaceRole = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: PTPNamespace,
@@ -217,7 +217,7 @@ func extractMetrics(messageTag string, processName string, ifaces []string, outp
 					r := []rune(ifaces[portId-1])
 					masterOffsetIfaceName[configName] = string(r[:len(r)-1]) + "x"
 					slaveIfaceName[configName] = ifaces[portId-1]
-				} else if role == FAULTY { // only if ptp4l is processing offset, ts2phc offset won't effect by port faulty
+				} else if role == FAULTY { // only if ptp4l is processing offset, ts2phc offset won't affect by port faulty
 					if isSlaveFaulty(configName, ifaces[portId-1]) &&
 						getMasterSourceProcess(configName) == ptp4lProcessName {
 						updatePTPMetrics(master, processName, getMasterOffsetIfaceName(configName), faultyOffset, faultyOffset, 0, 0)

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -3,6 +3,7 @@ package event
 import (
 	"fmt"
 	"net"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -196,10 +197,11 @@ func (e *EventHandler) ProcessEvents() {
 				// replace ts2phc logs here
 				var logOut []string
 				if event.WriteToLog {
-					var logData []string
+					logData := make([]string, 0, len(event.Values))
 					for k, v := range event.Values {
 						logData = append(logData, fmt.Sprintf("%s %d", k, v))
 					}
+					sort.Strings(logData)
 					logDataValues := strings.Join(logData, " ")
 					logOut = append(logOut, fmt.Sprintf("%s[%d]:[%s] %s %s %s\n", event.ProcessName,
 						time.Now().Unix(), event.CfgName, event.IFace, logDataValues, event.State))

--- a/pkg/pmc/pmc.go
+++ b/pkg/pmc/pmc.go
@@ -72,8 +72,6 @@ func RunPMCExpGetGMSettings(configFileName string) (g protocol.GrandmasterSettin
 func RunPMCExpSetGMSettings(configFileName string, g protocol.GrandmasterSettings) (err error) {
 	cmdStr := CmdSetGMSettings
 	cmdStr += strings.Replace(g.String(), "\n", " ", -1)
-	glog.Infof("pmc read config from /var/run/%s", configFileName)
-	glog.Infof("pmc run command: %s", cmdStr)
 	e, _, err := expect.Spawn(fmt.Sprintf("pmc -u -b 1 -f /var/run/%s", configFileName), -1)
 	if err != nil {
 		return err

--- a/vendor/github.com/aneeshkp/go-gpsd/.gitignore
+++ b/vendor/github.com/aneeshkp/go-gpsd/.gitignore
@@ -1,0 +1,25 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+
+examples/examples
+.idea

--- a/vendor/github.com/aneeshkp/go-gpsd/LICENSE
+++ b/vendor/github.com/aneeshkp/go-gpsd/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Josip Lisec
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/aneeshkp/go-gpsd/README.md
+++ b/vendor/github.com/aneeshkp/go-gpsd/README.md
@@ -1,0 +1,64 @@
+# go-gpsd
+
+*GPSD client for Go.*
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/stratoberry/go-gpsd.svg)](https://pkg.go.dev/github.com/stratoberry/go-gpsd)
+
+## Installation
+
+<pre><code># go get github.com/stratoberry/go-gpsd</code></pre>
+
+go-gpsd has no external dependencies.
+
+## Usage
+
+go-gpsd is a streaming client for GPSD's JSON service and as such can be used only in async manner unlike clients for other languages which support both async and sync modes.
+
+<pre><code>import ("github.com/stratoberry/go-gpsd")
+
+func main() {
+	gps := gpsd.Dial("localhost:2947")
+}
+</code></pre>
+
+After `Dial`ing the server, you should install stream filters. Stream filters allow you to capture only certain types of GPSD reports.
+
+<pre><code>gps.AddFilter("TPV", tpvFilter)</code></pre>
+
+Filter functions have a type of `gps.Filter` and should receive one argument of type `interface{}`.
+
+<pre><code>tpvFilter := func(r interface{}) {
+	report := r.(*gpsd.TPVReport)
+	fmt.Println("Location updated", report.Lat, report.Lon)
+}</code></pre>
+
+Due to the nature of GPSD reports your filter will manually have to cast the type of the argument it received to a proper `*gpsd.Report` struct pointer.
+
+After installing all needed filters, call the `Watch` method to start observing reports. Please note that at this time installed filters can't be removed.
+
+<pre><code>done := gps.Watch()
+&lt;-done</code></pre>
+
+`Watch()` will span a new goroutine in which all data processing will happen, `done` channel won't send anything.
+
+### Currently supported GPSD report types
+
+* [`VERSION`](https://gpsd.gitlab.io/gpsd/gpsd_json.html#_version) (`gpsd.VERSIONReport`)
+* [`TPV`](https://gpsd.gitlab.io/gpsd/gpsd_json.html#_tpv) (`gpsd.TPVReport`)
+* [`SKY`](https://gpsd.gitlab.io/gpsd/gpsd_json.html#_sky) (`gpsd.SKYReport`)
+* [`ATT`](https://gpsd.gitlab.io/gpsd/gpsd_json.html#_att) (`gpsd.ATTReport`)
+* [`GST`](https://gpsd.gitlab.io/gpsd/gpsd_json.html#_gst) (`gpsd.GSTReport`)
+* [`PPS`](https://gpsd.gitlab.io/gpsd/gpsd_json.html#_pps) (`gpsd.PPSReport`)
+* [`DEVICES`](https://gpsd.gitlab.io/gpsd/gpsd_json.html#_devices) (`gpsd.DEVICESReport`)
+* [`DEVICE`](https://gpsd.gitlab.io/gpsd/gpsd_json.html#_device_device) (`gpsd.DEVICEReport`)
+* [`ERROR`](https://gpsd.gitlab.io/gpsd/gpsd_json.html#_error) (`gpsd.ERRORReport`)
+
+## Documentation
+
+For complete library documentation visit [Go Reference](https://pkg.go.dev/github.com/stratoberry/go-gpsd).
+
+Documentation of GPSD's JSON protocol is available at [https://gpsd.gitlab.io/gpsd/gpsd_json.html](https://gpsd.gitlab.io/gpsd/gpsd_json.html).
+
+## References
+
+This library was originally developed as a part of a student project at [FOI/University of Zagreb](https://www.foi.unizg.hr/en).

--- a/vendor/github.com/aneeshkp/go-gpsd/gpsd.go
+++ b/vendor/github.com/aneeshkp/go-gpsd/gpsd.go
@@ -1,0 +1,348 @@
+package gpsd
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"time"
+)
+
+// DefaultAddress of gpsd (localhost:2947)
+const DefaultAddress = "localhost:2947"
+
+// Filter is a gpsd entry filter function
+type Filter func(interface{})
+
+// Session represents a connection to gpsd
+type Session struct {
+	socket  net.Conn
+	reader  *bufio.Reader
+	filters map[string][]Filter
+}
+
+// Mode describes status of a TPV report
+type Mode byte
+
+const (
+	// NoValueSeen indicates no data has been received yet
+	NoValueSeen Mode = 0
+	// NoFix indicates fix has not been required yet
+	NoFix Mode = 1
+	// Mode2D represents quality of the fix
+	Mode2D Mode = 2
+	// Mode3D represents quality of the fix
+	Mode3D Mode = 3
+)
+
+type gpsdReport struct {
+	Class string `json:"class"`
+}
+
+// TPVReport is a Time-Position-Velocity report
+type TPVReport struct {
+	Class  string    `json:"class"`
+	Tag    string    `json:"tag"`
+	Device string    `json:"device"`
+	Mode   Mode      `json:"mode"`
+	Time   time.Time `json:"time"`
+	Ept    float64   `json:"ept"`
+	Lat    float64   `json:"lat"`
+	Lon    float64   `json:"lon"`
+	Alt    float64   `json:"alt"`
+	Epx    float64   `json:"epx"`
+	Epy    float64   `json:"epy"`
+	Epv    float64   `json:"epv"`
+	Track  float64   `json:"track"`
+	Speed  float64   `json:"speed"`
+	Climb  float64   `json:"climb"`
+	Epd    float64   `json:"epd"`
+	Eps    float64   `json:"eps"`
+	Epc    float64   `json:"epc"`
+}
+
+// SKYReport reports sky view of GPS satellites
+type SKYReport struct {
+	Class      string      `json:"class"`
+	Tag        string      `json:"tag"`
+	Device     string      `json:"device"`
+	Time       time.Time   `json:"time"`
+	Xdop       float64     `json:"xdop"`
+	Ydop       float64     `json:"ydop"`
+	Vdop       float64     `json:"vdop"`
+	Tdop       float64     `json:"tdop"`
+	Hdop       float64     `json:"hdop"`
+	Pdop       float64     `json:"pdop"`
+	Gdop       float64     `json:"gdop"`
+	Satellites []Satellite `json:"satellites"`
+}
+
+// GSTReport is pseudorange noise report
+type GSTReport struct {
+	Class  string    `json:"class"`
+	Tag    string    `json:"tag"`
+	Device string    `json:"device"`
+	Time   time.Time `json:"time"`
+	Rms    float64   `json:"rms"`
+	Major  float64   `json:"major"`
+	Minor  float64   `json:"minor"`
+	Orient float64   `json:"orient"`
+	Lat    float64   `json:"lat"`
+	Lon    float64   `json:"lon"`
+	Alt    float64   `json:"alt"`
+}
+
+// ATTReport reports vehicle-attitude from the digital compass or the gyroscope
+type ATTReport struct {
+	Class       string    `json:"class"`
+	Tag         string    `json:"tag"`
+	Device      string    `json:"device"`
+	Time        time.Time `json:"time"`
+	Heading     float64   `json:"heading"`
+	MagSt       string    `json:"mag_st"`
+	Pitch       float64   `json:"pitch"`
+	PitchSt     string    `json:"pitch_st"`
+	Yaw         float64   `json:"yaw"`
+	YawSt       string    `json:"yaw_st"`
+	Roll        float64   `json:"roll"`
+	RollSt      string    `json:"roll_st"`
+	Dip         float64   `json:"dip"`
+	MagLen      float64   `json:"mag_len"`
+	MagX        float64   `json:"mag_x"`
+	MagY        float64   `json:"mag_y"`
+	MagZ        float64   `json:"mag_z"`
+	AccLen      float64   `json:"acc_len"`
+	AccX        float64   `json:"acc_x"`
+	AccY        float64   `json:"acc_y"`
+	AccZ        float64   `json:"acc_z"`
+	GyroX       float64   `json:"gyro_x"`
+	GyroY       float64   `json:"gyro_y"`
+	Depth       float64   `json:"depth"`
+	Temperature float64   `json:"temperature"`
+}
+
+// VERSIONReport returns version details of gpsd client
+type VERSIONReport struct {
+	Class      string `json:"class"`
+	Release    string `json:"release"`
+	Rev        string `json:"rev"`
+	ProtoMajor int    `json:"proto_major"`
+	ProtoMinor int    `json:"proto_minor"`
+	Remote     string `json:"remote"`
+}
+
+// DEVICESReport lists all devices connected to the system
+type DEVICESReport struct {
+	Class   string         `json:"class"`
+	Devices []DEVICEReport `json:"devices"`
+	Remote  string         `json:"remote"`
+}
+
+// DEVICEReport reports a state of a particular device
+type DEVICEReport struct {
+	Class     string  `json:"class"`
+	Path      string  `json:"path"`
+	Activated string  `json:"activated"`
+	Flags     int     `json:"flags"`
+	Driver    string  `json:"driver"`
+	Subtype   string  `json:"subtype"`
+	Bps       int     `json:"bps"`
+	Parity    string  `json:"parity"`
+	Stopbits  string  `json:"stopbits"`
+	Native    int     `json:"native"`
+	Cycle     float64 `json:"cycle"`
+	Mincycle  float64 `json:"mincycle"`
+}
+
+// PPSReport is triggered on each pulse-per-second strobe from a device
+type PPSReport struct {
+	Class      string  `json:"class"`
+	Device     string  `json:"device"`
+	RealSec    float64 `json:"real_sec"`
+	RealMusec  float64 `json:"real_musec"`
+	ClockSec   float64 `json:"clock_sec"`
+	ClockMusec float64 `json:"clock_musec"`
+}
+
+// TOFFReport is triggered on each PPS strobe from a device
+type TOFFReport struct {
+	Class     string  `json:"class"`
+	Device    string  `json:"device"`
+	RealSec   float64 `json:"real_sec"`
+	RealNSec  float64 `json:"real_nsec"`
+	ClockSec  float64 `json:"clock_sec"`
+	ClockNSec float64 `json:"clock_nsec"`
+}
+
+// ERRORReport is an error response
+type ERRORReport struct {
+	Class   string `json:"class"`
+	Message string `json:"message"`
+}
+
+// Satellite describes a location of a GPS satellite
+type Satellite struct {
+	PRN  float64 `json:"PRN"`
+	Az   float64 `json:"az"`
+	El   float64 `json:"el"`
+	Ss   float64 `json:"ss"`
+	Used bool    `json:"used"`
+}
+
+// Dial opens a new connection to GPSD.
+func Dial(address string) (*Session, error) {
+	return dialCommon(net.Dial("tcp4", address))
+}
+
+// DialTimeout opens a new connection to GPSD with a timeout.
+func DialTimeout(address string, to time.Duration) (*Session, error) {
+	return dialCommon(net.DialTimeout("tcp4", address, to))
+}
+
+func dialCommon(c net.Conn, err error) (session *Session, e error) {
+	session = new(Session)
+	session.socket = c
+	if err != nil {
+		return nil, err
+	}
+
+	session.reader = bufio.NewReader(session.socket)
+	session.reader.ReadString('\n')
+	session.filters = make(map[string][]Filter)
+
+	return
+}
+
+// Watch starts watching GPSD reports in a new goroutine.
+//
+// Example
+//
+//	gps := gpsd.Dial(gpsd.DEFAULT_ADDRESS)
+//	done := gpsd.Watch()
+//	<- done
+func (s *Session) Watch() (done chan bool) {
+	fmt.Fprintf(s.socket, "?WATCH={\"enable\":true,\"json\":true}")
+	done = make(chan bool)
+
+	go watch(done, s)
+
+	return
+}
+
+// SendCommand sends a command to GPSD
+func (s *Session) SendCommand(command string) {
+	fmt.Fprintf(s.socket, "?"+command+";")
+}
+
+// AddFilter attaches a function which will be called for all
+// GPSD reports with the given class. Callback functions have type Filter.
+//
+// Example:
+//
+//	gps := gpsd.Init(gpsd.DEFAULT_ADDRESS)
+//	gps.AddFilter("TPV", func (r interface{}) {
+//	  report := r.(*gpsd.TPVReport)
+//	  fmt.Println(report.Time, report.Lat, report.Lon)
+//	})
+//	done := gps.Watch()
+//	<- done
+func (s *Session) AddFilter(class string, f Filter) {
+	s.filters[class] = append(s.filters[class], f)
+}
+
+func (s *Session) deliverReport(class string, report interface{}) {
+	for _, f := range s.filters[class] {
+		f(report)
+	}
+}
+
+// Close closes the connection to GPSD
+func (s *Session) Close() {
+	if s.socket != nil {
+		if err := s.socket.Close(); err != nil {
+			return
+		}
+	}
+	s.socket = nil
+}
+
+func watch(done chan bool, s *Session) {
+	// We're not using a JSON decoder because we first need to inspect
+	// the JSON string to determine it's "class"
+	for {
+		if line, err := s.reader.ReadString('\n'); err == nil {
+			var reportPeek gpsdReport
+			lineBytes := []byte(line)
+			if err = json.Unmarshal(lineBytes, &reportPeek); err == nil {
+				if len(s.filters[reportPeek.Class]) == 0 {
+					continue
+				}
+
+				if report, err2 := unmarshalReport(reportPeek.Class, lineBytes); err2 == nil {
+					s.deliverReport(reportPeek.Class, report)
+				} else {
+					fmt.Println("JSON parsing error 2:", err)
+				}
+			} else {
+				fmt.Println("JSON parsing error:", err)
+			}
+		} else {
+			fmt.Println("Stream reader error (is gpsd running?):", err)
+			if err == io.EOF {
+				break
+			}
+		}
+	}
+	select {
+	case done <- true:
+		fmt.Println("Done gpsd monitoring")
+	case <-time.After(100 * time.Millisecond):
+		fmt.Println("Timed out waiting on gpsd monitor, exiting anyway")
+	}
+}
+
+func unmarshalReport(class string, bytes []byte) (interface{}, error) {
+	var err error
+
+	switch class {
+	case "TPV":
+		var r *TPVReport
+		err = json.Unmarshal(bytes, &r)
+		return r, err
+	case "SKY":
+		var r *SKYReport
+		err = json.Unmarshal(bytes, &r)
+		return r, err
+	case "GST":
+		var r *GSTReport
+		err = json.Unmarshal(bytes, &r)
+		return r, err
+	case "ATT":
+		var r *ATTReport
+		err = json.Unmarshal(bytes, &r)
+		return r, err
+	case "VERSION":
+		var r *VERSIONReport
+		err = json.Unmarshal(bytes, &r)
+		return r, err
+	case "DEVICES":
+		var r *DEVICESReport
+		err = json.Unmarshal(bytes, &r)
+		return r, err
+	case "PPS":
+		var r *PPSReport
+		err = json.Unmarshal(bytes, &r)
+		return r, err
+	case "TOFF":
+		var r *TOFFReport
+		err = json.Unmarshal(bytes, &r)
+		return r, err
+	case "ERROR":
+		var r *ERRORReport
+		err = json.Unmarshal(bytes, &r)
+		return r, err
+	}
+
+	return nil, err
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -7,6 +7,9 @@ github.com/PuerkitoBio/urlesc
 # github.com/StackExchange/wmi v1.2.1
 ## explicit; go 1.13
 github.com/StackExchange/wmi
+# github.com/aneeshkp/go-gpsd v0.0.0-20230804165302-4a2d069c566a
+## explicit; go 1.20
+github.com/aneeshkp/go-gpsd
 # github.com/beorn7/perks v1.0.1
 ## explicit; go 1.11
 github.com/beorn7/perks/quantile


### PR DESCRIPTION
This PR uses the direct call to gpsd for monitoring the GNSS state.
Current monitoring doesn't have GNSS offset. 
Once it is available then the offset will be reported accurately.