### PR TITLE
OCPBUGS-34914: remove leapfile from reference config

### DIFF
--- a/addons/intel/README.md
+++ b/addons/intel/README.md
@@ -108,7 +108,6 @@ spec:
       logging_level 7
       ts2phc.pulsewidth 100000000
       ts2phc.nmea_serialport  /dev/ttyGNSS_1700_0
-      leapfile  /usr/share/zoneinfo/leap-seconds.list
       [ens2f0]
       ts2phc.extts_polarity rising
       ts2phc.extts_correction 0


### PR DESCRIPTION
Leapfile is managed by linuxptp-daemon, but still appears in the reference config. This config entry will also be logged, which is misleading. This commit removes the entry from the reference config ts2phcConf section.
/cc @aneeshkp @josephdrichard @jzding @nishant-parekh 