### PR TITLE
Verify HW configuration to enable or disable T-GM Holdover

### DIFF
--- a/addons/generic/generic.go
+++ b/addons/generic/generic.go
@@ -2,15 +2,18 @@ package generic
 
 import (
 	"encoding/json"
+
 	"github.com/golang/glog"
 	"github.com/openshift/linuxptp-daemon/pkg/plugin"
 	ptpv1 "github.com/openshift/ptp-operator/api/v1"
 )
 
+// GenericPluginData is a struct to hold the reference string
 type GenericPluginData struct {
 	referenceString *string
 }
 
+// OnPTPConfigChangeGeneric is a generic function to handle PTPConfigChange
 func OnPTPConfigChangeGeneric(data *interface{}, nodeProfile *ptpv1.PtpProfile) error {
 	var pluginOpts string = ""
 	var err error
@@ -25,14 +28,13 @@ func OnPTPConfigChangeGeneric(data *interface{}, nodeProfile *ptpv1.PtpProfile) 
 
 	if data != nil && pluginOpts != "" {
 		_data := *data
-		glog.Infof("Saving status to hwconfig: %s", string(pluginOpts))
-		var pluginData *GenericPluginData = _data.(*GenericPluginData)
+		glog.Infof("Saving status to hwconfig: %s", pluginOpts)
+		var pluginData = _data.(*GenericPluginData)
 		_pluginData := *pluginData
 		*_pluginData.referenceString = pluginOpts
 	}
 	glog.Infof("OnPTPConfigChangeGeneric: (%s)", pluginOpts)
 	return err
-
 }
 
 func PopulateHwConfigGeneric(data *interface{}, hwconfigs *[]ptpv1.HwConfig) error {
@@ -40,7 +42,7 @@ func PopulateHwConfigGeneric(data *interface{}, hwconfigs *[]ptpv1.HwConfig) err
 	var referenceString string = ""
 	if data != nil {
 		_data := *data
-		var pluginData *GenericPluginData = _data.(*GenericPluginData)
+		var pluginData = _data.(*GenericPluginData)
 		_pluginData := *pluginData
 		if _pluginData.referenceString != nil {
 			referenceString = *_pluginData.referenceString

--- a/addons/mapping.go
+++ b/addons/mapping.go
@@ -3,10 +3,12 @@ package mapping
 import (
 	"github.com/openshift/linuxptp-daemon/addons/generic"
 	"github.com/openshift/linuxptp-daemon/addons/intel"
+	plugin2 "github.com/openshift/linuxptp-daemon/addons/plugin"
 	"github.com/openshift/linuxptp-daemon/pkg/plugin"
 )
 
+// PluginMapping is a map of plugin names to their respective constructors
 var PluginMapping = map[string]plugin.New{
-	"reference": generic.Reference,
-	"e810":      intel.E810,
+	"reference":  generic.Reference,
+	plugin2.E810: intel.E810,
 }

--- a/addons/plugin/naming.go
+++ b/addons/plugin/naming.go
@@ -1,0 +1,8 @@
+package plugin
+
+const (
+	// E810 is the name of the Intel E810 plugin
+	E810 = "e810"
+	// Gen is the name of the generic plugin
+	Gen = "generic"
+)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -80,7 +80,7 @@ func main() {
 	// The name of NodePtpDevice CR for this node is equal to the node name
 	var stdoutToSocket = false
 	if val, ok := os.LookupEnv("LOGS_TO_SOCKET"); ok && val != "" {
-		if ret, err := strconv.ParseBool(val); err == nil {
+		if ret, err2 := strconv.ParseBool(val); err2 == nil {
 			stdoutToSocket = ret
 		}
 	}
@@ -154,12 +154,12 @@ func main() {
 			}
 
 			nodeProfile := filepath.Join(cp.profileDir, nodeName)
-			if _, err := os.Stat(nodeProfile); err != nil {
-				if os.IsNotExist(err) {
+			if _, err2 := os.Stat(nodeProfile); err2 != nil {
+				if os.IsNotExist(err2) {
 					glog.Infof("ptp profile doesn't exist for node: %v", nodeName)
 					continue
 				} else {
-					glog.Errorf("error stating node profile %v: %v", nodeName, err)
+					glog.Errorf("error stating node profile %v: %v", nodeName, err2)
 					continue
 				}
 			}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -94,8 +94,8 @@ func GetKubeConfig() (*rest.Config, error) {
 	}
 	// If no in-cluster config, try the default location in the user's home directory
 	if usr, err := user.Current(); err == nil {
-		kubeConfig := filepath.Join(usr.HomeDir, ".kube", "config")
-		return configFromFlags(kubeConfig)
+		config := filepath.Join(usr.HomeDir, ".kube", "config")
+		return configFromFlags(config)
 	}
 
 	return nil, fmt.Errorf("could not locate a kubeconfig")

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -711,6 +711,10 @@ func addFlagsForMonitor(process string, configOpts *string, conf *ptp4lConf, std
 			}
 		}
 	case "ts2phc":
+		if !strings.Contains(*configOpts, "-m") {
+			glog.Info("adding -m to print messages to stdout for ts2phcS to use prometheus exporter")
+			*configOpts = fmt.Sprintf("%s -m", *configOpts)
+		}
 	}
 
 }

--- a/pkg/daemon/plugin.go
+++ b/pkg/daemon/plugin.go
@@ -40,18 +40,18 @@ func registerPlugin(name string) (*plugin.Plugin, *interface{}) {
 
 func (pm *PluginManager) OnPTPConfigChange(nodeProfile *ptpv1.PtpProfile) {
 	for pluginName, pluginObject := range pm.plugins {
-		pluginObject.OnPTPConfigChange(pm.data[pluginName], nodeProfile)
+		_ = pluginObject.OnPTPConfigChange(pm.data[pluginName], nodeProfile)
 	}
 }
 
 func (pm *PluginManager) AfterRunPTPCommand(nodeProfile *ptpv1.PtpProfile, command string) {
 	for pluginName, pluginObject := range pm.plugins {
-		pluginObject.AfterRunPTPCommand(pm.data[pluginName], nodeProfile, command)
+		_ = pluginObject.AfterRunPTPCommand(pm.data[pluginName], nodeProfile, command)
 	}
 }
 
 func (pm *PluginManager) PopulateHwConfig(hwconfigs *[]ptpv1.HwConfig) {
 	for pluginName, pluginObject := range pm.plugins {
-		pluginObject.PopulateHwConfig(pm.data[pluginName], hwconfigs)
+		_ = pluginObject.PopulateHwConfig(pm.data[pluginName], hwconfigs)
 	}
 }

--- a/pkg/debug/debug_test.go
+++ b/pkg/debug/debug_test.go
@@ -1,8 +1,9 @@
 package debug_test
 
 import (
-	"github.com/openshift/linuxptp-daemon/pkg/debug"
 	"testing"
+
+	"github.com/openshift/linuxptp-daemon/pkg/debug"
 )
 
 func TestPrintALLState_ChangesStateAndSetsResetGM(t *testing.T) {

--- a/pkg/dpll-netlink/dpll-uapi.go
+++ b/pkg/dpll-netlink/dpll-uapi.go
@@ -1,7 +1,7 @@
 // Port definitions from <kernel-root>/include/uapi/linux/dpll.h and
 // tools/net/ynl/generated/dpll-user.h
 
-package dpll_netlink
+package dpllnetlink
 
 import (
 	"encoding/json"

--- a/pkg/dpll-netlink/dpll.go
+++ b/pkg/dpll-netlink/dpll.go
@@ -1,6 +1,6 @@
 // Description: DPLL subsystem.
 
-package dpll_netlink
+package dpllnetlink
 
 import (
 	"errors"
@@ -88,9 +88,9 @@ func (c *Conn) DoDeviceIdGet(req DoDeviceIdGetRequest) (*DoDeviceIdGetReply, err
 
 	replies := make([]*DoDeviceIdGetReply, 0, len(msgs))
 	for _, m := range msgs {
-		ad, err := netlink.NewAttributeDecoder(m.Data)
-		if err != nil {
-			return nil, err
+		ad, err2 := netlink.NewAttributeDecoder(m.Data)
+		if err2 != nil {
+			return nil, err2
 		}
 
 		var reply DoDeviceIdGetReply
@@ -101,8 +101,8 @@ func (c *Conn) DoDeviceIdGet(req DoDeviceIdGetRequest) (*DoDeviceIdGetReply, err
 			}
 		}
 
-		if err := ad.Err(); err != nil {
-			return nil, err
+		if err3 := ad.Err(); err3 != nil {
+			return nil, err3
 		}
 
 		replies = append(replies, &reply)
@@ -127,6 +127,7 @@ type DoDeviceIdGetReply struct {
 	Id uint32
 }
 
+// ParseDeviceReplies  parses netlink messages into DoDeviceGetReply structs.
 func ParseDeviceReplies(msgs []genetlink.Message) ([]*DoDeviceGetReply, error) {
 	replies := make([]*DoDeviceGetReply, 0, len(msgs))
 	for _, m := range msgs {
@@ -159,8 +160,8 @@ func ParseDeviceReplies(msgs []genetlink.Message) ([]*DoDeviceGetReply, error) {
 			}
 		}
 
-		if err := ad.Err(); err != nil {
-			return nil, err
+		if err2 := ad.Err(); err2 != nil {
+			return nil, err2
 		}
 
 		replies = append(replies, &reply)
@@ -209,7 +210,6 @@ func (c *Conn) DoDeviceGet(req DoDeviceGetRequest) (*DoDeviceGetReply, error) {
 
 // DumpDeviceGet wraps the "device-get" operation:
 // Get list of DPLL devices (dump) or attributes of a single dpll device
-
 func (c *Conn) DumpDeviceGet() ([]*DoDeviceGetReply, error) {
 	// No attribute arguments.
 	var b []byte
@@ -252,6 +252,7 @@ type DoDeviceGetReply struct {
 	Type          uint32
 }
 
+// ParsePinReplies parses netlink messages into DoPinGetReply structs.
 func ParsePinReplies(msgs []genetlink.Message) ([]*DoPinGetReply, error) {
 	replies := make([]*DoPinGetReply, 0, len(msgs))
 
@@ -341,8 +342,8 @@ func ParsePinReplies(msgs []genetlink.Message) ([]*DoPinGetReply, error) {
 				log.Println(ad.Bytes())
 			}
 		}
-		if err := ad.Err(); err != nil {
-			return nil, err
+		if err2 := ad.Err(); err2 != nil {
+			return nil, err2
 		}
 		replies = append(replies, &reply)
 	}
@@ -384,6 +385,7 @@ func (c *Conn) DoPinGet(req DoPinGetRequest) (*DoPinGetReply, error) {
 	return replies[0], nil
 }
 
+// DumpPinGet wraps the "pin-get" operation:
 func (c *Conn) DumpPinGet() ([]*DoPinGetReply, error) {
 	ae := netlink.NewAttributeEncoder()
 

--- a/pkg/dpll/dpll_test.go
+++ b/pkg/dpll/dpll_test.go
@@ -88,7 +88,7 @@ func getTestData(source event.EventSource, pinType uint32) []DpllTestCase {
 				Mode:          1,
 				ModeSupported: 0,
 				LockStatus: func() uint32 {
-					if pinType == 2 {
+					if pinType == 2 { //TODO: This always return 4 ????
 						return 4 // holdover
 					} else {
 						return 4 // locked

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -217,9 +217,9 @@ func Init(nodeName string, stdOutToSocket bool, socketName string, processChanne
 	}
 	StateRegisterer = NewStateNotifier()
 	return ptpEvent
-
 }
 
+// GetLogData ... get log data for event
 func (e *EventChannel) GetLogData() string {
 	logData := make([]string, 0, len(e.Values))
 	for k, v := range e.Values {
@@ -507,7 +507,7 @@ func (e *EventHandler) toString() string {
 	// update if DPLL holdover is out of spec
 	out := strings.Builder{}
 	for cfgName, eData := range e.data {
-		out.WriteString("  data key : " + string(cfgName) + "\r\n")
+		out.WriteString("  data key : " + cfgName + "\r\n")
 		for _, data := range eData {
 			out.WriteString("  state: " + string(data.State) + "\r\n")
 			out.WriteString("  process name: " + string(data.ProcessName) + "\r\n")
@@ -519,8 +519,8 @@ func (e *EventHandler) toString() string {
 				}
 				out.WriteString("  signal source: " + string(dataDetails.signalSource) + "\r\n")
 				out.WriteString("  details state: " + string(dataDetails.State) + "\r\n")
-				out.WriteString("  log: " + string(dataDetails.logData) + "\r\n")
-				out.WriteString("  iface: " + string(dataDetails.IFace) + "\r\n")
+				out.WriteString("  log: " + dataDetails.logData + "\r\n")
+				out.WriteString("  iface: " + dataDetails.IFace + "\r\n")
 				out.WriteString("  source lost : " + strconv.FormatBool(dataDetails.sourceLost) + "\r\n")
 			}
 			out.WriteString("-----\r\n")
@@ -825,8 +825,7 @@ func (e *EventHandler) GetPTPState(source EventSource, cfgName string) PTPState 
 
 // UpdateClockStateMetrics ...
 func (e *EventHandler) UpdateClockStateMetrics(state PTPState, process, iFace string) {
-	labels := prometheus.Labels{}
-	labels = prometheus.Labels{
+	labels := prometheus.Labels{
 		"process": process, "node": e.nodeName, "iface": iFace}
 	if state == PTP_LOCKED {
 		e.clockMetric.With(labels).Set(1)
@@ -908,10 +907,9 @@ func (e *EventHandler) updateMetrics(cfgName string, process EventSource, proces
 			s.Labels = map[string]string{"from": pName, "node": e.nodeName,
 				"process": string(process), "iface": iface}
 			s.Value = dataValue
-			d.Metrics[dataType].GaugeMetric.With(s.Labels).Set(dataValue)
+			d.Metrics[dataType].GaugeMetric.With(s.Labels).Set(s.Value)
 		}
 	}
-
 }
 
 func registerMetrics(m *prometheus.GaugeVec) {

--- a/pkg/event/event_test.go
+++ b/pkg/event/event_test.go
@@ -25,9 +25,7 @@ var (
 )
 
 func monkeyPatch() {
-
 	event.PMCGMGetter = func(cfgName string) (protocol.GrandmasterSettings, error) {
-		cfgName = strings.Replace(cfgName, event.TS2PHCProcessName, event.PTP4lProcessName, 1)
 		return protocol.GrandmasterSettings{
 			ClockQuality: fbprotocol.ClockQuality{
 				ClockClass:              0,
@@ -47,7 +45,6 @@ func monkeyPatch() {
 		}, nil
 	}
 	event.PMCGMSetter = func(cfgName string, g protocol.GrandmasterSettings) error {
-		cfgName = strings.Replace(cfgName, event.TS2PHCProcessName, event.PTP4lProcessName, 1)
 		return nil
 	}
 }

--- a/pkg/event/pubsub.go
+++ b/pkg/event/pubsub.go
@@ -38,9 +38,7 @@ func (n *StateNotifier) Unregister(s Subscriber) {
 	id := fmt.Sprintf("%s_%s", s.Topic(), s.ID())
 	n.Lock()
 	defer n.Unlock()
-	if _, ok := n.Subscribers[id]; ok {
-		delete(n.Subscribers, id)
-	}
+	delete(n.Subscribers, id)
 }
 
 func (n *StateNotifier) monitor() {
@@ -74,5 +72,4 @@ func NewStateNotifier() *StateNotifier {
 	return &StateNotifier{
 		Subscribers: make(map[string]Subscriber),
 	}
-
 }

--- a/pkg/event/stats_test.go
+++ b/pkg/event/stats_test.go
@@ -133,9 +133,6 @@ func Test_updateStats(t *testing.T) {
 				dd.UpdateState()
 				assert.Equal(t, test.wantedState, dd.State, test.desc)
 			}
-
 		}
-
 	}
-
 }

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -9,6 +9,7 @@ type OnPTPConfigChange func(*interface{}, *ptpv1.PtpProfile) error
 type PopulateHwConfig func(*interface{}, *[]ptpv1.HwConfig) error
 type AfterRunPTPCommand func(*interface{}, *ptpv1.PtpProfile, string) error
 
+// Plugin is a struct to hold the plugin data
 type Plugin struct {
 	Name               string
 	Options            interface{}

--- a/pkg/pmc/pmc.go
+++ b/pkg/pmc/pmc.go
@@ -1,6 +1,7 @@
 package pmc
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -84,13 +85,14 @@ func RunPMCExpGetGMSettings(configFileName string) (g protocol.GrandmasterSettin
 
 	for i := 0; i < numRetry; i++ {
 		if err = e.Send(cmdStr + "\n"); err == nil {
-			result, matches, err := e.Expect(regexp.MustCompile(g.RegEx()), cmdTimeout)
-			if err != nil {
-				if _, ok := err.(expect.TimeoutError); ok {
+			result, matches, err2 := e.Expect(regexp.MustCompile(g.RegEx()), cmdTimeout)
+			if err2 != nil {
+				var timeoutError expect.TimeoutError
+				if errors.As(err2, &timeoutError) {
 					continue
 				}
-				glog.Errorf("pmc result match error %v", err)
-				return g, err
+				glog.Errorf("pmc result match error %v", err2)
+				return g, err2
 			}
 			glog.Infof("pmc result: %s", result)
 			for i, m := range matches[1:] {
@@ -127,10 +129,10 @@ func RunPMCExpSetGMSettings(configFileName string, g protocol.GrandmasterSetting
 	}()
 
 	if err = e.Send(cmdStr + "\n"); err == nil {
-		result, _, err := e.Expect(regexp.MustCompile(g.RegEx()), cmdTimeout)
-		if err != nil {
-			glog.Errorf("pmc result match error %v", err)
-			return err
+		result, _, err2 := e.Expect(regexp.MustCompile(g.RegEx()), cmdTimeout)
+		if err2 != nil {
+			glog.Errorf("pmc result match error %v", err2)
+			return err2
 		}
 		glog.Infof("pmc result: %s", result)
 	}

--- a/pkg/protocol/type.go
+++ b/pkg/protocol/type.go
@@ -2,9 +2,10 @@ package protocol
 
 import (
 	"fmt"
-	"github.com/golang/glog"
 	"strconv"
 	"strings"
+
+	"github.com/golang/glog"
 
 	"github.com/facebook/time/ptp/protocol"
 )
@@ -36,7 +37,6 @@ func (g *GrandmasterSettings) String() string {
 	if g == nil {
 		glog.Error("returned empty grandmasterSettings")
 		return ""
-
 	}
 	result := fmt.Sprintf(" clockClass              %d\n", g.ClockQuality.ClockClass)
 	result += fmt.Sprintf(" clockAccuracy           0x%x\n", g.ClockQuality.ClockAccuracy)
@@ -118,10 +118,7 @@ func btoi(b bool) uint8 {
 }
 
 func stob(s string) bool {
-	if s == "1" {
-		return true
-	}
-	return false
+	return s == "1"
 }
 
 func stou8(s string) uint8 {

--- a/pkg/synce/synce.go
+++ b/pkg/synce/synce.go
@@ -383,10 +383,9 @@ func PrintOption2Networks() {
 
 // ClockQuality ... return ClockQuality details
 func (c *Config) ClockQuality(qualityInfo QualityLevelInfo) (clock string, ql QualityLevelInfo) {
-
 	if c.ExtendedTlv == ExtendedTLV_DISABLED {
 		qualityInfo.ExtendedSSM = QL_DEFAULT_ENHSSM //**If extended SSM is not enabled, it's implicitly assumed as 0xFF
-	} else if c.ExtendedTlv == ExtendedTLV_ENABLED && qualityInfo.ExtendedSSM == QL_DEFAULT_SSM { // extQL is nto read
+	} else if c.ExtendedTlv == ExtendedTLV_ENABLED && qualityInfo.ExtendedSSM == QL_DEFAULT_SSM { // extQL is not read
 		return "", qualityInfo
 	}
 	if c.NetworkOption == SYNCE_NETWORK_OPT_1 {

--- a/pkg/synce/synce_test.go
+++ b/pkg/synce/synce_test.go
@@ -105,11 +105,9 @@ func Test_GetClockQuality(t *testing.T) {
 		})
 		assert.Equal(t, tt.expectedClock, clock)
 	}
-
 }
 
 func TestParseLog(t *testing.T) {
-
 	// Printing results
 	InitLogTestCase()
 	for _, l := range logTestCases {
@@ -117,7 +115,6 @@ func TestParseLog(t *testing.T) {
 		assert.Equal(t, l.expectedDevice, entry.Device, entry.String())
 		assert.Equal(t, l.expectedExtSource, entry.ExtSource, entry.String())
 		assert.Equal(t, l.expectedSource, entry.Source, entry.String())
-
 	}
 }
 

--- a/pkg/ublox/ublox.go
+++ b/pkg/ublox/ublox.go
@@ -119,9 +119,9 @@ func (u *UBlox) queryVersion(command string, promptRE *regexp.Regexp) (result st
 		return
 	}
 	defer func(e *expect.GExpect) {
-		err := e.Close()
-		if err != nil {
-			glog.Errorf("error closing expect %s", err)
+		err2 := e.Close()
+		if err2 != nil {
+			glog.Errorf("error closing expect %s", err2)
 		}
 	}(e)
 	if err = e.Send(fmt.Sprintf("%s -p %s", UBXCommand, command) + "\n"); err == nil {
@@ -142,9 +142,9 @@ func (u *UBlox) Query(command string, promptRE *regexp.Regexp) (result string, m
 		return
 	}
 	defer func(e *expect.GExpect) {
-		err := e.Close()
-		if err != nil {
-			glog.Errorf("error closing expect %s", err)
+		err2 := e.Close()
+		if err2 != nil {
+			glog.Errorf("error closing expect %s", err2)
 		}
 	}(e)
 	if err = e.Send(fmt.Sprintf("%s %s", UBXCommand, command) + "\n"); err == nil {
@@ -174,7 +174,7 @@ func (u *UBlox) Query(command string, promptRE *regexp.Regexp) (result string, m
 // TODO: Should read ACK-ACK to confirm right and read the item
 func (u *UBlox) EnableDisableVoltageController(command string, value int) ([]byte, error) {
 	if u.protoVersion == nil {
-		return []byte{}, fmt.Errorf("Cannot query UBlox without protocol version ")
+		return []byte{}, fmt.Errorf("cannot query UBlox without protocol version ")
 	}
 	commandArgs := []string{"/usr/bin/bash", "-c", fmt.Sprintf("\"%s  -v 1 -P %s  -p %s,%d\"", UBXCommand, *u.protoVersion, command, value)}
 
@@ -197,11 +197,10 @@ func (u *UBlox) query(command string, promptRE *regexp.Regexp) (string, error) {
 	}
 	glog.Infof("Ublox cmd %s returned\n %s", fmt.Sprintf("ubxtool %s", command), stdBuffer.String())
 	return match(stdBuffer.String(), promptRE)
-
 }
 
 func match(stdout string, ubLoxRegex *regexp.Regexp) (string, error) {
-	match := ubLoxRegex.FindStringSubmatch(string(stdout))
+	match := ubLoxRegex.FindStringSubmatch(stdout)
 	if len(match) > 0 {
 		return match[1], nil
 	}
@@ -318,6 +317,7 @@ func (u *UBlox) EnableNMEA() {
 	}
 }
 
+// ExtractOffset ...
 func ExtractOffset(output string) int64 {
 	// Find the line that contains "tAcc"
 	lines := strings.Split(output, "\n")
@@ -337,6 +337,7 @@ func ExtractOffset(output string) int64 {
 	return -1
 }
 
+// ExtractAntennaStatus ...
 func ExtractNavStatus(output string) int64 {
 	// Find the line that contains "gpsFix"
 	lines := strings.Split(output, "\n")

--- a/pkg/ublox/ublox_test.go
+++ b/pkg/ublox/ublox_test.go
@@ -89,7 +89,7 @@ func Test_Query(t *testing.T) {
 	t.Skip("Skipping test, ubxtool needs to be installed")
 	u := ublox.UBlox{}
 	//assert.Nil(t, e)
-	assert.NotNil(t, u)
+	assert.NotNil(t, &u)
 	ss, s, err := u.Query("-V", regexp.MustCompile("Version"))
 	assert.NotEmpty(t, ss)
 	assert.NotEmpty(t, s[0])


### PR DESCRIPTION
Added check to verify dependency  and linter fixes 

The dependency Checker iterates over the interfaces (p.ifaces) associated with the _ptpProcess.
Checking for DPLL Requirement:
       For each interface, it checks if the source is either GNSS or PPS, AND  if the process name is ts2phcProcessName.
adds dpll.DPLL_PROCESSNAME to the deps map.
Adding GPSD and GPSPIPE Dependencies:
   If the interface source is GNSS and the process name is ts2phcProcessName, it adds GPSD_PROCESSNAME and GPSPIPE_PROCESSNAME to the deps map