### PR TITLE
OCPBUGS-35587: T-GM - ts2phc process restart doesn't update PTP syncState when the process recovered

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -893,6 +893,7 @@ func (p *ptpProcess) cmdRun(stdoutToSocket bool) {
 		} else {
 			processStatus(nil, p.name, p.messageTag, PtpProcessDown)
 		}
+		p.updateGMStatusOnProcessDown(p.name)
 
 		time.Sleep(connectionRetryInterval) // Delay to prevent flooding restarts if startup fails
 		// Don't restart after termination
@@ -1174,4 +1175,15 @@ func (p *ptpProcess) replaceClockID(input string) (output string) {
 	iface := p.ifaces.GetPhcID2IFace(match[0])
 	output = clockIDRegEx.ReplaceAllString(input, iface)
 	return output
+}
+
+// updateGMStatusOnProcessDown send events when  ts2phc process is down by
+// send event to EventHandler
+func (p *ptpProcess) updateGMStatusOnProcessDown(process string) {
+	// need to update GM status for  following process kill for  ts2phc
+	if process == ts2phcProcessName {
+		// ts2phc process dead should update GM-STATUS
+		iface := p.ifaces.GetGMInterface().Name
+		p.ProcessTs2PhcEvents(faultyOffset, ts2phcProcessName, iface, map[event.ValueType]interface{}{event.PROCESS_STATUS: int64(0)})
+	}
 }

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -372,7 +372,7 @@ func extractRegularMetrics(configName, processName, output string, ifaces config
 	}
 
 	output = strings.Replace(output, "path", "", 1)
-	replacer := strings.NewReplacer("[", " ", "]", " ", ":", " ", " phc ", " ", " sys ", "")
+	replacer := strings.NewReplacer("[", " ", "]", " ", ":", " ", " phc ", " ", " sys ", " ")
 	output = replacer.Replace(output)
 
 	index := strings.Index(output, configName)

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -31,6 +31,7 @@ const (
 	PHASE_STATUS         ValueType = "phase_status"
 	FREQUENCY_STATUS     ValueType = "frequency_status"
 	NMEA_STATUS          ValueType = "nmea_status"
+	PROCESS_STATUS       ValueType = "process_status"
 	PPS_STATUS           ValueType = "pps_status"
 	GM_INTERFACE_UNKNOWN string    = "unknown"
 )


### PR DESCRIPTION
The ts2phc process termination only triggers FREERUN and doesn't recover back. This PR fixes this issue by sending the process status to the GM Event Decision Engine, which will mark T-GM as FREERUN. The event framework will use the PROCESS_DOWN indication to produce accurate events.