### PR TITLE
OCPBUGS-30810: add DPLL phase offset

### DIFF
--- a/addons/intel/README.md
+++ b/addons/intel/README.md
@@ -31,6 +31,11 @@ spec:
           LocalMaxHoldoverOffSet: 1500
           LocalHoldoverTimeout: 14400
           MaxInSpecOffset: 100
+        phaseOffsetPins:
+          ens2f0:
+            boardLabel: GNSS-1PPS
+          ens7f0:
+            boardLabel: SMA1
         pins:
           "ens2f0":
             "U.FL2": "0 2"

--- a/addons/intel/e810.go
+++ b/addons/intel/e810.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -20,6 +21,7 @@ type E810Opts struct {
 	UblxCmds            []E810UblxCmds               `json:"ublxCmds"`
 	DevicePins          map[string]map[string]string `json:"pins"`
 	DpllSettings        map[string]uint64            `json:"settings"`
+	PhaseOffsetPins     map[string]map[string]string `json:"phaseOffsetPins"`
 }
 
 type E810UblxCmds struct {
@@ -96,6 +98,24 @@ func OnPTPConfigChangeE810(data *interface{}, nodeProfile *ptpv1.PtpProfile) err
 			for k, v := range e810Opts.DpllSettings {
 				if _, ok := (*nodeProfile).PtpSettings[k]; !ok {
 					(*nodeProfile).PtpSettings[k] = strconv.FormatUint(v, 10)
+				}
+			}
+			for iface, properties := range e810Opts.PhaseOffsetPins {
+				ifaceFound := false
+				for dev := range e810Opts.DevicePins {
+					if strings.Compare(iface, dev) == 0 {
+						ifaceFound = true
+						break
+					}
+				}
+				if !ifaceFound {
+					glog.Errorf("e810 phase offset pin filter initialization failed: interface %s not found among  %v",
+						iface, reflect.ValueOf(e810Opts.DevicePins).MapKeys())
+					break
+				}
+				for pinProperty, value := range properties {
+					key := strings.Join([]string{iface, "phaseOffsetFilter", strconv.FormatUint(getClockIdE810(iface), 10), pinProperty}, ".")
+					(*nodeProfile).PtpSettings[key] = value
 				}
 			}
 		}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -381,7 +381,9 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 		output.profile_name = *nodeProfile.Name
 
 		if nodeProfile.Interface != nil && *nodeProfile.Interface != "" {
-			output.sections = append([]ptp4lConfSection{{options: map[string]string{}, sectionName: fmt.Sprintf("[%s]", *nodeProfile.Interface)}}, output.sections...)
+			output.sections = append([]ptp4lConfSection{{
+				options:     map[string]string{},
+				sectionName: fmt.Sprintf("[%s]", *nodeProfile.Interface)}}, output.sections...)
 		} else {
 			iface := string("")
 			nodeProfile.Interface = &iface
@@ -480,10 +482,20 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 			var localHoldoverTimeout uint64 = dpll.LocalHoldoverTimeout
 			var maxInSpecOffset uint64 = dpll.MaxInSpecOffset
 			var clockId uint64
+			phaseOffsetPinFilter := map[string]string{}
 			for _, iface := range dprocess.Ifaces {
 				var eventSource []event.EventSource
 				if iface.Source == event.GNSS || iface.Source == event.PPS {
+					glog.Info("Init dpll: ptp settings ", (*nodeProfile).PtpSettings)
 					for k, v := range (*nodeProfile).PtpSettings {
+						glog.Info("Init dpll: ptp kv ", k, " ", v)
+						if strings.Contains(k, strings.Join([]string{iface.Name, "phaseOffset"}, ".")) {
+							filterKey := strings.Split(k, ".")
+							property := filterKey[len(filterKey)-1]
+							phaseOffsetPinFilter[property] = v
+							glog.Infof("dpll phase offset filter property: %s[%s]=%s", iface.Name, property, v)
+							continue
+						}
 						i, err := strconv.ParseUint(v, 10, 64)
 						if err != nil {
 							continue
@@ -508,7 +520,7 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 					}
 					// pass array of ifaces which has source + clockId -
 					dpllDaemon := dpll.NewDpll(clockId, localMaxHoldoverOffSet, localHoldoverTimeout,
-						maxInSpecOffset, iface.Name, eventSource, dpll.NONE)
+						maxInSpecOffset, iface.Name, eventSource, dpll.NONE, dn.GetPhaseOffsetPinFilter(nodeProfile))
 					dpllDaemon.CmdInit()
 					dprocess.depProcess = append(dprocess.depProcess, dpllDaemon)
 				}
@@ -525,6 +537,23 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 	}
 
 	return nil
+}
+
+func (dn *Daemon) GetPhaseOffsetPinFilter(nodeProfile *ptpv1.PtpProfile) map[string]map[string]string {
+	phaseOffsetPinFilter := map[string]map[string]string{}
+	for k, v := range (*nodeProfile).PtpSettings {
+		if strings.Contains(k, "phaseOffsetFilter") {
+			filterKey := strings.Split(k, ".")
+			property := filterKey[len(filterKey)-1]
+			clockIdStr := filterKey[len(filterKey)-2]
+			if len(phaseOffsetPinFilter[clockIdStr]) == 0 {
+				phaseOffsetPinFilter[clockIdStr] = map[string]string{}
+			}
+			phaseOffsetPinFilter[clockIdStr][property] = v
+			continue
+		}
+	}
+	return phaseOffsetPinFilter
 }
 
 func (dn *Daemon) HandlePmcTicker() {

--- a/pkg/dpll-netlink/dpll-uapi.go
+++ b/pkg/dpll-netlink/dpll-uapi.go
@@ -3,9 +3,14 @@
 
 package dpll_netlink
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 const DPLL_MCGRP_MONITOR = "monitor"
+const DPLL_PHASE_OFFSET_DIVIDER = 1000
+const DPLL_TEMP_DIVIDER = 1000
 const (
 	DPLL_A_TYPES = iota
 	DPLL_A_ID
@@ -17,10 +22,42 @@ const (
 	DPLL_A_LOCK_STATUS
 	DPLL_A_TEMP
 	DPLL_A_TYPE
+
 	__DPLL_A_MAX
 	DPLL_A_MAX = __DPLL_A_MAX - 1
 )
 
+const (
+	DPLL_A_PIN_TYPES = iota
+
+	DPLL_A_PIN_ID
+	DPLL_A_PIN_PARENT_ID
+	DPLL_A_PIN_MODULE_NAME
+	DPLL_A_PIN_PAD
+	DPLL_A_PIN_CLOCK_ID
+	DPLL_A_PIN_BOARD_LABEL
+	DPLL_A_PIN_PANEL_LABEL
+	DPLL_A_PIN_PACKAGE_LABEL
+	DPLL_A_PIN_TYPE
+	DPLL_A_PIN_DIRECTION
+	DPLL_A_PIN_FREQUENCY
+	DPLL_A_PIN_FREQUENCY_SUPPORTED
+	DPLL_A_PIN_FREQUENCY_MIN
+	DPLL_A_PIN_FREQUENCY_MAX
+	DPLL_A_PIN_PRIO
+	DPLL_A_PIN_STATE
+	DPLL_A_PIN_CAPABILITIES
+	DPLL_A_PIN_PARENT_DEVICE
+	DPLL_A_PIN_PARENT_PIN
+	DPLL_A_PIN_PHASE_ADJUST_MIN
+	DPLL_A_PIN_PHASE_ADJUST_MAX
+	DPLL_A_PIN_PHASE_ADJUST
+	DPLL_A_PIN_PHASE_OFFSET
+	DPLL_A_PIN_FRACTIONAL_FREQUENCY_OFFSET
+
+	__DPLL_A_PIN_MAX
+	DPLL_A_PIN_MAX = __DPLL_A_PIN_MAX - 1
+)
 const (
 	DPLL_CMDS = iota
 	DPLL_CMD_DEVICE_ID_GET
@@ -29,6 +66,12 @@ const (
 	DPLL_CMD_DEVICE_CREATE_NTF
 	DPLL_CMD_DEVICE_DELETE_NTF
 	DPLL_CMD_DEVICE_CHANGE_NTF
+	DPLL_CMD_PIN_ID_GET
+	DPLL_CMD_PIN_GET
+	DPLL_CMD_PIN_SET
+	DPLL_CMD_PIN_CREATE_NTF
+	DPLL_CMD_PIN_DELETE_NTF
+	DPLL_CMD_PIN_CHANGE_NTF
 
 	__DPLL_CMD_MAX
 	DPLL_CMD_MAX = (__DPLL_CMD_MAX - 1)
@@ -94,9 +137,137 @@ func GetDpllStatusHR(reply *DoDeviceGetReply) DpllStatusHR {
 		Id:         reply.Id,
 		ModuleName: reply.ModuleName,
 		Mode:       GetMode(reply.Mode),
-		// TODO: ModeSupported
 		LockStatus: GetLockStatus(reply.LockStatus),
 		ClockId:    fmt.Sprintf("0x%x", reply.ClockId),
 		Type:       GetDpllType(reply.Type),
 	}
+}
+
+// DoPinGetReply is used with the DoPinGet method.
+type DoPinGetReplyHR struct {
+	Id                        uint32            `json:"id"`
+	ClockId                   uint64            `json:"clockId"`
+	BoardLabel                string            `json:"boardLabel"`
+	PanelLabel                string            `json:"panelLabel"`
+	PackageLabel              string            `json:"packageLabel"`
+	Type                      string            `json:"type"`
+	Frequency                 uint64            `json:"frequency"`
+	FrequencySupported        FrequencyRange    `json:"frequencySupported"`
+	Capabilities              string            `json:"capabilities"`
+	ParentDevice              PinParentDeviceHR `json:"pinParentDevice"`
+	ParentPin                 PinParentPinHR    `json:"pinParentPin"`
+	PhaseAdjustMin            int32             `json:"phaseAdjustMin"`
+	PhaseAdjustMax            int32             `json:"phaseAdjustMax"`
+	PhaseAdjust               int32             `json:"phaseAdjust"`
+	FractionalFrequencyOffset int               `json:"fractionalFrequencyOffset"`
+	ModuleName                string            `json:"moduleName"`
+}
+
+// PinParentDevice contains nested netlink attributes.
+type PinParentDeviceHR struct {
+	ParentId    uint32 `json:"parentId"`
+	Direction   string `json:"direction"`
+	Prio        uint32 `json:"prio"`
+	State       string `json:"state"`
+	PhaseOffset int64  `json:"phaseOffset"`
+}
+
+// PinParentPin contains nested netlink attributes.
+type PinParentPinHR struct {
+	ParentId uint32 `json:"parentId"`
+	State    string `json:"parentState"`
+}
+
+// GetPinState returns DPLL pin state as a string
+func GetPinState(s uint32) string {
+	stateMap := map[int]string{
+		1: "connected",
+		2: "disconnected",
+		3: "selectable",
+	}
+	r, found := stateMap[int(s)]
+	if found {
+		return r
+	}
+	return ""
+}
+
+// GetPinType returns DPLL pin type as a string
+func GetPinType(tp uint32) string {
+	typeMap := map[int]string{
+		1: "mux",
+		2: "ext",
+		3: "synce-eth-port",
+		4: "int-oscillator",
+		5: "gnss",
+	}
+	typ, found := typeMap[int(tp)]
+	if found {
+		return typ
+	}
+	return ""
+}
+
+// GetPinDirection returns DPLL pin direction as a string
+func GetPinDirection(d uint32) string {
+	directionMap := map[int]string{
+		1: "input",
+		2: "output",
+	}
+	dir, found := directionMap[int(d)]
+	if found {
+		return dir
+	}
+	return ""
+}
+
+// GetPinCapabilities returns DPLL pin capabilities as a csv
+func GetPinCapabilities(c uint32) string {
+	cMap := map[int]string{
+		0: "",
+		1: "direction-can-change",
+		2: "priority-can-change",
+		3: "direction-can-change,priority-can-change",
+		4: "state-can-change",
+		5: "state-can-change,direction-can-change",
+		6: "state-can-change,priority-can-change",
+		7: "state-can-change,direction-can-change,priority-can-change",
+	}
+	cap, found := cMap[int(c)]
+	if found {
+		return cap
+	}
+	return ""
+}
+
+// GetPinInfoHR returns human-readable pin status
+func GetPinInfoHR(reply *DoPinGetReply) ([]byte, error) {
+	hr := DoPinGetReplyHR{
+		Id:                 reply.Id,
+		ClockId:            reply.ClockId,
+		BoardLabel:         reply.BoardLabel,
+		PanelLabel:         reply.PanelLabel,
+		PackageLabel:       reply.PackageLabel,
+		Type:               GetPinType(reply.Type),
+		Frequency:          reply.Frequency,
+		FrequencySupported: reply.FrequencySupported,
+		Capabilities:       GetPinCapabilities(reply.Capabilities),
+		ParentDevice: PinParentDeviceHR{
+			ParentId:    reply.ParentDevice.ParentId,
+			Direction:   GetPinDirection(reply.ParentDevice.Direction),
+			Prio:        reply.ParentDevice.Prio,
+			State:       GetPinState(reply.ParentDevice.State),
+			PhaseOffset: reply.ParentDevice.PhaseOffset,
+		},
+		ParentPin: PinParentPinHR{
+			ParentId: reply.ParentPin.ParentId,
+			State:    GetPinState(reply.ParentPin.State),
+		},
+		PhaseAdjustMin:            reply.PhaseAdjustMin,
+		PhaseAdjustMax:            reply.PhaseAdjustMax,
+		PhaseAdjust:               reply.PhaseAdjust,
+		FractionalFrequencyOffset: reply.FractionalFrequencyOffset,
+		ModuleName:                reply.ModuleName,
+	}
+	return json.Marshal(hr)
 }

--- a/pkg/dpll/dpll.go
+++ b/pkg/dpll/dpll.go
@@ -115,8 +115,9 @@ type DpllConfig struct {
 	// is driver-specific and vendor-specific.
 	clockId uint64
 	sync.Mutex
-	isMonitoring bool
-	subscriber   []*DpllSubscriber
+	isMonitoring         bool
+	subscriber           []*DpllSubscriber
+	phaseOffsetPinFilter map[string]map[string]string
 }
 
 func (d *DpllConfig) InSpec() bool {
@@ -139,8 +140,12 @@ func (d *DpllConfig) State() event.PTPState {
 }
 
 // SetPhaseOffset ...  set phaseOffset
+// Measured phase offset values are fractional with 3-digit decimal places and shall be
+// divided by DPLL_PIN_PHASE_OFFSET_DIVIDER to get integer part
+// The units are picoseconds.
+// We further divide it by 1000 to report nanoseconds
 func (d *DpllConfig) SetPhaseOffset(phaseOffset int64) {
-	d.phaseOffset = phaseOffset
+	d.phaseOffset = int64(math.Round(float64(phaseOffset / nl.DPLL_PHASE_OFFSET_DIVIDER / 1000)))
 }
 
 // SourceLost ... get source status
@@ -274,8 +279,8 @@ func (d *DpllConfig) unRegisterAll() {
 
 // NewDpll ... create new DPLL process
 func NewDpll(clockId uint64, localMaxHoldoverOffSet, localHoldoverTimeout, maxInSpecOffset uint64,
-	iface string, dependsOn []event.EventSource, apiType dpllApiType) *DpllConfig {
-	glog.Infof("Calling NewDpll with clockId %x, localMaxHoldoverOffSet=%d, localHoldoverTimeout=%d, maxInSpecOffset=%d, iface=%s", clockId, localMaxHoldoverOffSet, localHoldoverTimeout, maxInSpecOffset, iface)
+	iface string, dependsOn []event.EventSource, apiType dpllApiType, phaseOffsetPinFilter map[string]map[string]string) *DpllConfig {
+	glog.Infof("Calling NewDpll with clockId %x, localMaxHoldoverOffSet=%d, localHoldoverTimeout=%d, maxInSpecOffset=%d, iface=%s, phase offset pin filter=%v", clockId, localMaxHoldoverOffSet, localHoldoverTimeout, maxInSpecOffset, iface, phaseOffsetPinFilter)
 	d := &DpllConfig{
 		clockId:                clockId,
 		LocalMaxHoldoverOffSet: localMaxHoldoverOffSet,
@@ -284,17 +289,19 @@ func NewDpll(clockId uint64, localMaxHoldoverOffSet, localHoldoverTimeout, maxIn
 		slope: func() float64 {
 			return (float64(localMaxHoldoverOffSet) / float64(localHoldoverTimeout)) * 1000.0
 		}(),
-		timer:        0,
-		offset:       0,
-		state:        event.PTP_FREERUN,
-		iface:        iface,
-		onHoldover:   false,
-		sourceLost:   false,
-		dependsOn:    dependsOn,
-		exitCh:       make(chan struct{}),
-		ticker:       time.NewTicker(monitoringInterval),
-		isMonitoring: false,
-		apiType:      apiType,
+		timer:                0,
+		offset:               0,
+		state:                event.PTP_FREERUN,
+		iface:                iface,
+		onHoldover:           false,
+		sourceLost:           false,
+		dependsOn:            dependsOn,
+		exitCh:               make(chan struct{}),
+		ticker:               time.NewTicker(monitoringInterval),
+		isMonitoring:         false,
+		apiType:              apiType,
+		phaseOffsetPinFilter: phaseOffsetPinFilter,
+		phaseOffset:          FaultyPhaseOffset,
 	}
 
 	d.timer = int64(math.Round(float64(d.MaxInSpecOffset*1000) / d.slope))
@@ -309,13 +316,35 @@ func (d *DpllConfig) Timer() int64 {
 	return d.timer
 }
 
+func (d *DpllConfig) PhaseOffsetPin(pin *nl.DoPinGetReply) bool {
+	if pin.ClockId == d.clockId && pin.ParentDevice.PhaseOffset != math.MaxInt64 {
+		for k, v := range d.phaseOffsetPinFilter[strconv.FormatUint(d.clockId, 10)] {
+			switch k {
+			case "boardLabel":
+				if strings.Compare(pin.BoardLabel, v) != 0 {
+					return false
+				}
+			case "panelLabel":
+				if strings.Compare(pin.PanelLabel, v) != 0 {
+					return false
+				}
+			default:
+				glog.Warningf("unsupported phase offset pin filter key: %s", k)
+			}
+		}
+		return true
+	}
+	return false
+}
+
 // nlUpdateState updates DPLL state in the DpllConfig structure.
-func (d *DpllConfig) nlUpdateState(replies []*nl.DoDeviceGetReply) bool {
+func (d *DpllConfig) nlUpdateState(devices []*nl.DoDeviceGetReply, pins []*nl.DoPinGetReply) bool {
 	valid := false
-	for _, reply := range replies {
+
+	for _, reply := range devices {
 		if reply.ClockId == d.clockId {
 			if reply.LockStatus == DPLL_INVALID {
-				glog.Info("discarding on invalid status: ", nl.GetDpllStatusHR(reply))
+				glog.Info("discarding on invalid lock status: ", nl.GetDpllStatusHR(reply))
 				continue
 			}
 			glog.Info(nl.GetDpllStatusHR(reply))
@@ -325,13 +354,17 @@ func (d *DpllConfig) nlUpdateState(replies []*nl.DoDeviceGetReply) bool {
 				valid = true
 			case "pps":
 				d.phaseStatus = int64(reply.LockStatus)
-				if d.apiType != MOCK {
-					d.phaseOffset = 0 // TODO: get offset from reply when implemented
-				}
 				valid = true
 			}
 		} else {
 			glog.Infof("discarding on clock ID %v (%s): ", nl.GetDpllStatusHR(reply), d.iface)
+		}
+	}
+	for _, pin := range pins {
+		if d.PhaseOffsetPin(pin) {
+			d.SetPhaseOffset(pin.ParentDevice.PhaseOffset)
+			glog.Info("setting phase offset to ", d.phaseOffset, " ns for clock id ", d.clockId)
+			valid = true
 		}
 	}
 	return valid
@@ -341,7 +374,7 @@ func (d *DpllConfig) nlUpdateState(replies []*nl.DoDeviceGetReply) bool {
 // calls dpll state updating function.
 func (d *DpllConfig) monitorNtf(c *genetlink.Conn) {
 	for {
-		msg, _, err := c.Receive()
+		msgs, _, err := c.Receive()
 		if err != nil {
 			if err.Error() == "netlink receive: use of closed file" {
 				glog.Infof("netlink connection has been closed - stop monitoring for %s", d.iface)
@@ -350,12 +383,31 @@ func (d *DpllConfig) monitorNtf(c *genetlink.Conn) {
 			}
 			return
 		}
-		replies, err := nl.ParseDeviceReplies(msg)
-		if err != nil {
-			glog.Error(err)
-			return
+		devices, pins := []*nl.DoDeviceGetReply{}, []*nl.DoPinGetReply{}
+		for _, msg := range msgs {
+			devices, pins = []*nl.DoDeviceGetReply{}, []*nl.DoPinGetReply{}
+			switch msg.Header.Command {
+			case nl.DPLL_CMD_DEVICE_CHANGE_NTF:
+				devices, err = nl.ParseDeviceReplies([]genetlink.Message{msg})
+				if err != nil {
+					glog.Error(err)
+					return
+				}
+
+			case nl.DPLL_CMD_PIN_CHANGE_NTF:
+				pins, err = nl.ParsePinReplies([]genetlink.Message{msg})
+				if err != nil {
+					glog.Error(err)
+					return
+				}
+
+			default:
+				glog.Info("unhandled dpll message", msg.Header.Command, msg.Data)
+
+			}
+
 		}
-		if d.nlUpdateState(replies) {
+		if d.nlUpdateState(devices, pins) {
 			d.stateDecision()
 		}
 	}
@@ -395,7 +447,7 @@ func (d *DpllConfig) setAPIType() {
 func (d *DpllConfig) MonitorDpllMock() {
 	glog.Info("starting dpll mock monitoring")
 
-	if d.nlUpdateState([]*nl.DoDeviceGetReply{<-MockDpllReplies}) {
+	if d.nlUpdateState([]*nl.DoDeviceGetReply{<-MockDpllReplies}, []*nl.DoPinGetReply{}) {
 		d.stateDecision()
 	}
 
@@ -432,7 +484,7 @@ func (d *DpllConfig) MonitorDpllNetlink() {
 				goto abort
 			}
 
-			if d.nlUpdateState(replies) {
+			if d.nlUpdateState(replies, []*nl.DoPinGetReply{}) {
 				d.stateDecision()
 			}
 
@@ -595,11 +647,9 @@ func (d *DpllConfig) stateDecision() {
 			}
 			glog.Infof("dpll is locked, offset is in range, state is LOCKED(%s)", d.iface)
 			d.state = event.PTP_LOCKED
-			d.phaseOffset = 5
 		} else { // what happens if source is lost and DPLL is locked? goto holdover?
 			glog.Infof("dpll is locked, offset is out of range, state is FREERUN(%s)", d.iface)
 			d.state = event.PTP_FREERUN
-			d.phaseOffset = FaultyPhaseOffset
 		}
 		d.inSpec = true
 		d.sendDpllEvent()
@@ -612,11 +662,10 @@ func (d *DpllConfig) stateDecision() {
 			} else if dpllStatus == DPLL_LOCKED_HO_ACQ && d.isOffsetInRange() {
 				d.state = event.PTP_LOCKED
 				d.sourceLost = false
-				d.phaseOffset = 5
+				d.inSpec = true
 			} else {
 				d.state = event.PTP_FREERUN
 				d.sourceLost = false
-				d.phaseOffset = FaultyPhaseOffset
 			}
 		} else if !d.sourceLost && d.isOffsetInRange() {
 			glog.Infof("dpll is locked, source is not lost, offset is in range, state is DPLL_LOCKED_HO_ACQ or DPLL_HOLDOVER(%s)", d.iface)
@@ -780,7 +829,6 @@ func (d *DpllConfig) holdover() {
 		case <-timeout:
 			d.inSpec = false // in HO, Out of spec
 			d.state = event.PTP_FREERUN
-			d.phaseOffset = FaultyPhaseOffset
 			glog.Infof("holdover timer %d expired", d.timer)
 			d.sendDpllEvent()
 			return

--- a/pkg/dpll/dpll_test.go
+++ b/pkg/dpll/dpll_test.go
@@ -2,11 +2,12 @@ package dpll_test
 
 import (
 	"fmt"
-	nl "github.com/openshift/linuxptp-daemon/pkg/dpll-netlink"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	nl "github.com/openshift/linuxptp-daemon/pkg/dpll-netlink"
 
 	"github.com/golang/glog"
 	"github.com/openshift/linuxptp-daemon/pkg/config"
@@ -55,7 +56,7 @@ func getTestData(source event.EventSource, pinType uint32) []DpllTestCase {
 		expectedIntermediateState: event.PTP_FREERUN,
 		expectedState:             event.PTP_FREERUN,
 		expectedPhaseStatus:       0, //no phase status event for eec
-		expectedPhaseOffset:       dpll.FaultyPhaseOffset,
+		expectedPhaseOffset:       dpll.FaultyPhaseOffset * 1000000,
 		expectedFrequencyStatus:   2, // locked
 		expectedInSpecState:       true,
 		desc:                      "1.locked frequency status, unknonw Phase status ",
@@ -75,7 +76,7 @@ func getTestData(source event.EventSource, pinType uint32) []DpllTestCase {
 		expectedIntermediateState: event.PTP_LOCKED,
 		expectedState:             event.PTP_LOCKED,
 		expectedPhaseStatus:       2, //no phase status event for eec
-		expectedPhaseOffset:       5,
+		expectedPhaseOffset:       5000000,
 		expectedFrequencyStatus:   2, // locked
 		expectedInSpecState:       true,
 		desc:                      "2. with locked frequency status, reading phase status ",
@@ -109,7 +110,7 @@ func getTestData(source event.EventSource, pinType uint32) []DpllTestCase {
 					return 4 //holdover
 				}
 			}(), //no phase status event for eec
-			expectedPhaseOffset: dpll.FaultyPhaseOffset,
+			expectedPhaseOffset: dpll.FaultyPhaseOffset * 1000000,
 			expectedFrequencyStatus: func() int64 {
 				if pinType == 2 {
 					return 4
@@ -149,7 +150,7 @@ func getTestData(source event.EventSource, pinType uint32) []DpllTestCase {
 					return 4
 				}
 			}(), //no phase status event for eec
-			expectedPhaseOffset: dpll.FaultyPhaseOffset,
+			expectedPhaseOffset: dpll.FaultyPhaseOffset * 1000000,
 			expectedFrequencyStatus: func() int64 {
 				if pinType == 2 {
 					return 4
@@ -176,7 +177,7 @@ func TestDpllConfig_MonitorProcessGNSS(t *testing.T) {
 	// event has to be running before dpll is started
 	eventProcessor := event.Init("node", false, "/tmp/go.sock", eChannel, closeChn, nil, nil, nil)
 	d := dpll.NewDpll(clockid, 1400, 2, 10, "ens01",
-		[]event.EventSource{event.GNSS}, dpll.MOCK)
+		[]event.EventSource{event.GNSS}, dpll.MOCK, map[string]map[string]string{})
 	d.CmdInit()
 	eventChannel := make(chan event.EventChannel, 10)
 	go eventProcessor.ProcessEvents()
@@ -194,6 +195,7 @@ func TestDpllConfig_MonitorProcessGNSS(t *testing.T) {
 	fmt.Println("starting Mock replies ")
 	for _, tt := range getTestData(event.GNSS, 2) {
 		d.SetSourceLost(tt.sourceLost)
+		d.SetPhaseOffset(tt.expectedPhaseOffset)
 		d.SetDependsOn([]event.EventSource{tt.source})
 		dpll.MockDpllReplies <- tt.reply
 		d.MonitorDpllMock()
@@ -202,7 +204,7 @@ func TestDpllConfig_MonitorProcessGNSS(t *testing.T) {
 		time.Sleep(tt.sleep * time.Second)
 		assert.Equal(t, tt.expectedPhaseStatus, d.PhaseStatus(), tt.desc)
 		assert.Equal(t, tt.expectedFrequencyStatus, d.FrequencyStatus(), tt.desc)
-		assert.Equal(t, tt.expectedPhaseOffset, d.PhaseOffset(), tt.desc)
+		assert.Equal(t, tt.expectedPhaseOffset/1000000, d.PhaseOffset(), tt.desc)
 		assert.Equal(t, tt.expectedState, d.State(), tt.desc)
 		assert.Equal(t, tt.expectedInSpecState, d.InSpec())
 
@@ -218,7 +220,7 @@ func TestDpllConfig_MonitorProcessPPS(t *testing.T) {
 	// event has to be running before dpll is started
 	eventProcessor := event.Init("node", false, "/tmp/go.sock", eChannel, closeChn, nil, nil, nil)
 	d := dpll.NewDpll(clockid, 1400, 2, 10, "ens01",
-		[]event.EventSource{event.GNSS}, dpll.MOCK)
+		[]event.EventSource{event.GNSS}, dpll.MOCK, map[string]map[string]string{})
 	d.CmdInit()
 	eventChannel := make(chan event.EventChannel, 10)
 	go eventProcessor.ProcessEvents()
@@ -236,13 +238,14 @@ func TestDpllConfig_MonitorProcessPPS(t *testing.T) {
 	fmt.Println("starting Mock replies ")
 	for _, tt := range getTestData(event.PPS, 1) {
 		d.SetSourceLost(tt.sourceLost)
+		d.SetPhaseOffset(tt.expectedPhaseOffset)
 		d.SetDependsOn([]event.EventSource{tt.source})
 		dpll.MockDpllReplies <- tt.reply
 		d.MonitorDpllMock()
 		time.Sleep(tt.sleep * time.Second)
 		assert.Equal(t, tt.expectedPhaseStatus, d.PhaseStatus(), tt.desc)
 		assert.Equal(t, tt.expectedFrequencyStatus, d.FrequencyStatus(), tt.desc)
-		assert.Equal(t, tt.expectedPhaseOffset, d.PhaseOffset(), tt.desc)
+		assert.Equal(t, tt.expectedPhaseOffset/1000000, d.PhaseOffset(), tt.desc)
 		assert.Equal(t, tt.expectedState, d.State(), tt.desc)
 		assert.Equal(t, tt.expectedInSpecState, d.InSpec(), tt.desc)
 
@@ -282,7 +285,7 @@ func TestSlopeAndTimer(t *testing.T) {
 	}
 	for _, tt := range testCase {
 		d := dpll.NewDpll(100, tt.localMaxHoldoverOffSet, tt.localHoldoverTimeout, tt.maxInSpecOffset,
-			"test", []event.EventSource{}, dpll.MOCK)
+			"test", []event.EventSource{}, dpll.MOCK, map[string]map[string]string{})
 		assert.Equal(t, tt.localMaxHoldoverOffSet, d.LocalMaxHoldoverOffSet, "localMaxHoldover offset")
 		assert.Equal(t, tt.localHoldoverTimeout, d.LocalHoldoverTimeout, "Local holdover timeout")
 		assert.Equal(t, tt.maxInSpecOffset, d.MaxInSpecOffset, "Max In Spec Offset")


### PR DESCRIPTION
This is a manual cherry-pick from three commits: #271, #276 and #279.
Add DPLL pin notification parser and handle pin notifications. Distinguish between pin notifications and device notifications. Update DPLL phase offset if included for the pin belonging to the DPLL instance.
/cc @aneeshkp @jzding @josephdrichard @nishant-parekh 