### PR TITLE
OCPBUGS-30856: Fix DPLL offset on holdover and freerun

### DIFF
--- a/pkg/dpll/dpll_test.go
+++ b/pkg/dpll/dpll_test.go
@@ -56,7 +56,7 @@ func getTestData(source event.EventSource, pinType uint32) []DpllTestCase {
 		expectedIntermediateState: event.PTP_FREERUN,
 		expectedState:             event.PTP_FREERUN,
 		expectedPhaseStatus:       0, //no phase status event for eec
-		expectedPhaseOffset:       dpll.FaultyPhaseOffset,
+		expectedPhaseOffset:       dpll.FaultyPhaseOffset * 1000000,
 		expectedFrequencyStatus:   2, // locked
 		expectedInSpecState:       true,
 		desc:                      "1.locked frequency status, unknonw Phase status ",
@@ -110,7 +110,7 @@ func getTestData(source event.EventSource, pinType uint32) []DpllTestCase {
 					return 4 //holdover
 				}
 			}(), //no phase status event for eec
-			expectedPhaseOffset: dpll.FaultyPhaseOffset,
+			expectedPhaseOffset: dpll.FaultyPhaseOffset * 1000000,
 			expectedFrequencyStatus: func() int64 {
 				if pinType == 2 {
 					return 4
@@ -150,7 +150,7 @@ func getTestData(source event.EventSource, pinType uint32) []DpllTestCase {
 					return 4
 				}
 			}(), //no phase status event for eec
-			expectedPhaseOffset: dpll.FaultyPhaseOffset,
+			expectedPhaseOffset: dpll.FaultyPhaseOffset * 1000000,
 			expectedFrequencyStatus: func() int64 {
 				if pinType == 2 {
 					return 4


### PR DESCRIPTION
This fixes a bug introduced in #271 leading to dpll phase offset freezing during trasitions to holdover and freerun states, where DPLL netlink indications from the driver stop. It also fixes the problem of not in-spec report on DPLL that has PPS as a source
/cc @aneeshkp @josephdrichard @jzding 