### PR TITLE
OCPBUGS-24043: nmea_status and clock_class metrics missing in 4.14 linuxptpdaemon

### DIFF
--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -126,6 +126,15 @@ var (
 			Help:      "0 = FREERUN, 1 = LOCKED, 2 = HOLDOVER",
 		}, []string{"process", "node", "iface"})
 
+	// ClockClassMetrics metrics to show current clock class
+	ClockClassMetrics = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: PTPNamespace,
+			Subsystem: PTPSubsystem,
+			Name:      "clock_class",
+			Help:      "6 = Locked, 7 = PRC unlocked in-spec, 52/187 = PRC unlocked out-of-spec, 248 = Default, 255 = Slave Only Clock",
+		}, []string{"process", "node"})
+
 	// InterfaceRole metrics to show current interface role
 	InterfaceRole = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -164,6 +173,7 @@ func RegisterMetrics(nodeName string) {
 		prometheus.MustRegister(ClockState)
 		prometheus.MustRegister(ProcessStatus)
 		prometheus.MustRegister(ProcessRestartCount)
+		prometheus.MustRegister(ClockClassMetrics)
 
 		// Including these stats kills performance when Prometheus polls with multiple targets
 		prometheus.Unregister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
@@ -458,6 +468,12 @@ func updateClockStateMetrics(process, iface string, state string) {
 func UpdateInterfaceRoleMetrics(process string, iface string, role ptpPortRole) {
 	InterfaceRole.With(prometheus.Labels{
 		"process": process, "node": NodeName, "iface": iface}).Set(float64(role))
+}
+
+// UpdateClockClassMetrics ... update clock class metrics
+func UpdateClockClassMetrics(clockClass float64) {
+	ClockClassMetrics.With(prometheus.Labels{
+		"process": ptp4lProcessName, "node": NodeName}).Set(float64(clockClass))
 }
 
 func UpdateProcessStatusMetrics(process, cfgName string, status int64) {

--- a/pkg/dpll/dpll_test.go
+++ b/pkg/dpll/dpll_test.go
@@ -174,7 +174,7 @@ func TestDpllConfig_MonitorProcessGNSS(t *testing.T) {
 	eChannel := make(chan event.EventChannel, 10)
 	closeChn := make(chan bool)
 	// event has to be running before dpll is started
-	eventProcessor := event.Init("node", false, "/tmp/go.sock", eChannel, closeChn, nil, nil)
+	eventProcessor := event.Init("node", false, "/tmp/go.sock", eChannel, closeChn, nil, nil, nil)
 	d := dpll.NewDpll(clockid, 1400, 2, 10, "ens01",
 		[]event.EventSource{event.GNSS}, dpll.MOCK)
 	d.CmdInit()
@@ -216,7 +216,7 @@ func TestDpllConfig_MonitorProcessPPS(t *testing.T) {
 	eChannel := make(chan event.EventChannel, 10)
 	closeChn := make(chan bool)
 	// event has to be running before dpll is started
-	eventProcessor := event.Init("node", false, "/tmp/go.sock", eChannel, closeChn, nil, nil)
+	eventProcessor := event.Init("node", false, "/tmp/go.sock", eChannel, closeChn, nil, nil, nil)
 	d := dpll.NewDpll(clockid, 1400, 2, 10, "ens01",
 		[]event.EventSource{event.GNSS}, dpll.MOCK)
 	d.CmdInit()

--- a/pkg/event/event_test.go
+++ b/pkg/event/event_test.go
@@ -200,7 +200,7 @@ func TestEventHandler_ProcessEvents(t *testing.T) {
 	eChannel := make(chan event.EventChannel, 100)
 	closeChn := make(chan bool)
 	go listenToEvents(closeChn, logOut)
-	eventManager := event.Init("node", true, "/tmp/go.sock", eChannel, closeChn, nil, nil)
+	eventManager := event.Init("node", true, "/tmp/go.sock", eChannel, closeChn, nil, nil, nil)
 	eventManager.MockEnable()
 	go eventManager.ProcessEvents()
 	time.Sleep(1 * time.Second)


### PR DESCRIPTION
add clock class metrics 