### PR TITLE
Fix SSM code for DNU and DUS for network 1 and 2 

### DIFF
--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -205,7 +205,7 @@ func (conf *ptp4lConf) extractSynceRelations() *synce.Relations {
 	re, _ := regexp.Compile(`[{}<>\[\] ]+`)
 	synceRelationInfo := synce.Config{}
 
-	var extendedTlv, networkOption int = 0, 1
+	var extendedTlv, networkOption int = synce.ExtendedTLV_DISABLED, synce.SYNCE_NETWORK_OPT_1
 	for _, section := range conf.sections {
 		if strings.HasPrefix(section.sectionName, "[<") {
 			if synceRelationInfo.Name != "" {
@@ -218,13 +218,13 @@ func (conf *ptp4lConf) extractSynceRelations() *synce.Relations {
 				Name:           "",
 				Ifaces:         nil,
 				ClockId:        "",
-				NetworkOption:  1,
-				ExtendedTlv:    0,
+				NetworkOption:  synce.SYNCE_NETWORK_OPT_1,
+				ExtendedTlv:    synce.ExtendedTLV_DISABLED,
 				ExternalSource: "",
 				LastQLState:    make(map[string]*synce.QualityLevelInfo),
 				LastClockState: "",
 			}
-			extendedTlv, networkOption = 0, 1
+			extendedTlv, networkOption = synce.ExtendedTLV_DISABLED, synce.SYNCE_NETWORK_OPT_1
 
 			synceRelationInfo.Name = re.ReplaceAllString(section.sectionName, "")
 			if networkOptionStr, ok := section.options["network_option"]; ok {

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -3,14 +3,15 @@ package daemon_test
 import (
 	"flag"
 	"fmt"
+	"os"
+	"strings"
+	"testing"
+
 	"github.com/openshift/linuxptp-daemon/pkg/event"
 	"github.com/openshift/linuxptp-daemon/pkg/synce"
 	ptpv1 "github.com/openshift/ptp-operator/api/v1"
 	"github.com/sirupsen/logrus"
 	"k8s.io/utils/pointer"
-	"os"
-	"strings"
-	"testing"
 
 	"github.com/openshift/linuxptp-daemon/pkg/config"
 	"github.com/openshift/linuxptp-daemon/pkg/daemon"
@@ -334,16 +335,17 @@ type synceLogTestCase struct {
 
 func InitSynceLogTestCase() {
 	logTestCases = []synceLogTestCase{
+
 		{
-			output:               "synce4l[1225226.278]: [synce4l.0.config] tx_rebuild_tlv: attached new TLV, QL=0x1 on ens7f0",
+			output:               "synce4l[1225226.279]: [synce4l.0.config] tx_rebuild_tlv: attached new TLV, QL=0x1 on ens7f0",
 			expectedState:        "",
 			expectedDevice:       pointer.String("synce1"),
 			expectedQL:           option2[synce.PRTC].SSM,
-			expectedExtendedQL:   synce.DEFAULT_EXTQL, //**If extended SSM is not enabled, it's implicitly assumed as 0xFF
+			expectedExtendedQL:   synce.QL_DEFAULT_SSM, //**If extended SSM is not enabled, it's implicitly assumed as 0xFF
 			expectedSource:       pointer.String("ens7f0"),
-			extendedTvl:          0,
+			extendedTvl:          1,
 			networkOption:        2,
-			expectedClockQuality: synce.PRS.String(),
+			expectedClockQuality: "",
 			expectedDescription:  " initial state with nPRTCo ext_ql should set ClockQuality for networkOption1 ",
 		},
 
@@ -352,7 +354,7 @@ func InitSynceLogTestCase() {
 			expectedState:        "",
 			expectedDevice:       pointer.String("synce1"),
 			expectedQL:           option1[synce.PRC].SSM,
-			expectedExtendedQL:   synce.DEFAULT_EXTQL, //**If extended SSM is not enabled, it's implicitly assumed as 0xFF
+			expectedExtendedQL:   synce.QL_DEFAULT_ENHSSM, //**If extended SSM is not enabled, it's implicitly assumed as 0xFF
 			expectedSource:       pointer.String("ens7f0"),
 			extendedTvl:          0,
 			networkOption:        1,
@@ -432,8 +434,8 @@ func TestDaemon_ProcessSynceLogs(t *testing.T) {
 		Name:           "synce1",
 		Ifaces:         []string{"ens7f0"},
 		ClockId:        "1",
-		NetworkOption:  1,
-		ExtendedTlv:    0,
+		NetworkOption:  synce.SYNCE_NETWORK_OPT_1,
+		ExtendedTlv:    synce.ExtendedTLV_DISABLED,
 		ExternalSource: "",
 		LastQLState:    make(map[string]*synce.QualityLevelInfo),
 		LastClockState: "",

--- a/pkg/synce/synce_test.go
+++ b/pkg/synce/synce_test.go
@@ -36,10 +36,10 @@ var (
 var testCases = []testCase{
 	{
 		sms:              option2[synce.PRTC].SSM,
-		smsExtended:      synce.DEFAULT_EXTQL,
+		smsExtended:      synce.QL_DEFAULT_ENHSSM,
 		expectedPriority: option2[synce.PRTC].Priority,
 		expectedClock:    synce.PRS.String(),
-		networkOption:    2,
+		networkOption:    synce.SYNCE_NETWORK_OPT_2,
 		enabledExtQl:     0,
 	},
 	{
@@ -70,7 +70,7 @@ var testCases = []testCase{
 		sms:              option2[synce.PRS].SSM,
 		smsExtended:      option2[synce.PRS].ExtendedSSM,
 		expectedPriority: option2[synce.PRS].Priority,
-		expectedClock:    synce.UNKNOWN.String(),
+		expectedClock:    synce.DNU.String(),
 		networkOption:    1,
 		enabledExtQl:     1,
 	},
@@ -78,7 +78,7 @@ var testCases = []testCase{
 		sms:              option2[synce.PRS].SSM,
 		smsExtended:      option2[synce.EEC1].ExtendedSSM,
 		expectedPriority: 0,
-		expectedClock:    synce.UNKNOWN.String(),
+		expectedClock:    synce.DUS.String(),
 		networkOption:    2,
 		enabledExtQl:     1,
 	},
@@ -89,8 +89,8 @@ func Test_GetClockQuality(t *testing.T) {
 		Name:           "synce1",
 		Ifaces:         nil,
 		ClockId:        "",
-		NetworkOption:  2,
-		ExtendedTlv:    1,
+		NetworkOption:  synce.SYNCE_NETWORK_OPT_2,
+		ExtendedTlv:    synce.ExtendedTLV_ENABLED,
 		ExternalSource: "",
 	}
 	synce.PrintOption1Networks()
@@ -129,7 +129,7 @@ func InitLogTestCase() {
 			expectedSource:     pointer.String("ens7f0"),
 			expectedDevice:     nil,
 			expectedQL:         option1[synce.PRTC].SSM,
-			expectedExtendedQL: synce.DEFAULT_QL,
+			expectedExtendedQL: synce.QL_DEFAULT_SSM,
 			enabledExtQl:       false,
 		},
 		{
@@ -138,7 +138,7 @@ func InitLogTestCase() {
 			expectedSource:     pointer.String("ens7f0"),
 			expectedDevice:     nil,
 			expectedQL:         option1[synce.PRTC].SSM,
-			expectedExtendedQL: synce.DEFAULT_QL,
+			expectedExtendedQL: synce.QL_DEFAULT_SSM,
 			enabledExtQl:       false,
 		},
 		{
@@ -147,7 +147,7 @@ func InitLogTestCase() {
 			expectedDevice:     nil,
 			expectedSource:     pointer.String("ens7f0"),
 			expectedExtSource:  nil,
-			expectedQL:         synce.DEFAULT_QL,
+			expectedQL:         synce.QL_DEFAULT_SSM,
 			expectedExtendedQL: 0xff,
 			enabledExtQl:       true,
 		},
@@ -157,8 +157,8 @@ func InitLogTestCase() {
 			expectedDevice:     pointer.String("synce1"),
 			expectedExtSource:  pointer.String("GNSS"),
 			expectedSource:     nil,
-			expectedQL:         synce.DEFAULT_QL,
-			expectedExtendedQL: synce.DEFAULT_QL,
+			expectedQL:         synce.QL_DEFAULT_SSM,
+			expectedExtendedQL: synce.QL_DEFAULT_SSM,
 		},
 		{
 			output:             "synce4l[627602.540]: [synce4l.0.config] EEC_HOLDOVER on synce1",
@@ -166,8 +166,8 @@ func InitLogTestCase() {
 			expectedExtSource:  nil,
 			expectedDevice:     pointer.String("synce1"),
 			expectedSource:     nil,
-			expectedQL:         synce.DEFAULT_QL,
-			expectedExtendedQL: synce.DEFAULT_QL,
+			expectedQL:         synce.QL_DEFAULT_SSM,
+			expectedExtendedQL: synce.QL_DEFAULT_SSM,
 		},
 		{
 			output:             "synce4l[627602.593]: [synce4l.0.config] tx_rebuild_tlv: attached new TLV, QL=0x1 on ens7f0",
@@ -176,7 +176,7 @@ func InitLogTestCase() {
 			expectedSource:     pointer.String("ens7f0"),
 			expectedExtSource:  nil,
 			expectedQL:         0x1,
-			expectedExtendedQL: synce.DEFAULT_QL,
+			expectedExtendedQL: synce.QL_DEFAULT_SSM,
 		},
 		{
 			output:             "synce4l[627602.593]: [synce4l.0.config] tx_rebuild_tlv: attached new extended TLV, EXT_QL=0xff on ens7f0",
@@ -184,7 +184,7 @@ func InitLogTestCase() {
 			expectedDevice:     nil,
 			expectedSource:     pointer.String("ens7f0"),
 			expectedExtSource:  nil,
-			expectedQL:         synce.DEFAULT_QL,
+			expectedQL:         synce.QL_DEFAULT_SSM,
 			expectedExtendedQL: 0xff,
 		},
 		{
@@ -193,8 +193,8 @@ func InitLogTestCase() {
 			expectedDevice:     pointer.String("synce1"),
 			expectedExtSource:  pointer.String("GNSS"),
 			expectedSource:     nil,
-			expectedQL:         synce.DEFAULT_QL,
-			expectedExtendedQL: synce.DEFAULT_QL,
+			expectedQL:         synce.QL_DEFAULT_SSM,
+			expectedExtendedQL: synce.QL_DEFAULT_SSM,
 		},
 		{
 			output:             "synce4l[627685.138]: [synce4l.0.config] act on EEC_LOCKED/EEC_LOCKED_HO_ACQ for ens7f0",
@@ -202,8 +202,8 @@ func InitLogTestCase() {
 			expectedExtSource:  nil,
 			expectedDevice:     nil,
 			expectedSource:     pointer.String("ens7f0"),
-			expectedQL:         synce.DEFAULT_QL,
-			expectedExtendedQL: synce.DEFAULT_QL,
+			expectedQL:         synce.QL_DEFAULT_SSM,
+			expectedExtendedQL: synce.QL_DEFAULT_SSM,
 		},
 	}
 


### PR DESCRIPTION
Use 0x3 as default for QL values   and use DNU and DUS for HOLDOVER and FREERUN
which is 0xf for SSM Option1 and 2 
