### PR TITLE
OCPBUGS-24010: fixup node profile access from plugin

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -62,7 +62,7 @@ type ptpProcess struct {
 	logFilterRegex    string
 	cmd               *exec.Cmd
 	depProcess        []process // these are list of dependent process which needs to be started/stopped if the parent process is starts/stops
-	nodeProfile       *ptpv1.PtpProfile
+	nodeProfile       ptpv1.PtpProfile
 	parentClockClass  float64
 	pmcCheck          bool
 	clockType         event.ClockType
@@ -257,7 +257,7 @@ func (dn *Daemon) applyNodePTPProfiles() error {
 						time.Sleep(3 * time.Second)
 						go d.CmdRun(false)
 						time.Sleep(3 * time.Second)
-						dn.pluginManager.AfterRunPTPCommand(p.nodeProfile, d.Name())
+						dn.pluginManager.AfterRunPTPCommand(&p.nodeProfile, d.Name())
 						d.MonitorProcess(config.ProcessConfig{
 							ClockType:    p.clockType,
 							ConfigName:   p.configName,
@@ -274,7 +274,7 @@ func (dn *Daemon) applyNodePTPProfiles() error {
 				}
 				go p.cmdRun(dn.stdoutToSocket)
 			}
-			dn.pluginManager.AfterRunPTPCommand(p.nodeProfile, p.name)
+			dn.pluginManager.AfterRunPTPCommand(&p.nodeProfile, p.name)
 		}
 	}
 	dn.pluginManager.PopulateHwConfig(dn.hwconfigs)
@@ -427,7 +427,7 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 			logFilterRegex:    getLogFilterRegex(nodeProfile),
 			cmd:               cmd,
 			depProcess:        []process{},
-			nodeProfile:       nodeProfile,
+			nodeProfile:       *nodeProfile,
 			clockType:         clockType,
 			ptpClockThreshold: getPTPThreshold(nodeProfile),
 		}


### PR DESCRIPTION
Fixup issue preventing ubxtool commands from being run by e810 plugin when there are multiple node profiles configured.