### PR TITLE
OCPBUGS-17526: clock class is not set to 140 when DPLL is lost source and out of spec - from holdover

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,7 +14,7 @@ import (
 const (
 	DefaultUpdateInterval  = 30
 	DefaultProfilePath     = "/etc/linuxptp"
-	DefaultPmcPollInterval = 5
+	DefaultPmcPollInterval = 60
 )
 
 func GetKubeConfig() (*rest.Config, error) {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -129,7 +129,7 @@ func New(
 	}
 	InitializeOffsetMaps()
 	pluginManager := registerPlugins(plugins)
-	eventChannel := make(chan event.EventChannel, 50)
+	eventChannel := make(chan event.EventChannel, 100)
 	return &Daemon{
 		nodeName:             nodeName,
 		namespace:            namespace,
@@ -246,7 +246,10 @@ func (dn *Daemon) applyNodePTPProfiles() error {
 	for _, p := range dn.processManager.process {
 		if p != nil {
 			p.eventCh = dn.processManager.eventChannel
-			if p.depProcess != nil {
+			// start ptp4l process early , it doesnt have
+			if p.depProcess == nil {
+				go p.cmdRun(dn.stdoutToSocket)
+			} else {
 				for _, d := range p.depProcess {
 					if d != nil {
 						time.Sleep(3 * time.Second)
@@ -267,9 +270,8 @@ func (dn *Daemon) applyNodePTPProfiles() error {
 						glog.Infof("Max %d Min %d Holdover %d", p.ptpClockThreshold.MaxOffsetThreshold, p.ptpClockThreshold.MinOffsetThreshold, p.ptpClockThreshold.HoldOverTimeout)
 					}
 				}
+				go p.cmdRun(dn.stdoutToSocket)
 			}
-			go p.cmdRun(dn.stdoutToSocket)
-			time.Sleep(1 * time.Second)
 			dn.pluginManager.AfterRunPTPCommand(p.nodeProfile, p.name)
 		}
 	}
@@ -516,9 +518,9 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 }
 
 func (dn *Daemon) HandlePmcTicker() {
-	for _, process := range dn.processManager.process {
-		if process.name == ptp4lProcessName {
-			process.pmcCheck = true
+	for _, p := range dn.processManager.process {
+		if p.name == ptp4lProcessName {
+			p.pmcCheck = true
 		}
 	}
 }
@@ -558,6 +560,11 @@ func processStatus(c *net.Conn, processName, messageTag string, status int64) {
 }
 
 func (p *ptpProcess) updateClockClass(c *net.Conn) {
+	defer func() {
+		if r := recover(); r != nil {
+			glog.Errorf("Recovered in f %#v", r)
+		}
+	}()
 	if _, matches, e := pmc.RunPMCExp(p.configName, pmc.CmdGetParentDataSet, pmc.ClockClassChangeRegEx); e == nil {
 		//regex: 'gm.ClockClass[[:space:]]+(\d+)'
 		//match  1: 'gm.ClockClass                         135'
@@ -572,10 +579,13 @@ func (p *ptpProcess) updateClockClass(c *net.Conn) {
 					//ptp4l[5196819.100]: [ptp4l.0.config] CLOCK_CLASS_CHANGE:248
 					clockClassOut := fmt.Sprintf("%s[%d]:[%s] CLOCK_CLASS_CHANGE %f\n", p.name, time.Now().Unix(), p.configName, clockClass)
 					fmt.Printf("%s", clockClassOut)
-
-					_, err := (*c).Write([]byte(clockClassOut))
-					if err != nil {
-						glog.Errorf("failed to write class change event %s", err.Error())
+					if c == nil {
+						glog.Error("failed to write class change event, connection object is nil ")
+					} else {
+						_, err := (*c).Write([]byte(clockClassOut))
+						if err != nil {
+							glog.Errorf("failed to write class change event %s", err.Error())
+						}
 					}
 				}
 			} else {
@@ -784,7 +794,8 @@ func (p *ptpProcess) ProcessTs2PhcEvents(ptpOffset float64, source string, iface
 		if len(p.ifaces) > 0 {
 			iface = p.ifaces[0]
 		}
-		p.eventCh <- event.EventChannel{
+		select {
+		case p.eventCh <- event.EventChannel{
 			ProcessName: event.TS2PHC,
 			State:       ptpState,
 			CfgName:     p.configName,
@@ -796,6 +807,10 @@ func (p *ptpProcess) ProcessTs2PhcEvents(ptpOffset float64, source string, iface
 			Time:       time.Now().UnixMilli(),
 			WriteToLog: false,
 			Reset:      false,
+		}:
+		default:
+
 		}
+
 	}
 }

--- a/pkg/daemon/gpsd.go
+++ b/pkg/daemon/gpsd.go
@@ -39,6 +39,7 @@ type GPSD struct {
 	ublxTool             *ublox.UBlox
 	gpsdSession          *gpsdlib.Session
 	gpsdDoneCh           chan bool
+	sourceLost           bool
 }
 
 // Subscriber ... event subscriber
@@ -211,7 +212,9 @@ retry:
 
 		if g.noFixStateOccurrence > noFixThreshold {
 			g.state = event.PTP_FREERUN
+			g.sourceLost = true
 		} else if tpv.Mode == gpsdlib.Mode2D || tpv.Mode == gpsdlib.Mode3D {
+			g.sourceLost = false
 			if g.isOffsetInRange() {
 				g.state = event.PTP_LOCKED
 			} else {
@@ -232,6 +235,7 @@ retry:
 			},
 			ClockType:  g.processConfig.ClockType,
 			Time:       time.Now().UnixMilli(),
+			SourceLost: g.sourceLost,
 			WriteToLog: true,
 			Reset:      false,
 		}:
@@ -341,6 +345,7 @@ retry:
 					},
 					ClockType:  processCfg.ClockType,
 					Time:       time.Now().UnixMilli(),
+					SourceLost: false,
 					WriteToLog: true,
 					Reset:      false,
 				}:

--- a/pkg/event/stats.go
+++ b/pkg/event/stats.go
@@ -11,6 +11,7 @@ type Data struct {
 	Metrics     map[ValueType]DataMetrics
 	time        int64
 	logData     string
+	sourceLost  bool
 }
 
 // DataMetrics ...

--- a/pkg/protocol/type.go
+++ b/pkg/protocol/type.go
@@ -13,6 +13,7 @@ import (
 const (
 	ClockClassFreerun       protocol.ClockClass = 248
 	ClockClassUninitialized protocol.ClockClass = 0
+	ClockClassOutOfSpec     protocol.ClockClass = 140
 )
 
 type GrandmasterSettings struct {


### PR DESCRIPTION
Defining HOLDOVER/LOCKED and FREERUN state from DPLL 
With Lost Source, IN Spec, and Out of Spec state transitions.
When GNSS is Lost, if the DPLL is in HOLDover and inSpec then do not set it to FREERUN, Instead, GM should be in Holdover state

