### PR TITLE
OCPBUGS-37042: prevent writing uninitialized TimePropertiesDS

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -130,7 +130,6 @@ func main() {
 		&refreshNodePtpDevice,
 		closeProcessManager,
 		cp.pmcPollInterval,
-		lm,
 	).Run()
 
 	tickerPull := time.NewTicker(time.Second * time.Duration(cp.updateInterval))

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	k8s.io/apimachinery v0.28.3
 	k8s.io/client-go v0.28.3
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
+	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
@@ -87,5 +88,4 @@ require (
 	sigs.k8s.io/controller-runtime v0.16.3 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
-	sigs.k8s.io/yaml v1.3.0 // indirect
 )

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/openshift/linuxptp-daemon/pkg/config"
 	"github.com/openshift/linuxptp-daemon/pkg/dpll"
-	"github.com/openshift/linuxptp-daemon/pkg/leap"
 
 	"github.com/openshift/linuxptp-daemon/pkg/event"
 	ptpnetwork "github.com/openshift/linuxptp-daemon/pkg/network"
@@ -172,8 +171,6 @@ type Daemon struct {
 
 	// Allow vendors to include plugins
 	pluginManager PluginManager
-
-	leapManager *leap.LeapManager
 }
 
 // New LinuxPTP is called by daemon to generate new linuxptp instance
@@ -189,7 +186,6 @@ func New(
 	refreshNodePtpDevice *bool,
 	closeManager chan bool,
 	pmcPollInterval int,
-	leapManager *leap.LeapManager,
 ) *Daemon {
 	if !stdoutToSocket {
 		RegisterMetrics(nodeName)
@@ -213,8 +209,7 @@ func New(
 			eventChannel:    eventChannel,
 			ptpEventHandler: event.Init(nodeName, stdoutToSocket, eventSocket, eventChannel, closeManager, Offset, ClockState, ClockClassMetrics),
 		},
-		leapManager: leapManager,
-		stopCh:      stopCh,
+		stopCh: stopCh,
 	}
 }
 
@@ -582,7 +577,6 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 				gmInterface: gmInterface,
 				stopped:     false,
 				messageTag:  messageTag,
-				leapManager: dn.leapManager,
 				ublxTool:    nil,
 			}
 			gpsDaemon.CmdInit()

--- a/pkg/daemon/daemon_internal_test.go
+++ b/pkg/daemon/daemon_internal_test.go
@@ -53,7 +53,6 @@ func applyProfileSyncE(t *testing.T, profile *ptpv1.PtpProfile) {
 		nil,
 		make(chan bool),
 		30,
-		nil,
 	)
 	assert.NotNil(t, dn)
 	err := dn.applyNodePtpProfile(0, profile)

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -14,6 +14,7 @@ import (
 
 	fbprotocol "github.com/facebook/time/ptp/protocol"
 	"github.com/golang/glog"
+	"github.com/openshift/linuxptp-daemon/pkg/leap"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -692,15 +693,17 @@ func (e *EventHandler) updateCLockClass(cfgName string, clkClass fbprotocol.Cloc
 	}
 	switch clockType {
 	case GM:
+		g.TimePropertiesDS.TimeTraceable = true
+		g.TimePropertiesDS.PtpTimescale = true
+		g.TimePropertiesDS.FrequencyTraceable = true
+		g.TimePropertiesDS.CurrentUtcOffsetValid = true
+		g.TimePropertiesDS.CurrentUtcOffset = int32(leap.GetUtcOffset())
 		switch clkClass {
 		case fbprotocol.ClockClass6: // T-GM connected to a PRTC in locked mode (e.g., PRTC traceable to GNSS)
 			// update only when ClockClass is changed
 			if g.ClockQuality.ClockClass != fbprotocol.ClockClass6 {
 				g.ClockQuality.ClockClass = fbprotocol.ClockClass6
 				g.ClockQuality.ClockAccuracy = fbprotocol.ClockAccuracyNanosecond100
-				g.TimePropertiesDS.TimeTraceable = true
-				g.TimePropertiesDS.FrequencyTraceable = true
-				g.TimePropertiesDS.CurrentUtcOffsetValid = true
 				g.TimePropertiesDS.TimeSource = fbprotocol.TimeSourceGNSS
 				// T-REC-G.8275.1-202211-I section 6.3.5
 				g.ClockQuality.OffsetScaledLogVariance = 0x4e5d
@@ -711,9 +714,6 @@ func (e *EventHandler) updateCLockClass(cfgName string, clkClass fbprotocol.Cloc
 				g.ClockQuality.ClockClass = protocol.ClockClassOutOfSpec
 				g.ClockQuality.ClockAccuracy = fbprotocol.ClockAccuracyUnknown
 				g.TimePropertiesDS.TimeSource = fbprotocol.TimeSourceGNSS
-				g.TimePropertiesDS.TimeTraceable = false
-				g.TimePropertiesDS.FrequencyTraceable = false
-				g.TimePropertiesDS.CurrentUtcOffsetValid = false
 				// T-REC-G.8275.1-202211-I section 6.3.5
 				g.ClockQuality.OffsetScaledLogVariance = 0xffff
 				err = gmSetterFn(cfgName, g)
@@ -723,9 +723,6 @@ func (e *EventHandler) updateCLockClass(cfgName string, clkClass fbprotocol.Cloc
 				g.ClockQuality.ClockClass = fbprotocol.ClockClass7
 				g.ClockQuality.ClockAccuracy = fbprotocol.ClockAccuracyUnknown
 				g.TimePropertiesDS.TimeSource = fbprotocol.TimeSourceGNSS
-				g.TimePropertiesDS.TimeTraceable = true
-				g.TimePropertiesDS.FrequencyTraceable = true
-				g.TimePropertiesDS.CurrentUtcOffsetValid = true
 				// T-REC-G.8275.1-202211-I section 6.3.5
 				g.ClockQuality.OffsetScaledLogVariance = 0xffff
 				err = gmSetterFn(cfgName, g)
@@ -734,10 +731,7 @@ func (e *EventHandler) updateCLockClass(cfgName string, clkClass fbprotocol.Cloc
 			if g.ClockQuality.ClockClass != protocol.ClockClassFreerun {
 				g.ClockQuality.ClockClass = protocol.ClockClassFreerun
 				g.ClockQuality.ClockAccuracy = fbprotocol.ClockAccuracyUnknown
-				g.TimePropertiesDS.TimeSource = fbprotocol.TimeSourceGNSS
-				g.TimePropertiesDS.TimeTraceable = false
-				g.TimePropertiesDS.FrequencyTraceable = false
-				g.TimePropertiesDS.CurrentUtcOffsetValid = false
+				g.TimePropertiesDS.TimeSource = fbprotocol.TimeSourceNTP
 				// T-REC-G.8275.1-202211-I section 6.3.5
 				g.ClockQuality.OffsetScaledLogVariance = 0xffff
 				err = gmSetterFn(cfgName, g)


### PR DESCRIPTION
This PR fixes a bug where the daemon wrote uninitialized values to the time properties dataset, which led to corrupting the ptp time scale, current UTC offset and other dataset properties. The fix is done by always initializing the time properties according to the current UTC offset and a predefined set of flags. Leap manager was changed to provide current UTC offset to external packages.
/cc @aneeshkp @jzding @josephdrichard @nishant-parekh 