### PR TITLE
OCPBUGS-41882: Disable Ublox GNGSA and GNGSV nmea messages

### DIFF
--- a/addons/intel/e810.go
+++ b/addons/intel/e810.go
@@ -65,12 +65,22 @@ func getDefaultUblxCmds() []E810UblxCmds {
 		Args:         []string{"-p", "CFG-MSG,1,3,1"},
 	}
 
+	// Ublx command to disable SA messages
+	cfgMsgDisableSA := E810UblxCmds{
+		ReportOutput: false,
+		Args:         []string{"-p", "CFG-MSG,0xf0,0x02,0"},
+	}
+	// Ublx command to disable SV messages
+	cfgMsgDisableSV := E810UblxCmds{
+		ReportOutput: false,
+		Args:         []string{"-p", "CFG-MSG,0xf0,0x03,0"},
+	}
 	// Ublx command to save configuration to storage
 	cfgSave := E810UblxCmds{
 		ReportOutput: false,
 		Args:         []string{"-p", "SAVE"},
 	}
-	return []E810UblxCmds{cfgMsgNavClock, cfgMsgNavStatus, cfgSave}
+	return []E810UblxCmds{cfgMsgNavClock, cfgMsgNavStatus, cfgMsgDisableSA, cfgMsgDisableSV, cfgSave}
 }
 
 func OnPTPConfigChangeE810(data *interface{}, nodeProfile *ptpv1.PtpProfile) error {


### PR DESCRIPTION
This commit disables SA and SV messages to reduce unnecessare computing load on ts2phc. The amount of these two messages can increase uncontrollably with the number of visible satellites, and they don't provide any useful information for the timing solution.

/cc @aneeshkp @jzding @josephdrichard @nishant-parekh 