### PR TITLE
OCPBUGS-17470: GNSS state change is not captured by DPLL Netlink event listener

### DIFF
--- a/pkg/dpll/dpll_test.go
+++ b/pkg/dpll/dpll_test.go
@@ -1,30 +1,33 @@
 package dpll_test
 
 import (
+	"strconv"
+	"strings"
+	"testing"
+
 	"github.com/golang/glog"
 	"github.com/openshift/linuxptp-daemon/pkg/config"
 	"github.com/openshift/linuxptp-daemon/pkg/dpll"
 	"github.com/openshift/linuxptp-daemon/pkg/event"
 	"github.com/stretchr/testify/assert"
-	"strconv"
-	"strings"
-	"testing"
 )
 
 func TestDpllConfig_MonitorProcess(t *testing.T) {
 	d := dpll.NewDpll(1400, 5, 10, "ens01", []event.EventSource{})
 	eventChannel := make(chan event.EventChannel, 10)
+	if d != nil {
+		d.MonitorProcess(config.ProcessConfig{
+			ClockType:       "GM",
+			ConfigName:      "test",
+			EventChannel:    eventChannel,
+			GMThreshold:     config.Threshold{},
+			InitialPTPState: event.PTP_FREERUN,
+		})
 
-	d.MonitorProcess(config.ProcessConfig{
-		ClockType:       "GM",
-		ConfigName:      "test",
-		EventChannel:    eventChannel,
-		GMThreshold:     config.Threshold{},
-		InitialPTPState: event.PTP_FREERUN,
-	})
+		ptpState := <-eventChannel
+		assert.Equal(t, ptpState.ProcessName, event.DPLL)
+	}
 
-	ptpState := <-eventChannel
-	assert.Equal(t, ptpState.ProcessName, event.DPLL)
 }
 
 func TestSysfs(t *testing.T) {

--- a/pkg/event/event_test.go
+++ b/pkg/event/event_test.go
@@ -21,7 +21,7 @@ func TestEventHandler_ProcessEvents(t *testing.T) {
 	closeChn := make(chan bool)
 	go listenToEvents(closeChn)
 	time.Sleep(2 * time.Second)
-	eventMananger := event.Init("node", true, "/tmp/go.sock", eChannel, closeChn)
+	eventMananger := event.Init("node", true, "/tmp/go.sock", eChannel, closeChn, nil, nil)
 	eventMananger.MockEnable()
 	go eventMananger.ProcessEvents()
 	sendGnssEvent(eChannel)
@@ -107,10 +107,8 @@ func sendGnssEvent(eventChannel chan<- event.EventChannel) {
 	glog.Info("sending Nav status event to event handler Process")
 	eventChannel <- event.EventChannel{
 		ProcessName: "GNSS",
-		Type:        event.PTP_FREERUN,
 		CfgName:     "ts2phc.0.config",
-		Value:       0,
+		Values:      map[event.ValueType]int64{"satellites": 10},
 		ClockType:   "GM",
-		Update:      true,
 	}
 }

--- a/pkg/event/pubsub.go
+++ b/pkg/event/pubsub.go
@@ -1,0 +1,38 @@
+package event
+
+type Subscriber interface {
+	Notify(source EventSource, state PTPState)
+	Topic() EventSource
+}
+
+type Notifier interface {
+	Register(o *Subscriber)
+	Unregister(o *Subscriber)
+	Notify(state PTPState)
+}
+
+type StateNotifier struct {
+	Subscribers map[Subscriber]struct {
+	}
+}
+
+func (n *StateNotifier) Register(s Subscriber) {
+	n.Subscribers[s] = struct{}{}
+}
+func (n *StateNotifier) Unregister(s Subscriber) {
+	delete(n.Subscribers, s)
+}
+func (n *StateNotifier) notify(source EventSource, state PTPState) {
+	for o := range n.Subscribers {
+		if o.Topic() == source {
+			o.Notify(source, state)
+		}
+	}
+}
+
+func NewStateNotifier() *StateNotifier {
+	return &StateNotifier{
+		Subscribers: make(map[Subscriber]struct{}),
+	}
+
+}


### PR DESCRIPTION
Add subscriber pattern
This fixes issue with getting state of unrelated process without depending on channels 