### PR TITLE
[release-4.15] OCPBUGS-32305: fix missing openshift_ptp_process_status metric initial install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.14 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.15 AS builder
 WORKDIR /go/src/github.com/openshift/linuxptp-daemon
 COPY . .
 RUN make clean && make
 
-FROM registry.ci.openshift.org/ocp/4.14:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.15:base-rhel9
 
-COPY ./extra/leap-seconds.list /usr/share/zoneinfo/leap-seconds.list
-
-RUN yum -y update && yum -y update glibc && yum --setopt=skip_missing_names_on_install=False -y install linuxptp ethtool hwdata  && yum clean all
-
+RUN yum -y update && \
+    yum -y update glibc &&  \
+    yum --setopt=skip_missing_names_on_install=False -y install linuxptp ethtool hwdata && \
+    yum clean all
 
 RUN yum install -y gpsd-minimal
 RUN yum install -y gpsd-minimal-clients
@@ -18,7 +18,7 @@ RUN ln -s /usr/bin/gpspipe /usr/local/bin/gpspipe
 RUN ln -s /usr/sbin/gpsd /usr/local/sbin/gpsd
 RUN ln -s /usr/bin/ubxtool /usr/local/bin/ubxtool
 
-
 COPY --from=builder /go/src/github.com/openshift/linuxptp-daemon/bin/ptp /usr/local/bin/
+COPY ./extra/leap-seconds.list /usr/share/zoneinfo/leap-seconds.list
 
 CMD ["/usr/local/bin/ptp"]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/linuxptp-daemon
 
-go 1.19
+go 1.20
 
 require github.com/openshift/ptp-operator v0.0.0-20230207052655-ede9197d99ca
 


### PR DESCRIPTION
This update port back some fixes around metrics cleanup and refactor from the following commits, except HA changes.
https://github.com/openshift/linuxptp-daemon/pull/275
https://github.com/openshift/linuxptp-daemon/pull/277
https://github.com/openshift/linuxptp-daemon/pull/280

Use sort.Slice() instead of slices.SortFunc() since the latter is not available in golang 1.20.