### PR TITLE
[release-4.16] OCPBUGS-37043: prevent writing uninitialized TimePropertiesDS

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -130,7 +130,6 @@ func main() {
 		&refreshNodePtpDevice,
 		closeProcessManager,
 		cp.pmcPollInterval,
-		lm,
 	).Run()
 
 	tickerPull := time.NewTicker(time.Second * time.Duration(cp.updateInterval))

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/openshift/linuxptp-daemon/pkg/config"
 	"github.com/openshift/linuxptp-daemon/pkg/dpll"
-	"github.com/openshift/linuxptp-daemon/pkg/leap"
 
 	"github.com/openshift/linuxptp-daemon/pkg/event"
 	ptpnetwork "github.com/openshift/linuxptp-daemon/pkg/network"
@@ -172,8 +171,6 @@ type Daemon struct {
 
 	// Allow vendors to include plugins
 	pluginManager PluginManager
-
-	leapManager *leap.LeapManager
 }
 
 // New LinuxPTP is called by daemon to generate new linuxptp instance
@@ -189,7 +186,6 @@ func New(
 	refreshNodePtpDevice *bool,
 	closeManager chan bool,
 	pmcPollInterval int,
-	leapManager *leap.LeapManager,
 ) *Daemon {
 	if !stdoutToSocket {
 		RegisterMetrics(nodeName)
@@ -213,8 +209,7 @@ func New(
 			eventChannel:    eventChannel,
 			ptpEventHandler: event.Init(nodeName, stdoutToSocket, eventSocket, eventChannel, closeManager, Offset, ClockState, ClockClassMetrics),
 		},
-		leapManager: leapManager,
-		stopCh:      stopCh,
+		stopCh: stopCh,
 	}
 }
 
@@ -560,7 +555,6 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 				gmInterface: gmInterface,
 				stopped:     false,
 				messageTag:  messageTag,
-				leapManager: dn.leapManager,
 				ublxTool:    nil,
 			}
 			gpsDaemon.CmdInit()

--- a/pkg/daemon/gpsd.go
+++ b/pkg/daemon/gpsd.go
@@ -44,7 +44,6 @@ type GPSD struct {
 	subscriber           *GPSDSubscriber
 	monitorCtx           context.Context
 	monitorCancel        context.CancelFunc
-	leapManager          *leap.LeapManager
 }
 
 // GPSDSubscriber ... event subscriber
@@ -278,13 +277,6 @@ retry:
 				} // loop ends
 				g.offset = nOffset
 				g.sourceLost = false
-				if timeLs != nil {
-					select {
-					case g.leapManager.UbloxLsInd <- *timeLs:
-					case <-time.After(100 * time.Millisecond):
-						glog.Infof("failied to send leap event updates")
-					}
-				}
 
 				switch nStatus >= 3 {
 				case true:
@@ -314,6 +306,13 @@ retry:
 				}:
 				default:
 					glog.Error("failed to send gnss terminated event to eventHandler")
+				}
+				if timeLs != nil {
+					select {
+					case leap.LeapMgr.UbloxLsInd <- *timeLs:
+					case <-time.After(100 * time.Millisecond):
+						glog.Infof("failied to send Leap event updates")
+					}
 				}
 			case <-g.monitorCtx.Done():
 				doneFn()

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/openshift/linuxptp-daemon/pkg/leap"
 	"github.com/openshift/linuxptp-daemon/pkg/pmc"
 	"github.com/openshift/linuxptp-daemon/pkg/protocol"
 
@@ -689,15 +690,17 @@ func (e *EventHandler) updateCLockClass(cfgName string, clkClass fbprotocol.Cloc
 	}
 	switch clockType {
 	case GM:
+		g.TimePropertiesDS.TimeTraceable = true
+		g.TimePropertiesDS.PtpTimescale = true
+		g.TimePropertiesDS.FrequencyTraceable = true
+		g.TimePropertiesDS.CurrentUtcOffsetValid = true
+		g.TimePropertiesDS.CurrentUtcOffset = int32(leap.GetUtcOffset())
 		switch clkClass {
 		case fbprotocol.ClockClass6: // T-GM connected to a PRTC in locked mode (e.g., PRTC traceable to GNSS)
 			// update only when ClockClass is changed
 			if g.ClockQuality.ClockClass != fbprotocol.ClockClass6 {
 				g.ClockQuality.ClockClass = fbprotocol.ClockClass6
 				g.ClockQuality.ClockAccuracy = fbprotocol.ClockAccuracyNanosecond100
-				g.TimePropertiesDS.TimeTraceable = true
-				g.TimePropertiesDS.FrequencyTraceable = true
-				g.TimePropertiesDS.CurrentUtcOffsetValid = true
 				g.TimePropertiesDS.TimeSource = fbprotocol.TimeSourceGNSS
 				// T-REC-G.8275.1-202211-I section 6.3.5
 				g.ClockQuality.OffsetScaledLogVariance = 0x4e5d
@@ -708,9 +711,6 @@ func (e *EventHandler) updateCLockClass(cfgName string, clkClass fbprotocol.Cloc
 				g.ClockQuality.ClockClass = protocol.ClockClassOutOfSpec
 				g.ClockQuality.ClockAccuracy = fbprotocol.ClockAccuracyUnknown
 				g.TimePropertiesDS.TimeSource = fbprotocol.TimeSourceGNSS
-				g.TimePropertiesDS.TimeTraceable = false
-				g.TimePropertiesDS.FrequencyTraceable = false
-				g.TimePropertiesDS.CurrentUtcOffsetValid = false
 				// T-REC-G.8275.1-202211-I section 6.3.5
 				g.ClockQuality.OffsetScaledLogVariance = 0xffff
 				err = gmSetterFn(cfgName, g)
@@ -720,9 +720,6 @@ func (e *EventHandler) updateCLockClass(cfgName string, clkClass fbprotocol.Cloc
 				g.ClockQuality.ClockClass = fbprotocol.ClockClass7
 				g.ClockQuality.ClockAccuracy = fbprotocol.ClockAccuracyUnknown
 				g.TimePropertiesDS.TimeSource = fbprotocol.TimeSourceGNSS
-				g.TimePropertiesDS.TimeTraceable = true
-				g.TimePropertiesDS.FrequencyTraceable = true
-				g.TimePropertiesDS.CurrentUtcOffsetValid = true
 				// T-REC-G.8275.1-202211-I section 6.3.5
 				g.ClockQuality.OffsetScaledLogVariance = 0xffff
 				err = gmSetterFn(cfgName, g)
@@ -732,9 +729,7 @@ func (e *EventHandler) updateCLockClass(cfgName string, clkClass fbprotocol.Cloc
 				g.ClockQuality.ClockClass = protocol.ClockClassFreerun
 				g.ClockQuality.ClockAccuracy = fbprotocol.ClockAccuracyUnknown
 				g.TimePropertiesDS.TimeSource = fbprotocol.TimeSourceGNSS
-				g.TimePropertiesDS.TimeTraceable = false
-				g.TimePropertiesDS.FrequencyTraceable = false
-				g.TimePropertiesDS.CurrentUtcOffsetValid = false
+				g.TimePropertiesDS.TimeSource = fbprotocol.TimeSourceNTP
 				// T-REC-G.8275.1-202211-I section 6.3.5
 				g.ClockQuality.OffsetScaledLogVariance = 0xffff
 				err = gmSetterFn(cfgName, g)


### PR DESCRIPTION
This PR fixes a bug where the daemon wrote uninitialized values to the time properties dataset, which led to corrupting the ptp time scale, current UTC offset and other dataset properties. The fix is done by always initializing the time properties according to the current UTC offset and a predefined set of flags. Leap manager was changed to provide current UTC offset to external packages.

This is a manual cherrypick of #335 
/cc @aneeshkp @jzding @josephdrichard @nishant-parekh 