### PR TITLE
OCPBUGS-39187: [release-4.17] fix ts2phc leap window check

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -949,10 +949,11 @@ func (p *ptpProcess) processPTPMetrics(output string) {
 		logEntry := synce.ParseLog(output)
 		p.ProcessSynceEvents(logEntry)
 
-	} else if p.name == ts2phcProcessName && (strings.Contains(output, NMEASourceDisabledIndicator) ||
-		strings.Contains(output, InvalidMasterTimestampIndicator) ||
-		(strings.Contains(output, NMEASourceDisabledIndicator2) &&
-			(!leap.LeapMgr.IsLeapInWindow(time.Now().UTC(), -2*time.Second, time.Second)))) { //TODO identify which interface lost nmea or 1pps
+	} else if p.name == ts2phcProcessName &&
+		(strings.Contains(output, NMEASourceDisabledIndicator) ||
+			strings.Contains(output, InvalidMasterTimestampIndicator) ||
+			strings.Contains(output, NMEASourceDisabledIndicator2)) &&
+		!leap.LeapMgr.IsLeapInWindow(time.Now().UTC(), -2*time.Second, time.Second) { //TODO identify which interface lost nmea or 1pps
 		iface := p.ifaces.GetGMInterface().Name
 		p.ProcessTs2PhcEvents(faultyOffset, ts2phcProcessName, iface, map[event.ValueType]interface{}{event.NMEA_STATUS: int64(0)})
 		glog.Error("nmea string lost") //TODO: add for 1pps lost

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/openshift/linuxptp-daemon/pkg/config"
 	"github.com/openshift/linuxptp-daemon/pkg/daemon"
+	"github.com/openshift/linuxptp-daemon/pkg/leap"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
@@ -236,7 +237,8 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 func Test_ProcessPTPMetrics(t *testing.T) {
-
+	leap.MockLeapFile()
+	defer close(leap.LeapMgr.Close)
 	assert := assert.New(t)
 	for _, tc := range testCases {
 		tc.node = MYNODE

--- a/pkg/event/event_test.go
+++ b/pkg/event/event_test.go
@@ -15,9 +15,6 @@ import (
 	"github.com/openshift/linuxptp-daemon/pkg/leap"
 	"github.com/openshift/linuxptp-daemon/pkg/protocol"
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	fake "k8s.io/client-go/kubernetes/fake"
 )
 
 var (
@@ -207,7 +204,8 @@ func TestEventHandler_ProcessEvents(t *testing.T) {
 	eventManager := event.Init("node", true, "/tmp/go.sock", eChannel, closeChn, nil, nil, nil)
 	eventManager.MockEnable()
 	go eventManager.ProcessEvents()
-	assert.NoError(t, mockLeap())
+	assert.NoError(t, leap.MockLeapFile())
+	defer close(leap.LeapMgr.Close)
 	time.Sleep(1 * time.Second)
 	for _, test := range tests {
 		select {
@@ -340,25 +338,4 @@ func sendEvents(cfgName string, processName event.EventSource, state event.PTPSt
 		WriteToLog:  true,
 		Reset:       false,
 	}
-}
-
-func mockLeap() error {
-	cm := &v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{Namespace: "openshift-ptp", Name: "leap-configmap"},
-		Data: map[string]string{
-			"test-node-name": `# Do not edit
-# This file is generated automatically by linuxptp-daemon
-#$	3927775672
-#@	4291747200
-3692217600     37    # 1 Jan 2017`,
-		},
-	}
-	os.Setenv("NODE_NAME", "test-node-name")
-	client := fake.NewSimpleClientset(cm)
-	lm, err := leap.New(client, "openshift-ptp")
-	if err != nil {
-		return err
-	}
-	go lm.Run()
-	return nil
 }


### PR DESCRIPTION
This fixes the leap window condition check when receiving ts2phc status messages. Any of them should not cause "nmea string lost" event during the leap second clock irregularity.
/cc @aneeshkp @jzding @josephdrichard @nishant-parekh 