### PR TITLE
CNF12625: fix Leap second PMC command time window

### DIFF
--- a/pkg/leap/leap-file.go
+++ b/pkg/leap/leap-file.go
@@ -249,7 +249,7 @@ func (l *LeapManager) Run() {
 			if l.retryUpdate {
 				l.updateLeapConfigmap()
 			}
-			if l.IsLeapInWindow(time.Now().UTC(), -pmcWindowStartHours*time.Hour, pmcWindowEndSeconds*time.Second) {
+			if l.IsLeapInWindow(time.Now().UTC(), -pmcWindowStartHours*time.Hour, -pmcWindowEndSeconds*time.Second) {
 				if !l.pmcLeapSent {
 					g, err := pmc.RunPMCExpGetGMSettings(l.ptp4lConfigPath)
 					if err != nil {


### PR DESCRIPTION
This commit fixes leap second pmc command time window. Before the fix, pmc command is sent in a time window from -12h to +60s relatively to the leap event. The correct time window is -12h to -60s

/cc @aneeshkp @jzding @josephdrichard @nishant-parekh 