### PR TITLE
OCPBUGS-34198: Revert "OCPBUGS-33524: PTP Boundary HA configuration cannot handle spaced empty Phc2SysOpts and ptp4lOpts with"

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -305,8 +305,8 @@ func (dn *Daemon) applyNodePTPProfiles() error {
 	glog.Infof("updating NodePTPProfiles to:")
 	runID := 0
 	slices.SortFunc(dn.ptpUpdate.NodeProfiles, func(a, b ptpv1.PtpProfile) int {
-		aHasPhc2sysOpts := a.Phc2sysOpts != nil && strings.TrimSpace(*a.Phc2sysOpts) != ""
-		bHasPhc2sysOpts := b.Phc2sysOpts != nil && strings.TrimSpace(*b.Phc2sysOpts) != ""
+		aHasPhc2sysOpts := a.Phc2sysOpts != nil && *a.Phc2sysOpts != ""
+		bHasPhc2sysOpts := b.Phc2sysOpts != nil && *b.Phc2sysOpts != ""
 		//sorted in ascending order
 		// here having phc2sysOptions is considered a high number
 		if !aHasPhc2sysOpts && bHasPhc2sysOpts {
@@ -458,7 +458,7 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 			messageTag = fmt.Sprintf("[ts2phc.%d.config:{level}]", runID)
 		}
 
-		if configOpts == nil || strings.TrimSpace(*configOpts) == "" {
+		if configOpts == nil || *configOpts == "" {
 			glog.Infof("configOpts empty, skipping: %s", pProcess)
 			continue
 		}


### PR DESCRIPTION
Reverts openshift/linuxptp-daemon#304
GM configuration is not applying correctly when setting ts2phc options to " " empty spaced string