### PR TITLE
Update dockerfile to use 4.17 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,9 @@ ENV GOTOOLCHAIN=local
 COPY . .
 RUN make clean && make
 
-# Change to 4.17 after 4.16 goes to GA
-FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
-
+FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
 
 RUN yum -y update && yum -y update glibc && yum --setopt=skip_missing_names_on_install=False -y install linuxptp ethtool hwdata synce4l && yum clean all
-
 
 RUN yum install -y gpsd-minimal
 RUN yum install -y gpsd-minimal-clients


### PR DESCRIPTION
Update dockerfile to use linuxptp 4.2 and synce4l rpm 
This is temporary fix until  base container image is updated to 9.4 