### PR TITLE
[release-4.15] OCPBUGS-29102: update clock state to FREERUN when the slave port is down

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -38,23 +38,23 @@ const (
 	InvalidMasterTimestampIndicator = "ignoring invalid master time stamp"
 )
 
-// ProcessManager manages a set of ptpProcess
+// ProcessManager manages a set of PtpProcess
 // which could be ptp4l, phc2sys or timemaster.
 // Processes in ProcessManager will be started
 // or stopped simultaneously.
 type ProcessManager struct {
-	process         []*ptpProcess
+	process         []*PtpProcess
 	eventChannel    chan event.EventChannel
 	ptpEventHandler *event.EventHandler
 }
 
-type ptpProcess struct {
-	name              string
-	ifaces            config.IFaces
+type PtpProcess struct {
+	Name              string
+	Ifaces            config.IFaces
 	ptp4lSocketPath   string
 	ptp4lConfigPath   string
 	configName        string
-	messageTag        string
+	MessageTag        string
 	eventCh           chan event.EventChannel
 	exitCh            chan bool
 	execMutex         sync.Mutex
@@ -66,17 +66,17 @@ type ptpProcess struct {
 	parentClockClass  float64
 	pmcCheck          bool
 	clockType         event.ClockType
-	ptpClockThreshold *ptpv1.PtpClockThreshold
+	PtpClockThreshold *ptpv1.PtpClockThreshold
 }
 
-func (p *ptpProcess) Stopped() bool {
+func (p *PtpProcess) Stopped() bool {
 	p.execMutex.Lock()
 	me := p.stopped
 	p.execMutex.Unlock()
 	return me
 }
 
-func (p *ptpProcess) setStopped(val bool) {
+func (p *PtpProcess) setStopped(val bool) {
 	p.execMutex.Lock()
 	p.stopped = val
 	p.execMutex.Unlock()
@@ -204,7 +204,7 @@ func (dn *Daemon) applyNodePTPProfiles() error {
 	glog.Infof("in applyNodePTPProfiles")
 	for _, p := range dn.processManager.process {
 		if p != nil {
-			glog.Infof("stopping process.... %s", p.name)
+			glog.Infof("stopping process.... %s", p.Name)
 			p.cmdStop()
 			if p.depProcess != nil {
 				for _, d := range p.depProcess {
@@ -263,18 +263,18 @@ func (dn *Daemon) applyNodePTPProfiles() error {
 							ConfigName:   p.configName,
 							EventChannel: dn.processManager.eventChannel,
 							GMThreshold: config.Threshold{
-								Max:             p.ptpClockThreshold.MaxOffsetThreshold,
-								Min:             p.ptpClockThreshold.MinOffsetThreshold,
-								HoldOverTimeout: p.ptpClockThreshold.HoldOverTimeout,
+								Max:             p.PtpClockThreshold.MaxOffsetThreshold,
+								Min:             p.PtpClockThreshold.MinOffsetThreshold,
+								HoldOverTimeout: p.PtpClockThreshold.HoldOverTimeout,
 							},
 							InitialPTPState: event.PTP_FREERUN,
 						})
-						glog.Infof("Max %d Min %d Holdover %d", p.ptpClockThreshold.MaxOffsetThreshold, p.ptpClockThreshold.MinOffsetThreshold, p.ptpClockThreshold.HoldOverTimeout)
+						glog.Infof("Max %d Min %d Holdover %d", p.PtpClockThreshold.MaxOffsetThreshold, p.PtpClockThreshold.MinOffsetThreshold, p.PtpClockThreshold.HoldOverTimeout)
 					}
 				}
 				go p.cmdRun(dn.stdoutToSocket)
 			}
-			dn.pluginManager.AfterRunPTPCommand(&p.nodeProfile, p.name)
+			dn.pluginManager.AfterRunPTPCommand(&p.nodeProfile, p.Name)
 		}
 	}
 	dn.pluginManager.PopulateHwConfig(dn.hwconfigs)
@@ -415,13 +415,13 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 		args := strings.Split(cmdLine, " ")
 		cmd = exec.Command(args[0], args[1:]...)
 
-		dprocess := ptpProcess{
-			name:              p,
-			ifaces:            ifaces,
+		dprocess := PtpProcess{
+			Name:              p,
+			Ifaces:            ifaces,
 			ptp4lConfigPath:   configPath,
 			ptp4lSocketPath:   socketPath,
 			configName:        configFile,
-			messageTag:        messageTag,
+			MessageTag:        messageTag,
 			exitCh:            make(chan bool),
 			stopped:           false,
 			logFilterRegex:    getLogFilterRegex(nodeProfile),
@@ -429,7 +429,7 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 			depProcess:        []process{},
 			nodeProfile:       *nodeProfile,
 			clockType:         clockType,
-			ptpClockThreshold: getPTPThreshold(nodeProfile),
+			PtpClockThreshold: getPTPThreshold(nodeProfile),
 		}
 		//TODO HARDWARE PLUGIN for e810
 		if pProcess == ts2phcProcessName { //& if the x plugin is enabled
@@ -437,7 +437,7 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 				output.gnss_serial_port = GPSPIPE_SERIALPORT
 			}
 			//TODO: move this to plugin or call it from hwplugin or leave it here and remove Hardcoded
-			gmInterface := dprocess.ifaces.GetGMInterface().Name
+			gmInterface := dprocess.Ifaces.GetGMInterface().Name
 
 			if e := mkFifo(); e != nil {
 				glog.Errorf("Error creating named pipe, GNSS monitoring will not work as expected %s", e.Error())
@@ -480,7 +480,7 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 			var localHoldoverTimeout uint64 = dpll.LocalHoldoverTimeout
 			var maxInSpecOffset uint64 = dpll.MaxInSpecOffset
 			var clockId uint64
-			for _, iface := range dprocess.ifaces {
+			for _, iface := range dprocess.Ifaces {
 				var eventSource []event.EventSource
 				if iface.Source == event.GNSS || iface.Source == event.PPS {
 					for k, v := range (*nodeProfile).PtpSettings {
@@ -529,7 +529,7 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 
 func (dn *Daemon) HandlePmcTicker() {
 	for _, p := range dn.processManager.process {
-		if p.name == ptp4lProcessName {
+		if p.Name == ptp4lProcessName {
 			p.pmcCheck = true
 		}
 	}
@@ -569,7 +569,7 @@ func processStatus(c *net.Conn, processName, messageTag string, status int64) {
 	}
 }
 
-func (p *ptpProcess) updateClockClass(c *net.Conn) {
+func (p *PtpProcess) updateClockClass(c *net.Conn) {
 	defer func() {
 		if r := recover(); r != nil {
 			glog.Errorf("Recovered in f %#v", r)
@@ -587,7 +587,7 @@ func (p *ptpProcess) updateClockClass(c *net.Conn) {
 					p.parentClockClass = clockClass
 					glog.Infof("clock change event identified")
 					//ptp4l[5196819.100]: [ptp4l.0.config] CLOCK_CLASS_CHANGE:248
-					clockClassOut := fmt.Sprintf("%s[%d]:[%s] CLOCK_CLASS_CHANGE %f\n", p.name, time.Now().Unix(), p.configName, clockClass)
+					clockClassOut := fmt.Sprintf("%s[%d]:[%s] CLOCK_CLASS_CHANGE %f\n", p.Name, time.Now().Unix(), p.configName, clockClass)
 					fmt.Printf("%s", clockClassOut)
 					if c == nil {
 						UpdateClockClassMetrics(clockClass) // no socket then update metrics
@@ -609,8 +609,8 @@ func (p *ptpProcess) updateClockClass(c *net.Conn) {
 	}
 }
 
-// cmdRun runs given ptpProcess and restarts on errors
-func (p *ptpProcess) cmdRun(stdoutToSocket bool) {
+// cmdRun runs given PtpProcess and restarts on errors
+func (p *PtpProcess) cmdRun(stdoutToSocket bool) {
 	var c net.Conn
 	done := make(chan struct{}) // Done setting up logging.  Go ahead and wait for process
 	defer func() {
@@ -628,8 +628,8 @@ func (p *ptpProcess) cmdRun(stdoutToSocket bool) {
 	}
 
 	for {
-		glog.Infof("Starting %s...", p.name)
-		glog.Infof("%s cmd: %+v", p.name, p.cmd)
+		glog.Infof("Starting %s...", p.Name)
+		glog.Infof("%s cmd: %+v", p.Name, p.cmd)
 
 		//
 		// don't discard process stderr output
@@ -637,20 +637,20 @@ func (p *ptpProcess) cmdRun(stdoutToSocket bool) {
 		p.cmd.Stderr = os.Stderr
 		cmdReader, err := p.cmd.StdoutPipe()
 		if err != nil {
-			glog.Errorf("CmdRun() error creating StdoutPipe for %s: %v", p.name, err)
+			glog.Errorf("CmdRun() error creating StdoutPipe for %s: %v", p.Name, err)
 			break
 		}
 		if !stdoutToSocket {
 			scanner := bufio.NewScanner(cmdReader)
-			processStatus(nil, p.name, p.messageTag, PtpProcessUp)
+			processStatus(nil, p.Name, p.MessageTag, PtpProcessUp)
 			go func() {
 				for scanner.Scan() {
 					output := scanner.Text()
 					if regexErr != nil || !logFilterRegex.MatchString(output) {
 						fmt.Printf("%s\n", output)
 					}
-					p.processPTPMetrics(output)
-					if p.name == ptp4lProcessName {
+					p.ProcessPTPMetrics(output)
+					if p.Name == ptp4lProcessName {
 						if strings.Contains(output, ClockClassChangeIndicator) {
 							go p.updateClockClass(nil)
 						}
@@ -673,7 +673,7 @@ func (p *ptpProcess) cmdRun(stdoutToSocket bool) {
 					}
 				}
 				scanner := bufio.NewScanner(cmdReader)
-				processStatus(&c, p.name, p.messageTag, PtpProcessUp)
+				processStatus(&c, p.Name, p.MessageTag, PtpProcessUp)
 				for scanner.Scan() {
 					output := scanner.Text()
 					if p.pmcCheck {
@@ -687,8 +687,8 @@ func (p *ptpProcess) cmdRun(stdoutToSocket bool) {
 					out := fmt.Sprintf("%s\n", output)
 
 					// for ts2phc, we need to extract metrics to identify GM state
-					p.processPTPMetrics(output)
-					if p.name == ptp4lProcessName {
+					p.ProcessPTPMetrics(output)
+					if p.Name == ptp4lProcessName {
 						if strings.Contains(output, ClockClassChangeIndicator) {
 							go p.updateClockClass(&c)
 						}
@@ -706,27 +706,27 @@ func (p *ptpProcess) cmdRun(stdoutToSocket bool) {
 		if !p.Stopped() {
 			err = p.cmd.Start() // this is asynchronous call,
 			if err != nil {
-				glog.Errorf("CmdRun() error starting %s: %v", p.name, err)
+				glog.Errorf("CmdRun() error starting %s: %v", p.Name, err)
 			}
 		}
 		<-done // goroutine is done
 		err = p.cmd.Wait()
 		if err != nil {
-			glog.Errorf("CmdRun() error waiting for %s: %v", p.name, err)
+			glog.Errorf("CmdRun() error waiting for %s: %v", p.Name, err)
 		}
 		if stdoutToSocket && c != nil {
-			processStatus(&c, p.name, p.messageTag, PtpProcessDown)
+			processStatus(&c, p.Name, p.MessageTag, PtpProcessDown)
 		} else {
-			processStatus(nil, p.name, p.messageTag, PtpProcessDown)
+			processStatus(nil, p.Name, p.MessageTag, PtpProcessDown)
 		}
 
 		time.Sleep(connectionRetryInterval) // Delay to prevent flooding restarts if startup fails
 		// Don't restart after termination
 		if p.Stopped() {
-			glog.Infof("Not recreating %s...", p.name)
+			glog.Infof("Not recreating %s...", p.Name)
 			break
 		} else {
-			glog.Infof("Recreating %s...", p.name)
+			glog.Infof("Recreating %s...", p.Name)
 			newCmd := exec.Command(p.cmd.Args[0], p.cmd.Args[1:]...)
 			p.cmd = newCmd
 		}
@@ -739,41 +739,42 @@ func (p *ptpProcess) cmdRun(stdoutToSocket bool) {
 }
 
 // for ts2phc along with processing metrics need to identify event
-func (p *ptpProcess) processPTPMetrics(output string) {
-	if p.name == ts2phcProcessName && (strings.Contains(output, NMEASourceDisabledIndicator) ||
+func (p *PtpProcess) ProcessPTPMetrics(output string) {
+	if p.Name == ts2phcProcessName && (strings.Contains(output, NMEASourceDisabledIndicator) ||
 		strings.Contains(output, InvalidMasterTimestampIndicator)) { //TODO identify which interface lost nmea or 1pps
-		iface := p.ifaces.GetGMInterface().Name
+		iface := p.Ifaces.GetGMInterface().Name
 		p.ProcessTs2PhcEvents(faultyOffset, ts2phcProcessName, iface, map[event.ValueType]interface{}{event.NMEA_STATUS: int64(0)})
 		glog.Error("nmea string lost") //TODO: add for 1pps lost
 	} else {
-		configName, source, ptpOffset, _, iface := extractMetrics(p.messageTag, p.name, p.ifaces, output)
+		configName, source, ptpOffset, _, iface := extractMetrics(p.MessageTag, p.Name, p.Ifaces, output)
 		if iface != "" { // for ptp4l/phc2sys this function only update metrics
 			var values map[event.ValueType]interface{}
 			ifaceName := masterOffsetIface.getByAlias(configName, iface).name
-			if iface != clockRealTime && p.name == ts2phcProcessName {
-				eventSource := p.ifaces.GetEventSource(ifaceName)
+			if iface != clockRealTime && p.Name == ts2phcProcessName {
+				eventSource := p.Ifaces.GetEventSource(ifaceName)
 				if eventSource == event.GNSS {
 					values = map[event.ValueType]interface{}{event.NMEA_STATUS: int64(1)}
 				}
+				p.ProcessTs2PhcEvents(ptpOffset, source, iface, values)
 			}
 			p.ProcessTs2PhcEvents(ptpOffset, source, ifaceName, values)
 		}
 	}
 }
 
-// cmdStop stops ptpProcess launched by cmdRun
-func (p *ptpProcess) cmdStop() {
-	glog.Infof("stopping %s...", p.name)
+// cmdStop stops PtpProcess launched by cmdRun
+func (p *PtpProcess) cmdStop() {
+	glog.Infof("stopping %s...", p.Name)
 	if p.cmd == nil {
 		return
 	}
 	p.setStopped(true)
 	if p.cmd.Process != nil {
-		glog.Infof("Sending TERM to (%s) PID: %d", p.name, p.cmd.Process.Pid)
+		glog.Infof("Sending TERM to (%s) PID: %d", p.Name, p.cmd.Process.Pid)
 		err := p.cmd.Process.Signal(syscall.SIGTERM)
 		if err != nil {
 			// If the process is already terminated, we will get an error here
-			glog.Errorf("failed to send SIGTERM to %s (%d): %v", p.name, p.cmd.Process.Pid, err)
+			glog.Errorf("failed to send SIGTERM to %s (%d): %v", p.Name, p.cmd.Process.Pid, err)
 			return
 		}
 	}
@@ -784,7 +785,7 @@ func (p *ptpProcess) cmdStop() {
 		}
 	}
 	<-p.exitCh
-	glog.Infof("Process %s (%d) terminated", p.name, p.cmd.Process.Pid)
+	glog.Infof("Process %s (%d) terminated", p.Name, p.cmd.Process.Pid)
 }
 
 func getPTPThreshold(nodeProfile *ptpv1.PtpProfile) *ptpv1.PtpClockThreshold {
@@ -803,16 +804,16 @@ func getPTPThreshold(nodeProfile *ptpv1.PtpProfile) *ptpv1.PtpClockThreshold {
 	}
 }
 
-func (p *ptpProcess) MonitorEvent(offset float64, clockState string) {
+func (p *PtpProcess) MonitorEvent(offset float64, clockState string) {
 	// not implemented
 }
 
-func (p *ptpProcess) ProcessTs2PhcEvents(ptpOffset float64, source string, iface string, extraValue map[event.ValueType]interface{}) {
+func (p *PtpProcess) ProcessTs2PhcEvents(ptpOffset float64, source string, iface string, extraValue map[event.ValueType]interface{}) {
 	var ptpState event.PTPState
 	ptpState = event.PTP_FREERUN
 	ptpOffsetInt64 := int64(ptpOffset)
-	if ptpOffsetInt64 <= p.ptpClockThreshold.MaxOffsetThreshold &&
-		ptpOffsetInt64 >= p.ptpClockThreshold.MinOffsetThreshold {
+	if ptpOffsetInt64 <= p.PtpClockThreshold.MaxOffsetThreshold &&
+		ptpOffsetInt64 >= p.PtpClockThreshold.MinOffsetThreshold {
 		ptpState = event.PTP_LOCKED
 	}
 	if source == ts2phcProcessName { // for ts2phc send it to event to create metrics and events
@@ -847,9 +848,9 @@ func (p *ptpProcess) ProcessTs2PhcEvents(ptpOffset float64, source string, iface
 			iface = string(r[:len(r)-1]) + "x"
 		}
 		if ptpState == event.PTP_LOCKED {
-			updateClockStateMetrics(p.name, iface, LOCKED)
+			updateClockStateMetrics(p.Name, iface, LOCKED)
 		} else {
-			updateClockStateMetrics(p.name, iface, FREERUN)
+			updateClockStateMetrics(p.Name, iface, FREERUN)
 		}
 	}
 

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -1,0 +1,193 @@
+package daemon_test
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/openshift/linuxptp-daemon/pkg/config"
+	"github.com/openshift/linuxptp-daemon/pkg/daemon"
+	ptpv1 "github.com/openshift/ptp-operator/api/v1"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	s0     = 0.0
+	s1     = 2.0
+	s2     = 1.0
+	MYNODE = "mynode"
+	// SKIP skip the verification of the metric
+	SKIP    = 12345678
+	CLEANUP = -12345678
+)
+
+var process *daemon.PtpProcess
+var registry *prometheus.Registry
+
+type TestCase struct {
+	MessageTag                  string
+	Name                        string
+	Ifaces                      config.IFaces
+	log                         string
+	from                        string
+	process                     string
+	node                        string
+	iface                       string
+	expectedOffset              float64 // offset_ns
+	expectedMaxOffset           float64 // max_offset_ns1
+	expectedFrequencyAdjustment float64 // frequency_adjustment_ns
+	expectedDelay               float64 // delay_ns
+	expectedClockState          float64 // clock_state
+	expectedNmeaStatus          float64 // nmea_status
+	expectedPpsStatus           float64 // pps_status
+	expectedClockClassMetrics   float64 // clock_class
+}
+
+func (tc *TestCase) init() {
+	tc.expectedOffset = SKIP
+	tc.expectedMaxOffset = SKIP
+	tc.expectedFrequencyAdjustment = SKIP
+	tc.expectedDelay = SKIP
+	tc.expectedClockState = SKIP
+	tc.expectedNmeaStatus = SKIP
+	tc.expectedPpsStatus = SKIP
+	tc.expectedClockClassMetrics = SKIP
+
+}
+
+func (tc *TestCase) String() string {
+	b := strings.Builder{}
+	b.WriteString("log: \"" + tc.log + "\"\n")
+	b.WriteString("from: " + tc.from + "\n")
+	b.WriteString("process: " + tc.process + "\n")
+	b.WriteString("node: " + tc.node + "\n")
+	b.WriteString("iface: " + tc.iface + "\n")
+	return b.String()
+}
+
+func (tc *TestCase) cleanupMetrics() {
+	daemon.Offset.With(map[string]string{"from": tc.from, "process": tc.process, "node": tc.node, "iface": tc.iface}).Set(CLEANUP)
+	daemon.MaxOffset.With(map[string]string{"from": tc.from, "process": tc.process, "node": tc.node, "iface": tc.iface}).Set(CLEANUP)
+	daemon.FrequencyAdjustment.With(map[string]string{"from": tc.from, "process": tc.process, "node": tc.node, "iface": tc.iface}).Set(CLEANUP)
+	daemon.Delay.With(map[string]string{"from": tc.from, "process": tc.process, "node": tc.node, "iface": tc.iface}).Set(CLEANUP)
+	daemon.ClockState.With(map[string]string{"process": tc.process, "node": tc.node, "iface": tc.iface}).Set(CLEANUP)
+	daemon.ClockClassMetrics.With(map[string]string{"process": tc.process, "node": tc.node}).Set(CLEANUP)
+}
+
+var testCases = []TestCase{
+	{
+		log:                         "phc2sys[1823126.732]: [ptp4l.0.config] CLOCK_REALTIME phc offset       -10 s2 freq   +8956 delay    508",
+		MessageTag:                  "[ptp4l.0.config]",
+		Name:                        "phc2sys",
+		from:                        "phc",
+		process:                     "phc2sys",
+		iface:                       "CLOCK_REALTIME",
+		expectedOffset:              -10,
+		expectedMaxOffset:           -10,
+		expectedFrequencyAdjustment: 8956,
+		expectedDelay:               508,
+		expectedClockState:          s2,
+		expectedNmeaStatus:          SKIP,
+		expectedPpsStatus:           SKIP,
+		expectedClockClassMetrics:   SKIP,
+	},
+	{
+		log:                         "ts2phc[1896327.319]: [ts2phc.0.config] ens2f0 master offset         -1 s2 freq      -2",
+		MessageTag:                  "[ts2phc.0.config]",
+		Name:                        "ts2phc",
+		from:                        "master",
+		process:                     "ts2phc",
+		iface:                       "ens2fx",
+		expectedOffset:              -1,
+		expectedMaxOffset:           -1,
+		expectedFrequencyAdjustment: -2,
+		expectedDelay:               0,
+		expectedClockState:          s2,
+		expectedNmeaStatus:          SKIP,
+		expectedPpsStatus:           SKIP,
+		expectedClockClassMetrics:   SKIP,
+	},
+	{
+		log:                         "ts2phc[1896327.319]: [ts2phc.0.config] ens2f0 master offset         3 s0 freq      4",
+		MessageTag:                  "[ts2phc.0.config]",
+		Name:                        "ts2phc",
+		from:                        "master",
+		process:                     "ts2phc",
+		iface:                       "ens2fx",
+		expectedOffset:              3,
+		expectedMaxOffset:           3,
+		expectedFrequencyAdjustment: 4,
+		expectedDelay:               0,
+		expectedClockState:          s0,
+		expectedNmeaStatus:          SKIP,
+		expectedPpsStatus:           SKIP,
+		expectedClockClassMetrics:   SKIP,
+	},
+}
+
+func setup() {
+	flag.Set("alsologtostderr", fmt.Sprintf("%t", true))
+	var logLevel string
+	flag.StringVar(&logLevel, "logLevel", "4", "test")
+	flag.Lookup("v").Value.Set(logLevel)
+
+	daemon.InitializeOffsetMaps()
+	process = &daemon.PtpProcess{}
+	process.PtpClockThreshold = &ptpv1.PtpClockThreshold{
+		HoldOverTimeout:    5,
+		MaxOffsetThreshold: 100,
+		MinOffsetThreshold: -100,
+	}
+	daemon.RegisterMetrics(MYNODE)
+}
+
+func teardown() {
+}
+
+func TestMain(m *testing.M) {
+	setup()
+	code := m.Run()
+	teardown()
+	os.Exit(code)
+}
+func Test_ProcessPTPMetrics(t *testing.T) {
+
+	assert := assert.New(t)
+	for _, tc := range testCases {
+		tc.node = MYNODE
+		tc.cleanupMetrics()
+		process.Name = tc.Name
+		process.MessageTag = tc.MessageTag
+		process.Ifaces = tc.Ifaces
+		process.ProcessPTPMetrics(tc.log)
+
+		if tc.expectedOffset != SKIP {
+			ptpOffset := daemon.Offset.With(map[string]string{"from": tc.from, "process": tc.process, "node": tc.node, "iface": tc.iface})
+			assert.Equal(tc.expectedOffset, testutil.ToFloat64(ptpOffset), "Offset does not match\n%s", tc.String())
+		}
+		if tc.expectedMaxOffset != SKIP {
+			ptpMaxOffset := daemon.MaxOffset.With(map[string]string{"from": tc.from, "process": tc.process, "node": tc.node, "iface": tc.iface})
+			assert.Equal(tc.expectedMaxOffset, testutil.ToFloat64(ptpMaxOffset), "MaxOffset does not match\n%s", tc.String())
+		}
+		if tc.expectedFrequencyAdjustment != SKIP {
+			ptpFrequencyAdjustment := daemon.FrequencyAdjustment.With(map[string]string{"from": tc.from, "process": tc.process, "node": tc.node, "iface": tc.iface})
+			assert.Equal(tc.expectedFrequencyAdjustment, testutil.ToFloat64(ptpFrequencyAdjustment), "FrequencyAdjustment does not match\n%s", tc.String())
+		}
+		if tc.expectedDelay != SKIP {
+			ptpDelay := daemon.Delay.With(map[string]string{"from": tc.from, "process": tc.process, "node": tc.node, "iface": tc.iface})
+			assert.Equal(tc.expectedDelay, testutil.ToFloat64(ptpDelay), "Delay does not match\n%s", tc.String())
+		}
+		if tc.expectedClockState != SKIP {
+			clockState := daemon.ClockState.With(map[string]string{"process": tc.process, "node": tc.node, "iface": tc.iface})
+			assert.Equal(tc.expectedClockState, testutil.ToFloat64(clockState), "ClockState does not match\n%s", tc.String())
+		}
+		if tc.expectedClockClassMetrics != SKIP {
+			clockClassMetrics := daemon.ClockClassMetrics.With(map[string]string{"process": tc.process, "node": tc.node})
+			assert.Equal(tc.expectedClockClassMetrics, testutil.ToFloat64(clockClassMetrics), "ClockClassMetrics does not match\n%s", tc.String())
+		}
+	}
+}

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -132,7 +132,7 @@ var (
 			Namespace: PTPNamespace,
 			Subsystem: PTPSubsystem,
 			Name:      "clock_class",
-			Help:      "6 = Locked, 7 = PRC unlocked in-spec, 52/187 = PRC unlocked out-of-spec, 248 = Default, 255 = Slave Only Clock",
+			Help:      "6 = Locked, 7 = PRC unlocked in-spec, 52/187 = PRC unlocked out-of-spec, 135 = T-BC holdover in-spec, 165 = T-BC holdover out-of-spec, 248 = Default, 255 = Slave Only Clock",
 		}, []string{"process", "node"})
 
 	// InterfaceRole metrics to show current interface role
@@ -263,6 +263,7 @@ func extractMetrics(messageTag string, processName string, ifaces []config.Iface
 						masterOffsetSource.get(configName) == ptp4lProcessName {
 						updatePTPMetrics(master, processName, masterOffsetIface.get(configName).alias, faultyOffset, faultyOffset, 0, 0)
 						updatePTPMetrics(phc, phcProcessName, clockRealTime, faultyOffset, faultyOffset, 0, 0)
+						updateClockStateMetrics(processName, masterOffsetIface.get(configName).alias, FREERUN)
 						masterOffsetIface.set(configName, "")
 						slaveIface.set(configName, "")
 					}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/lint.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/lint.go
@@ -1,0 +1,46 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil/promlint"
+)
+
+// CollectAndLint registers the provided Collector with a newly created pedantic
+// Registry. It then calls GatherAndLint with that Registry and with the
+// provided metricNames.
+func CollectAndLint(c prometheus.Collector, metricNames ...string) ([]promlint.Problem, error) {
+	reg := prometheus.NewPedanticRegistry()
+	if err := reg.Register(c); err != nil {
+		return nil, fmt.Errorf("registering collector failed: %s", err)
+	}
+	return GatherAndLint(reg, metricNames...)
+}
+
+// GatherAndLint gathers all metrics from the provided Gatherer and checks them
+// with the linter in the promlint package. If any metricNames are provided,
+// only metrics with those names are checked.
+func GatherAndLint(g prometheus.Gatherer, metricNames ...string) ([]promlint.Problem, error) {
+	got, err := g.Gather()
+	if err != nil {
+		return nil, fmt.Errorf("gathering metrics failed: %s", err)
+	}
+	if metricNames != nil {
+		got = filterMetrics(got, metricNames)
+	}
+	return promlint.NewWithMetricFamilies(got).Lint()
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/promlint.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/promlint.go
@@ -1,0 +1,386 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package promlint provides a linter for Prometheus metrics.
+package promlint
+
+import (
+	"fmt"
+	"io"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/prometheus/common/expfmt"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+// A Linter is a Prometheus metrics linter.  It identifies issues with metric
+// names, types, and metadata, and reports them to the caller.
+type Linter struct {
+	// The linter will read metrics in the Prometheus text format from r and
+	// then lint it, _and_ it will lint the metrics provided directly as
+	// MetricFamily proto messages in mfs. Note, however, that the current
+	// constructor functions New and NewWithMetricFamilies only ever set one
+	// of them.
+	r   io.Reader
+	mfs []*dto.MetricFamily
+}
+
+// A Problem is an issue detected by a Linter.
+type Problem struct {
+	// The name of the metric indicated by this Problem.
+	Metric string
+
+	// A description of the issue for this Problem.
+	Text string
+}
+
+// newProblem is helper function to create a Problem.
+func newProblem(mf *dto.MetricFamily, text string) Problem {
+	return Problem{
+		Metric: mf.GetName(),
+		Text:   text,
+	}
+}
+
+// New creates a new Linter that reads an input stream of Prometheus metrics in
+// the Prometheus text exposition format.
+func New(r io.Reader) *Linter {
+	return &Linter{
+		r: r,
+	}
+}
+
+// NewWithMetricFamilies creates a new Linter that reads from a slice of
+// MetricFamily protobuf messages.
+func NewWithMetricFamilies(mfs []*dto.MetricFamily) *Linter {
+	return &Linter{
+		mfs: mfs,
+	}
+}
+
+// Lint performs a linting pass, returning a slice of Problems indicating any
+// issues found in the metrics stream. The slice is sorted by metric name
+// and issue description.
+func (l *Linter) Lint() ([]Problem, error) {
+	var problems []Problem
+
+	if l.r != nil {
+		d := expfmt.NewDecoder(l.r, expfmt.FmtText)
+
+		mf := &dto.MetricFamily{}
+		for {
+			if err := d.Decode(mf); err != nil {
+				if err == io.EOF {
+					break
+				}
+
+				return nil, err
+			}
+
+			problems = append(problems, lint(mf)...)
+		}
+	}
+	for _, mf := range l.mfs {
+		problems = append(problems, lint(mf)...)
+	}
+
+	// Ensure deterministic output.
+	sort.SliceStable(problems, func(i, j int) bool {
+		if problems[i].Metric == problems[j].Metric {
+			return problems[i].Text < problems[j].Text
+		}
+		return problems[i].Metric < problems[j].Metric
+	})
+
+	return problems, nil
+}
+
+// lint is the entry point for linting a single metric.
+func lint(mf *dto.MetricFamily) []Problem {
+	fns := []func(mf *dto.MetricFamily) []Problem{
+		lintHelp,
+		lintMetricUnits,
+		lintCounter,
+		lintHistogramSummaryReserved,
+		lintMetricTypeInName,
+		lintReservedChars,
+		lintCamelCase,
+		lintUnitAbbreviations,
+	}
+
+	var problems []Problem
+	for _, fn := range fns {
+		problems = append(problems, fn(mf)...)
+	}
+
+	// TODO(mdlayher): lint rules for specific metrics types.
+	return problems
+}
+
+// lintHelp detects issues related to the help text for a metric.
+func lintHelp(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+
+	// Expect all metrics to have help text available.
+	if mf.Help == nil {
+		problems = append(problems, newProblem(mf, "no help text"))
+	}
+
+	return problems
+}
+
+// lintMetricUnits detects issues with metric unit names.
+func lintMetricUnits(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+
+	unit, base, ok := metricUnits(*mf.Name)
+	if !ok {
+		// No known units detected.
+		return nil
+	}
+
+	// Unit is already a base unit.
+	if unit == base {
+		return nil
+	}
+
+	problems = append(problems, newProblem(mf, fmt.Sprintf("use base unit %q instead of %q", base, unit)))
+
+	return problems
+}
+
+// lintCounter detects issues specific to counters, as well as patterns that should
+// only be used with counters.
+func lintCounter(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+
+	isCounter := mf.GetType() == dto.MetricType_COUNTER
+	isUntyped := mf.GetType() == dto.MetricType_UNTYPED
+	hasTotalSuffix := strings.HasSuffix(mf.GetName(), "_total")
+
+	switch {
+	case isCounter && !hasTotalSuffix:
+		problems = append(problems, newProblem(mf, `counter metrics should have "_total" suffix`))
+	case !isUntyped && !isCounter && hasTotalSuffix:
+		problems = append(problems, newProblem(mf, `non-counter metrics should not have "_total" suffix`))
+	}
+
+	return problems
+}
+
+// lintHistogramSummaryReserved detects when other types of metrics use names or labels
+// reserved for use by histograms and/or summaries.
+func lintHistogramSummaryReserved(mf *dto.MetricFamily) []Problem {
+	// These rules do not apply to untyped metrics.
+	t := mf.GetType()
+	if t == dto.MetricType_UNTYPED {
+		return nil
+	}
+
+	var problems []Problem
+
+	isHistogram := t == dto.MetricType_HISTOGRAM
+	isSummary := t == dto.MetricType_SUMMARY
+
+	n := mf.GetName()
+
+	if !isHistogram && strings.HasSuffix(n, "_bucket") {
+		problems = append(problems, newProblem(mf, `non-histogram metrics should not have "_bucket" suffix`))
+	}
+	if !isHistogram && !isSummary && strings.HasSuffix(n, "_count") {
+		problems = append(problems, newProblem(mf, `non-histogram and non-summary metrics should not have "_count" suffix`))
+	}
+	if !isHistogram && !isSummary && strings.HasSuffix(n, "_sum") {
+		problems = append(problems, newProblem(mf, `non-histogram and non-summary metrics should not have "_sum" suffix`))
+	}
+
+	for _, m := range mf.GetMetric() {
+		for _, l := range m.GetLabel() {
+			ln := l.GetName()
+
+			if !isHistogram && ln == "le" {
+				problems = append(problems, newProblem(mf, `non-histogram metrics should not have "le" label`))
+			}
+			if !isSummary && ln == "quantile" {
+				problems = append(problems, newProblem(mf, `non-summary metrics should not have "quantile" label`))
+			}
+		}
+	}
+
+	return problems
+}
+
+// lintMetricTypeInName detects when metric types are included in the metric name.
+func lintMetricTypeInName(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+	n := strings.ToLower(mf.GetName())
+
+	for i, t := range dto.MetricType_name {
+		if i == int32(dto.MetricType_UNTYPED) {
+			continue
+		}
+
+		typename := strings.ToLower(t)
+		if strings.Contains(n, "_"+typename+"_") || strings.HasSuffix(n, "_"+typename) {
+			problems = append(problems, newProblem(mf, fmt.Sprintf(`metric name should not include type '%s'`, typename)))
+		}
+	}
+	return problems
+}
+
+// lintReservedChars detects colons in metric names.
+func lintReservedChars(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+	if strings.Contains(mf.GetName(), ":") {
+		problems = append(problems, newProblem(mf, "metric names should not contain ':'"))
+	}
+	return problems
+}
+
+var camelCase = regexp.MustCompile(`[a-z][A-Z]`)
+
+// lintCamelCase detects metric names and label names written in camelCase.
+func lintCamelCase(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+	if camelCase.FindString(mf.GetName()) != "" {
+		problems = append(problems, newProblem(mf, "metric names should be written in 'snake_case' not 'camelCase'"))
+	}
+
+	for _, m := range mf.GetMetric() {
+		for _, l := range m.GetLabel() {
+			if camelCase.FindString(l.GetName()) != "" {
+				problems = append(problems, newProblem(mf, "label names should be written in 'snake_case' not 'camelCase'"))
+			}
+		}
+	}
+	return problems
+}
+
+// lintUnitAbbreviations detects abbreviated units in the metric name.
+func lintUnitAbbreviations(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+	n := strings.ToLower(mf.GetName())
+	for _, s := range unitAbbreviations {
+		if strings.Contains(n, "_"+s+"_") || strings.HasSuffix(n, "_"+s) {
+			problems = append(problems, newProblem(mf, "metric names should not contain abbreviated units"))
+		}
+	}
+	return problems
+}
+
+// metricUnits attempts to detect known unit types used as part of a metric name,
+// e.g. "foo_bytes_total" or "bar_baz_milligrams".
+func metricUnits(m string) (unit string, base string, ok bool) {
+	ss := strings.Split(m, "_")
+
+	for unit, base := range units {
+		// Also check for "no prefix".
+		for _, p := range append(unitPrefixes, "") {
+			for _, s := range ss {
+				// Attempt to explicitly match a known unit with a known prefix,
+				// as some words may look like "units" when matching suffix.
+				//
+				// As an example, "thermometers" should not match "meters", but
+				// "kilometers" should.
+				if s == p+unit {
+					return p + unit, base, true
+				}
+			}
+		}
+	}
+
+	return "", "", false
+}
+
+// Units and their possible prefixes recognized by this library.  More can be
+// added over time as needed.
+var (
+	// map a unit to the appropriate base unit.
+	units = map[string]string{
+		// Base units.
+		"amperes": "amperes",
+		"bytes":   "bytes",
+		"celsius": "celsius", // Also allow Celsius because it is common in typical Prometheus use cases.
+		"grams":   "grams",
+		"joules":  "joules",
+		"kelvin":  "kelvin", // SI base unit, used in special cases (e.g. color temperature, scientific measurements).
+		"meters":  "meters", // Both American and international spelling permitted.
+		"metres":  "metres",
+		"seconds": "seconds",
+		"volts":   "volts",
+
+		// Non base units.
+		// Time.
+		"minutes": "seconds",
+		"hours":   "seconds",
+		"days":    "seconds",
+		"weeks":   "seconds",
+		// Temperature.
+		"kelvins":    "kelvin",
+		"fahrenheit": "celsius",
+		"rankine":    "celsius",
+		// Length.
+		"inches": "meters",
+		"yards":  "meters",
+		"miles":  "meters",
+		// Bytes.
+		"bits": "bytes",
+		// Energy.
+		"calories": "joules",
+		// Mass.
+		"pounds": "grams",
+		"ounces": "grams",
+	}
+
+	unitPrefixes = []string{
+		"pico",
+		"nano",
+		"micro",
+		"milli",
+		"centi",
+		"deci",
+		"deca",
+		"hecto",
+		"kilo",
+		"kibi",
+		"mega",
+		"mibi",
+		"giga",
+		"gibi",
+		"tera",
+		"tebi",
+		"peta",
+		"pebi",
+	}
+
+	// Common abbreviations that we'd like to discourage.
+	unitAbbreviations = []string{
+		"s",
+		"ms",
+		"us",
+		"ns",
+		"sec",
+		"b",
+		"kb",
+		"mb",
+		"gb",
+		"tb",
+		"pb",
+		"m",
+		"h",
+		"d",
+	}
+)

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/testutil.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/testutil.go
@@ -1,0 +1,230 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package testutil provides helpers to test code using the prometheus package
+// of client_golang.
+//
+// While writing unit tests to verify correct instrumentation of your code, it's
+// a common mistake to mostly test the instrumentation library instead of your
+// own code. Rather than verifying that a prometheus.Counter's value has changed
+// as expected or that it shows up in the exposition after registration, it is
+// in general more robust and more faithful to the concept of unit tests to use
+// mock implementations of the prometheus.Counter and prometheus.Registerer
+// interfaces that simply assert that the Add or Register methods have been
+// called with the expected arguments. However, this might be overkill in simple
+// scenarios. The ToFloat64 function is provided for simple inspection of a
+// single-value metric, but it has to be used with caution.
+//
+// End-to-end tests to verify all or larger parts of the metrics exposition can
+// be implemented with the CollectAndCompare or GatherAndCompare functions. The
+// most appropriate use is not so much testing instrumentation of your code, but
+// testing custom prometheus.Collector implementations and in particular whole
+// exporters, i.e. programs that retrieve telemetry data from a 3rd party source
+// and convert it into Prometheus metrics.
+//
+// In a similar pattern, CollectAndLint and GatherAndLint can be used to detect
+// metrics that have issues with their name, type, or metadata without being
+// necessarily invalid, e.g. a counter with a name missing the “_total” suffix.
+package testutil
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"github.com/prometheus/common/expfmt"
+
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/internal"
+)
+
+// ToFloat64 collects all Metrics from the provided Collector. It expects that
+// this results in exactly one Metric being collected, which must be a Gauge,
+// Counter, or Untyped. In all other cases, ToFloat64 panics. ToFloat64 returns
+// the value of the collected Metric.
+//
+// The Collector provided is typically a simple instance of Gauge or Counter, or
+// – less commonly – a GaugeVec or CounterVec with exactly one element. But any
+// Collector fulfilling the prerequisites described above will do.
+//
+// Use this function with caution. It is computationally very expensive and thus
+// not suited at all to read values from Metrics in regular code. This is really
+// only for testing purposes, and even for testing, other approaches are often
+// more appropriate (see this package's documentation).
+//
+// A clear anti-pattern would be to use a metric type from the prometheus
+// package to track values that are also needed for something else than the
+// exposition of Prometheus metrics. For example, you would like to track the
+// number of items in a queue because your code should reject queuing further
+// items if a certain limit is reached. It is tempting to track the number of
+// items in a prometheus.Gauge, as it is then easily available as a metric for
+// exposition, too. However, then you would need to call ToFloat64 in your
+// regular code, potentially quite often. The recommended way is to track the
+// number of items conventionally (in the way you would have done it without
+// considering Prometheus metrics) and then expose the number with a
+// prometheus.GaugeFunc.
+func ToFloat64(c prometheus.Collector) float64 {
+	var (
+		m      prometheus.Metric
+		mCount int
+		mChan  = make(chan prometheus.Metric)
+		done   = make(chan struct{})
+	)
+
+	go func() {
+		for m = range mChan {
+			mCount++
+		}
+		close(done)
+	}()
+
+	c.Collect(mChan)
+	close(mChan)
+	<-done
+
+	if mCount != 1 {
+		panic(fmt.Errorf("collected %d metrics instead of exactly 1", mCount))
+	}
+
+	pb := &dto.Metric{}
+	m.Write(pb)
+	if pb.Gauge != nil {
+		return pb.Gauge.GetValue()
+	}
+	if pb.Counter != nil {
+		return pb.Counter.GetValue()
+	}
+	if pb.Untyped != nil {
+		return pb.Untyped.GetValue()
+	}
+	panic(fmt.Errorf("collected a non-gauge/counter/untyped metric: %s", pb))
+}
+
+// CollectAndCount registers the provided Collector with a newly created
+// pedantic Registry. It then calls GatherAndCount with that Registry and with
+// the provided metricNames. In the unlikely case that the registration or the
+// gathering fails, this function panics. (This is inconsistent with the other
+// CollectAnd… functions in this package and has historical reasons. Changing
+// the function signature would be a breaking change and will therefore only
+// happen with the next major version bump.)
+func CollectAndCount(c prometheus.Collector, metricNames ...string) int {
+	reg := prometheus.NewPedanticRegistry()
+	if err := reg.Register(c); err != nil {
+		panic(fmt.Errorf("registering collector failed: %s", err))
+	}
+	result, err := GatherAndCount(reg, metricNames...)
+	if err != nil {
+		panic(err)
+	}
+	return result
+}
+
+// GatherAndCount gathers all metrics from the provided Gatherer and counts
+// them. It returns the number of metric children in all gathered metric
+// families together. If any metricNames are provided, only metrics with those
+// names are counted.
+func GatherAndCount(g prometheus.Gatherer, metricNames ...string) (int, error) {
+	got, err := g.Gather()
+	if err != nil {
+		return 0, fmt.Errorf("gathering metrics failed: %s", err)
+	}
+	if metricNames != nil {
+		got = filterMetrics(got, metricNames)
+	}
+
+	result := 0
+	for _, mf := range got {
+		result += len(mf.GetMetric())
+	}
+	return result, nil
+}
+
+// CollectAndCompare registers the provided Collector with a newly created
+// pedantic Registry. It then calls GatherAndCompare with that Registry and with
+// the provided metricNames.
+func CollectAndCompare(c prometheus.Collector, expected io.Reader, metricNames ...string) error {
+	reg := prometheus.NewPedanticRegistry()
+	if err := reg.Register(c); err != nil {
+		return fmt.Errorf("registering collector failed: %s", err)
+	}
+	return GatherAndCompare(reg, expected, metricNames...)
+}
+
+// GatherAndCompare gathers all metrics from the provided Gatherer and compares
+// it to an expected output read from the provided Reader in the Prometheus text
+// exposition format. If any metricNames are provided, only metrics with those
+// names are compared.
+func GatherAndCompare(g prometheus.Gatherer, expected io.Reader, metricNames ...string) error {
+	got, err := g.Gather()
+	if err != nil {
+		return fmt.Errorf("gathering metrics failed: %s", err)
+	}
+	if metricNames != nil {
+		got = filterMetrics(got, metricNames)
+	}
+	var tp expfmt.TextParser
+	wantRaw, err := tp.TextToMetricFamilies(expected)
+	if err != nil {
+		return fmt.Errorf("parsing expected metrics failed: %s", err)
+	}
+	want := internal.NormalizeMetricFamilies(wantRaw)
+
+	return compare(got, want)
+}
+
+// compare encodes both provided slices of metric families into the text format,
+// compares their string message, and returns an error if they do not match.
+// The error contains the encoded text of both the desired and the actual
+// result.
+func compare(got, want []*dto.MetricFamily) error {
+	var gotBuf, wantBuf bytes.Buffer
+	enc := expfmt.NewEncoder(&gotBuf, expfmt.FmtText)
+	for _, mf := range got {
+		if err := enc.Encode(mf); err != nil {
+			return fmt.Errorf("encoding gathered metrics failed: %s", err)
+		}
+	}
+	enc = expfmt.NewEncoder(&wantBuf, expfmt.FmtText)
+	for _, mf := range want {
+		if err := enc.Encode(mf); err != nil {
+			return fmt.Errorf("encoding expected metrics failed: %s", err)
+		}
+	}
+
+	if wantBuf.String() != gotBuf.String() {
+		return fmt.Errorf(`
+metric output does not match expectation; want:
+
+%s
+got:
+
+%s`, wantBuf.String(), gotBuf.String())
+
+	}
+	return nil
+}
+
+func filterMetrics(metrics []*dto.MetricFamily, names []string) []*dto.MetricFamily {
+	var filtered []*dto.MetricFamily
+	for _, m := range metrics {
+		for _, name := range names {
+			if m.GetName() == name {
+				filtered = append(filtered, m)
+				break
+			}
+		}
+	}
+	return filtered
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -178,6 +178,8 @@ github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/collectors
 github.com/prometheus/client_golang/prometheus/internal
 github.com/prometheus/client_golang/prometheus/promhttp
+github.com/prometheus/client_golang/prometheus/testutil
+github.com/prometheus/client_golang/prometheus/testutil/promlint
 # github.com/prometheus/client_model v0.2.0
 ## explicit; go 1.9
 github.com/prometheus/client_model/go


### PR DESCRIPTION
Update clock state to FREERUN when the slave port is down.
Update help text for openshift_ptp_clock_class.
Add unit tests for metrics and events.