### PR TITLE
OCPBUGS-39322: [release-4.18]fix ts2phc leap window check

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -966,10 +966,11 @@ func (p *ptpProcess) processPTPMetrics(output string) {
 		logEntry := synce.ParseLog(output)
 		p.ProcessSynceEvents(logEntry)
 
-	} else if p.name == ts2phcProcessName && (strings.Contains(output, NMEASourceDisabledIndicator) ||
-		strings.Contains(output, InvalidMasterTimestampIndicator) ||
-		(strings.Contains(output, NMEASourceDisabledIndicator2) &&
-			(!leap.LeapMgr.IsLeapInWindow(time.Now().UTC(), -2*time.Second, time.Second)))) { //TODO identify which interface lost nmea or 1pps
+	} else if p.name == ts2phcProcessName &&
+		(strings.Contains(output, NMEASourceDisabledIndicator) ||
+			strings.Contains(output, InvalidMasterTimestampIndicator) ||
+			strings.Contains(output, NMEASourceDisabledIndicator2)) &&
+		!leap.LeapMgr.IsLeapInWindow(time.Now().UTC(), -2*time.Second, time.Second) { //TODO identify which interface lost nmea or 1pps
 		iface := p.ifaces.GetGMInterface().Name
 		p.ProcessTs2PhcEvents(faultyOffset, ts2phcProcessName, iface, state, map[event.ValueType]interface{}{event.NMEA_STATUS: int64(0)})
 		glog.Error("nmea string lost") //TODO: add for 1pps lost

--- a/pkg/daemon/daemon_internal_test.go
+++ b/pkg/daemon/daemon_internal_test.go
@@ -6,15 +6,11 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/bigkevmcd/go-configparser"
 	"github.com/openshift/linuxptp-daemon/pkg/leap"
 	ptpv1 "github.com/openshift/ptp-operator/api/v1"
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	fake "k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/yaml"
 )
 
@@ -43,8 +39,8 @@ func clean(t *testing.T) {
 func applyProfileSyncE(t *testing.T, profile *ptpv1.PtpProfile) {
 
 	stopCh := make(<-chan struct{})
-	err := mockLeap()
-	assert.NoError(t, err)
+	assert.NoError(t, leap.MockLeapFile())
+	defer close(leap.LeapMgr.Close)
 	dn := New(
 		"test-node-name",
 		"openshift-ptp",
@@ -62,11 +58,8 @@ func applyProfileSyncE(t *testing.T, profile *ptpv1.PtpProfile) {
 		30,
 	)
 	assert.NotNil(t, dn)
-	err = dn.applyNodePtpProfile(0, profile)
+	err := dn.applyNodePtpProfile(0, profile)
 	assert.NoError(t, err)
-	time.Sleep(time.Second)
-	close(leap.LeapMgr.Close)
-
 }
 
 func testRequirements(t *testing.T, profile *ptpv1.PtpProfile) {
@@ -104,25 +97,4 @@ func Test_applyProfile_synce(t *testing.T) {
 		testRequirements(t, profile)
 		clean(t)
 	}
-}
-
-func mockLeap() error {
-	cm := &v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{Namespace: "openshift-ptp", Name: "leap-configmap"},
-		Data: map[string]string{
-			"test-node-name": `# Do not edit
-# This file is generated automatically by linuxptp-daemon
-#$	3927775672
-#@	4291747200
-3692217600     37    # 1 Jan 2017`,
-		},
-	}
-	os.Setenv("NODE_NAME", "test-node-name")
-	client := fake.NewSimpleClientset(cm)
-	lm, err := leap.New(client, "openshift-ptp")
-	if err != nil {
-		return err
-	}
-	go lm.Run()
-	return nil
 }

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/openshift/linuxptp-daemon/pkg/event"
+	"github.com/openshift/linuxptp-daemon/pkg/leap"
 	"github.com/openshift/linuxptp-daemon/pkg/synce"
 	ptpv1 "github.com/openshift/ptp-operator/api/v1"
 	"github.com/sirupsen/logrus"
@@ -220,7 +221,6 @@ func setup() {
 	var logLevel string
 	flag.StringVar(&logLevel, "logLevel", "4", "test")
 	flag.Lookup("v").Value.Set(logLevel)
-
 	daemon.InitializeOffsetMaps()
 	pm = daemon.NewProcessManager()
 	daemon.RegisterMetrics(MYNODE)
@@ -236,6 +236,8 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 func Test_ProcessPTPMetrics(t *testing.T) {
+	leap.MockLeapFile()
+	defer close(leap.LeapMgr.Close)
 
 	assert := assert.New(t)
 	for _, tc := range testCases {

--- a/pkg/event/event_test.go
+++ b/pkg/event/event_test.go
@@ -15,9 +15,6 @@ import (
 	"github.com/openshift/linuxptp-daemon/pkg/leap"
 	"github.com/openshift/linuxptp-daemon/pkg/protocol"
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	fake "k8s.io/client-go/kubernetes/fake"
 )
 
 var (
@@ -220,7 +217,8 @@ func TestEventHandler_ProcessEvents(t *testing.T) {
 	eventManager := event.Init("node", true, "/tmp/go.sock", eChannel, closeChn, nil, nil, nil)
 	eventManager.MockEnable()
 	go eventManager.ProcessEvents()
-	assert.NoError(t, mockLeap())
+	assert.NoError(t, leap.MockLeapFile())
+	defer close(leap.LeapMgr.Close)
 	time.Sleep(1 * time.Second)
 	for _, test := range tests {
 		select {
@@ -354,25 +352,4 @@ func sendEvents(cfgName string, processName event.EventSource, state event.PTPSt
 		WriteToLog:         true,
 		Reset:              false,
 	}
-}
-
-func mockLeap() error {
-	cm := &v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{Namespace: "openshift-ptp", Name: "leap-configmap"},
-		Data: map[string]string{
-			"test-node-name": `# Do not edit
-# This file is generated automatically by linuxptp-daemon
-#$	3927775672
-#@	4291747200
-3692217600     37    # 1 Jan 2017`,
-		},
-	}
-	os.Setenv("NODE_NAME", "test-node-name")
-	client := fake.NewSimpleClientset(cm)
-	lm, err := leap.New(client, "openshift-ptp")
-	if err != nil {
-		return err
-	}
-	go lm.Run()
-	return nil
 }


### PR DESCRIPTION
This fixes the leap window condition check when receiving ts2phc status messages. Any of them should not cause "nmea string lost" event during the leap second clock irregularity.

/cc @aneeshkp @jzding @josephdrichard @nishant-parekh 