### PR TITLE
override dockerfile_path from .ci_operator.yaml 

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -2,3 +2,4 @@ build_root_image:
   name: release
   namespace: openshift
   tag: rhel-8-release-golang-1.20-openshift-4.14
+  dockerfile_path: Dockerfile # Dockerfile for building the build root image


### PR DESCRIPTION
to build from Dockerfile upstream instead of Dockerfile.art