### PR TITLE
OCPBUGS-36201: implement leap event handling

### DIFF
--- a/pkg/daemon/daemon_internal_test.go
+++ b/pkg/daemon/daemon_internal_test.go
@@ -8,8 +8,12 @@ import (
 	"testing"
 
 	"github.com/bigkevmcd/go-configparser"
+	"github.com/openshift/linuxptp-daemon/pkg/leap"
 	ptpv1 "github.com/openshift/ptp-operator/api/v1"
 	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fake "k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/yaml"
 )
 
@@ -38,6 +42,7 @@ func clean(t *testing.T) {
 func applyProfileSyncE(t *testing.T, profile *ptpv1.PtpProfile) {
 
 	stopCh := make(<-chan struct{})
+	mockLeap()
 	dn := New(
 		"test-node-name",
 		"openshift-ptp",
@@ -57,6 +62,7 @@ func applyProfileSyncE(t *testing.T, profile *ptpv1.PtpProfile) {
 	assert.NotNil(t, dn)
 	err := dn.applyNodePtpProfile(0, profile)
 	assert.NoError(t, err)
+	close(leap.LeapMgr.Close)
 
 }
 
@@ -93,4 +99,25 @@ func Test_applyProfile_synce(t *testing.T) {
 		testRequirements(t, profile)
 		clean(t)
 	}
+}
+
+func mockLeap() error {
+	cm := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "openshift-ptp", Name: "leap-configmap"},
+		Data: map[string]string{
+			"test-node-name": `# Do not edit
+# This file is generated automatically by linuxptp-daemon
+#$	3927775672
+#@	4291747200
+3692217600     37    # 1 Jan 2017`,
+		},
+	}
+	os.Setenv("NODE_NAME", "test-node-name")
+	client := fake.NewSimpleClientset(cm)
+	lm, err := leap.New(client, "openshift-ptp")
+	if err != nil {
+		return err
+	}
+	go lm.Run()
+	return nil
 }


### PR DESCRIPTION
this commit adds leap event handling that includes following:
1. Determine that current time is within -12h...1m from the leap
2. Send PMC command (once) to indicate leap61 or leap 59 to the downstream architecture and
3. Handle ts2phc time ambiguity

/cc @aneeshkp @jzding @josephdrichard @nishant-parekh 