### PR TITLE
OCPBUGS-17454: parse DPLL replies by type

### DIFF
--- a/pkg/dpll-netlink/dpll-uapi.go
+++ b/pkg/dpll-netlink/dpll-uapi.go
@@ -3,6 +3,8 @@
 
 package dpll_netlink
 
+import "fmt"
+
 const DPLL_MCGRP_MONITOR = "monitor"
 const (
 	DPLL_A_TYPES = iota
@@ -102,7 +104,7 @@ type DpllStatusHR struct {
 	Mode          string
 	ModeSupported string
 	LockStatus    string
-	ClockId       uint64
+	ClockId       string
 	Type          string
 }
 
@@ -114,7 +116,7 @@ func GetDpllStatusHR(reply *DoDeviceGetReply) DpllStatusHR {
 		Mode:       GetMode(reply.Mode),
 		// TODO: ModeSupported
 		LockStatus: GetLockStatus(reply.LockStatus),
-		ClockId:    reply.ClockId,
+		ClockId:    fmt.Sprintf("0x%x", reply.ClockId),
 		Type:       GetDpllType(reply.Type),
 	}
 }

--- a/pkg/dpll/dpll.go
+++ b/pkg/dpll/dpll.go
@@ -134,10 +134,6 @@ func NewDpll(localMaxHoldoverOffSet, localHoldoverTimeout, maxInSpecOffset int64
 
 // nlUpdateState updates DPLL state in the DpllConfig structure.
 func (d *DpllConfig) nlUpdateState(replies []*nl.DoDeviceGetReply) {
-	const (
-		EEC_DPLL uint32 = 0
-		PPS_DPLL uint32 = 1
-	)
 	for _, reply := range replies {
 		if !d.clockIdUpdated && reply.ClockId != d.clockId {
 			if bits.OnesCount64(reply.ClockId^d.clockId) <= 4 {
@@ -150,10 +146,10 @@ func (d *DpllConfig) nlUpdateState(replies []*nl.DoDeviceGetReply) {
 		}
 		if reply.ClockId == d.clockId {
 			glog.Info(nl.GetDpllStatusHR(reply))
-			switch reply.Id {
-			case EEC_DPLL:
+			switch nl.GetDpllType(reply.Type) {
+			case "eec":
 				d.frequency_status = int64(reply.LockStatus)
-			case PPS_DPLL:
+			case "pps":
 				d.phase_status = int64(reply.LockStatus)
 				d.phase_offset = 0 // TODO: get offset from reply when implemented
 			}


### PR DESCRIPTION
This commit fixes a mistake in netlink dpll notification parsing. The parsing should be done by type and not by id
/cc @aneeshkp @jzding  @josephdrichard 