### PR TITLE
 	OCPBUGS-37044: [release-4.15] prevent writing uninitialized TimePropertiesDS

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -130,7 +130,6 @@ func main() {
 		&refreshNodePtpDevice,
 		closeProcessManager,
 		cp.pmcPollInterval,
-		lm,
 	).Run()
 
 	tickerPull := time.NewTicker(time.Second * time.Duration(cp.updateInterval))

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/openshift/linuxptp-daemon/pkg/config"
 	"github.com/openshift/linuxptp-daemon/pkg/dpll"
-	"github.com/openshift/linuxptp-daemon/pkg/leap"
 
 	"github.com/openshift/linuxptp-daemon/pkg/event"
 	ptpnetwork "github.com/openshift/linuxptp-daemon/pkg/network"
@@ -159,8 +158,6 @@ type Daemon struct {
 
 	// Allow vendors to include plugins
 	pluginManager PluginManager
-
-	leapManager *leap.LeapManager
 }
 
 // New LinuxPTP is called by daemon to generate new linuxptp instance
@@ -176,7 +173,6 @@ func New(
 	refreshNodePtpDevice *bool,
 	closeManager chan bool,
 	pmcPollInterval int,
-	leapManager *leap.LeapManager,
 ) *Daemon {
 	if !stdoutToSocket {
 		RegisterMetrics(nodeName)
@@ -200,8 +196,7 @@ func New(
 			eventChannel:    eventChannel,
 			ptpEventHandler: event.Init(nodeName, stdoutToSocket, eventSocket, eventChannel, closeManager, Offset, ClockState, ClockClassMetrics),
 		},
-		leapManager: leapManager,
-		stopCh:      stopCh,
+		stopCh: stopCh,
 	}
 }
 
@@ -532,7 +527,6 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 				gmInterface: gmInterface,
 				stopped:     false,
 				messageTag:  messageTag,
-				leapManager: dn.leapManager,
 				ublxTool:    nil,
 			}
 			gpsDaemon.CmdInit()

--- a/pkg/daemon/gpsd.go
+++ b/pkg/daemon/gpsd.go
@@ -44,7 +44,6 @@ type GPSD struct {
 	subscriber           *GPSDSubscriber
 	monitorCtx           context.Context
 	monitorCancel        context.CancelFunc
-	leapManager          *leap.LeapManager
 }
 
 // GPSDSubscriber ... event subscriber
@@ -278,13 +277,6 @@ retry:
 				} // loop ends
 				g.offset = nOffset
 				g.sourceLost = false
-				if timeLs != nil {
-					select {
-					case g.leapManager.UbloxLsInd <- *timeLs:
-					case <-time.After(100 * time.Millisecond):
-						glog.Infof("failied to send leap event updates")
-					}
-				}
 
 				switch nStatus >= 3 {
 				case true:
@@ -314,6 +306,13 @@ retry:
 				}:
 				default:
 					glog.Error("failed to send gnss terminated event to eventHandler")
+				}
+				if timeLs != nil {
+					select {
+					case leap.LeapMgr.UbloxLsInd <- *timeLs:
+					case <-time.After(100 * time.Millisecond):
+						glog.Infof("failied to send Leap event updates")
+					}
 				}
 			case <-g.monitorCtx.Done():
 				doneFn()

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/openshift/linuxptp-daemon/pkg/leap"
 	"github.com/openshift/linuxptp-daemon/pkg/pmc"
 	"github.com/openshift/linuxptp-daemon/pkg/protocol"
 
@@ -689,15 +690,17 @@ func (e *EventHandler) updateCLockClass(cfgName string, clkClass fbprotocol.Cloc
 	}
 	switch clockType {
 	case GM:
+		g.TimePropertiesDS.TimeTraceable = true
+		g.TimePropertiesDS.PtpTimescale = true
+		g.TimePropertiesDS.FrequencyTraceable = true
+		g.TimePropertiesDS.CurrentUtcOffsetValid = true
+		g.TimePropertiesDS.CurrentUtcOffset = int32(leap.GetUtcOffset())
 		switch clkClass {
 		case fbprotocol.ClockClass6: // T-GM connected to a PRTC in locked mode (e.g., PRTC traceable to GNSS)
 			// update only when ClockClass is changed
 			if g.ClockQuality.ClockClass != fbprotocol.ClockClass6 {
 				g.ClockQuality.ClockClass = fbprotocol.ClockClass6
 				g.ClockQuality.ClockAccuracy = fbprotocol.ClockAccuracyNanosecond100
-				g.TimePropertiesDS.TimeTraceable = true
-				g.TimePropertiesDS.FrequencyTraceable = true
-				g.TimePropertiesDS.CurrentUtcOffsetValid = true
 				g.TimePropertiesDS.TimeSource = fbprotocol.TimeSourceGNSS
 				// T-REC-G.8275.1-202211-I section 6.3.5
 				g.ClockQuality.OffsetScaledLogVariance = 0x4e5d
@@ -708,9 +711,6 @@ func (e *EventHandler) updateCLockClass(cfgName string, clkClass fbprotocol.Cloc
 				g.ClockQuality.ClockClass = protocol.ClockClassOutOfSpec
 				g.ClockQuality.ClockAccuracy = fbprotocol.ClockAccuracyUnknown
 				g.TimePropertiesDS.TimeSource = fbprotocol.TimeSourceGNSS
-				g.TimePropertiesDS.TimeTraceable = false
-				g.TimePropertiesDS.FrequencyTraceable = false
-				g.TimePropertiesDS.CurrentUtcOffsetValid = false
 				// T-REC-G.8275.1-202211-I section 6.3.5
 				g.ClockQuality.OffsetScaledLogVariance = 0xffff
 				err = gmSetterFn(cfgName, g)
@@ -720,9 +720,6 @@ func (e *EventHandler) updateCLockClass(cfgName string, clkClass fbprotocol.Cloc
 				g.ClockQuality.ClockClass = fbprotocol.ClockClass7
 				g.ClockQuality.ClockAccuracy = fbprotocol.ClockAccuracyUnknown
 				g.TimePropertiesDS.TimeSource = fbprotocol.TimeSourceGNSS
-				g.TimePropertiesDS.TimeTraceable = true
-				g.TimePropertiesDS.FrequencyTraceable = true
-				g.TimePropertiesDS.CurrentUtcOffsetValid = true
 				// T-REC-G.8275.1-202211-I section 6.3.5
 				g.ClockQuality.OffsetScaledLogVariance = 0xffff
 				err = gmSetterFn(cfgName, g)
@@ -732,9 +729,7 @@ func (e *EventHandler) updateCLockClass(cfgName string, clkClass fbprotocol.Cloc
 				g.ClockQuality.ClockClass = protocol.ClockClassFreerun
 				g.ClockQuality.ClockAccuracy = fbprotocol.ClockAccuracyUnknown
 				g.TimePropertiesDS.TimeSource = fbprotocol.TimeSourceGNSS
-				g.TimePropertiesDS.TimeTraceable = false
-				g.TimePropertiesDS.FrequencyTraceable = false
-				g.TimePropertiesDS.CurrentUtcOffsetValid = false
+				g.TimePropertiesDS.TimeSource = fbprotocol.TimeSourceNTP
 				// T-REC-G.8275.1-202211-I section 6.3.5
 				g.ClockQuality.OffsetScaledLogVariance = 0xffff
 				err = gmSetterFn(cfgName, g)

--- a/pkg/leap/leap-file.go
+++ b/pkg/leap/leap-file.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/golang/glog"
@@ -48,6 +49,9 @@ type LeapManager struct {
 	// Default leap file path and name
 	leapFilePath string
 	leapFileName string
+	// UTC offset and its validity time
+	utcOffset     int
+	utcOffsetTime time.Time
 }
 
 type LeapEvent struct {
@@ -62,21 +66,73 @@ type LeapFile struct {
 	Hash           string      `json:"hash"`
 }
 
-func New(kubeclient *kubernetes.Clientset, namespace string) (*LeapManager, error) {
-	lm := &LeapManager{
-		UbloxLsInd:   make(chan ublox.TimeLs, 2),
-		Close:        make(chan bool),
-		client:       kubeclient,
-		namespace:    namespace,
-		leapFile:     LeapFile{},
-		leapFilePath: defaultLeapFilePath,
-		leapFileName: defaultLeapFileName,
+var lock = &sync.Mutex{}
+
+var LeapMgr *LeapManager
+
+func New(kubeclient kubernetes.Interface, namespace string) (*LeapManager, error) {
+	if LeapMgr == nil {
+		lock.Lock()
+		defer lock.Unlock()
+		if LeapMgr == nil {
+			lm := &LeapManager{
+				UbloxLsInd:   make(chan ublox.TimeLs, 2),
+				Close:        make(chan bool),
+				client:       kubeclient,
+				namespace:    namespace,
+				leapFile:     LeapFile{},
+				leapFilePath: defaultLeapFilePath,
+				leapFileName: defaultLeapFileName,
+			}
+			err := lm.populateLeapData()
+			if err != nil {
+				return nil, err
+			}
+			LeapMgr = lm
+		}
 	}
-	err := lm.populateLeapData()
-	if err != nil {
-		return nil, err
+	return LeapMgr, nil
+}
+
+func (l *LeapManager) Run() {
+	glog.Info("starting Leap file manager")
+	ticker := time.NewTicker(MaintenancePeriod)
+	defer ticker.Stop()
+	for {
+		select {
+		case v := <-l.UbloxLsInd:
+			l.handleLeapIndication(&v)
+		case <-l.Close:
+			LeapMgr = nil
+			return
+		case <-ticker.C:
+			if l.retryUpdate {
+				l.updateLeapConfigmap()
+			}
+			// TODO: if current time is within -12h ... +60s from leap event:
+			// Send PMC command
+		}
 	}
-	return lm, nil
+}
+
+func GetUtcOffset() int {
+	if LeapMgr != nil {
+		if time.Now().UTC().After(LeapMgr.utcOffsetTime) {
+			return LeapMgr.utcOffset
+		} else if len(LeapMgr.leapFile.LeapEvents) > 1 {
+			return LeapMgr.leapFile.LeapEvents[len(LeapMgr.leapFile.LeapEvents)-2].LeapSec
+		}
+	}
+	glog.Fatal("failed to get UTC offset")
+	return 0
+}
+
+func (l *LeapManager) setUtcOffset() error {
+	startTime := time.Date(1900, time.January, 1, 0, 0, 0, 0, time.UTC)
+	lastLeap := l.leapFile.LeapEvents[len(l.leapFile.LeapEvents)-1]
+	l.utcOffsetTime = startTime.Add(time.Second * time.Duration(lastLeap.LeapTime))
+	l.utcOffset = lastLeap.LeapSec
+	return nil
 }
 
 func parseLeapFile(b []byte) (*LeapFile, error) {
@@ -150,7 +206,7 @@ func (l *LeapManager) populateLeapData() error {
 	lf, found := cm.Data[nodeName]
 	if !found {
 		glog.Info("Populate Leap data from file")
-		b, err := os.ReadFile(filepath.Join(defaultLeapFilePath, defaultLeapFileName))
+		b, err := os.ReadFile(filepath.Join(l.leapFilePath, l.leapFileName))
 		if err != nil {
 			return err
 		}
@@ -187,26 +243,8 @@ func (l *LeapManager) populateLeapData() error {
 		l.leapFile = *leapData
 	}
 	glog.Info("Leap file expiration is set to ", l.leapFile.ExpirationTime)
+	l.setUtcOffset()
 	return nil
-}
-
-func (l *LeapManager) Run() {
-	glog.Info("starting Leap file manager")
-	ticker := time.NewTicker(MaintenancePeriod)
-	for {
-		select {
-		case v := <-l.UbloxLsInd:
-			l.handleLeapIndication(&v)
-		case <-l.Close:
-			return
-		case <-ticker.C:
-			if l.retryUpdate {
-				l.updateLeapConfigmap()
-			}
-			// TODO: if current time is within -12h ... +60s from leap event:
-			// Send PMC command
-		}
-	}
 }
 
 // updateLeapFile updates a new leap event to the list of leap events, if provided
@@ -227,6 +265,7 @@ func (l *LeapManager) updateLeapFile(leapTime time.Time,
 	}
 	l.leapFile.UpdateTime = fmt.Sprint(int(currentTime.Sub(startTime).Seconds()))
 	l.rehashLeapData()
+	l.setUtcOffset()
 }
 
 func (l *LeapManager) rehashLeapData() {

--- a/pkg/leap/leap-file_test.go
+++ b/pkg/leap/leap-file_test.go
@@ -299,3 +299,66 @@ func Test_handleLeapIndication(t *testing.T) {
 	assert.Equal(t, uint64(3928780800), lm.leapFile.LeapEvents[1].LeapTime)
 	assert.Equal(t, "4291747200", lm.leapFile.ExpirationTime)
 }
+
+func Test_New_Good(t *testing.T) {
+	cm := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "openshift-ptp", Name: "leap-configmap"},
+		Data: map[string]string{
+			"test-node-name": `# Do not edit
+# This file is generated automatically by linuxptp-daemon
+#$	3927775672
+#@	4291747200
+3692217600     37    # 1 Jan 2017`,
+		},
+	}
+	os.Setenv("NODE_NAME", "test-node-name")
+	client := fake.NewSimpleClientset(cm)
+	lm, err := New(client, "openshift-ptp")
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(lm.leapFile.LeapEvents))
+	offset := GetUtcOffset()
+	assert.Equal(t, 37, offset)
+	LeapMgr = nil
+}
+
+func Test_Run(t *testing.T) {
+	cm := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "openshift-ptp", Name: "leap-configmap"},
+		Data: map[string]string{
+			"test-node-name": `# Do not edit
+# This file is generated automatically by linuxptp-daemon
+#$	3927775672
+#@	4291747200
+3692217600     37    # 1 Jan 2017`,
+		},
+	}
+	os.Setenv("NODE_NAME", "test-node-name")
+	client := fake.NewSimpleClientset(cm)
+	lm, err := New(client, "openshift-ptp")
+
+	assert.NoError(t, err)
+	go lm.Run()
+	assert.NotNil(t, LeapMgr)
+	var timeLs = &ublox.TimeLs{
+		SrcOfCurrLs:   2,
+		CurrLs:        19,
+		SrcOfLsChange: 2,
+		LsChange:      0,
+		TimeToLsEvent: 0,
+		DateOfLsGpsWn: 0,
+		DateOfLsGpsDn: 0,
+		Valid:         3,
+	}
+	select {
+	case LeapMgr.UbloxLsInd <- *timeLs:
+	case <-time.After(100 * time.Millisecond):
+		assert.FailNow(t, "failed to send event to leap manager")
+	}
+	time.Sleep(100 * time.Millisecond)
+	offset := GetUtcOffset()
+	assert.Equal(t, 38, offset)
+	close(LeapMgr.Close)
+	time.Sleep(100 * time.Millisecond)
+	assert.Nil(t, LeapMgr)
+}


### PR DESCRIPTION
This PR fixes a bug where the daemon wrote uninitialized values to the time properties dataset, which led to corrupting the ptp time scale, current UTC offset and other dataset properties. The fix is done by always initializing the time properties according to the current UTC offset and a predefined set of flags. Leap manager was changed to provide current UTC offset to external packages.

This is a manual cherry-pick of #341
/cc @aneeshkp @jzding @josephdrichard @nishant-parekh 