### PR TITLE
OCPBUGS-43510: Incorrect Clock Class Transition Behavior in T-GM and PTP Holdover States

### DIFF
--- a/addons/intel/e810.go
+++ b/addons/intel/e810.go
@@ -203,8 +203,8 @@ func AfterRunPTPCommandE810(data *interface{}, nodeProfile *ptpv1.PtpProfile, co
 					glog.Infof("Running /usr/bin/ubxtool with args %s", strings.Join(ublxArgs, ", "))
 					stdout, err = exec.Command("/usr/local/bin/ubxtool", ublxArgs...).CombinedOutput()
 					//stdout, err = exec.Command("/usr/local/bin/ubxtool", "-p", "STATUS").CombinedOutput()
-					_data := *data
 					if data != nil && ublxOpt.ReportOutput {
+						_data := *data
 						glog.Infof("Saving status to hwconfig: %s", string(stdout))
 						var pluginData *E810PluginData = _data.(*E810PluginData)
 						_pluginData := *pluginData

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -815,7 +815,7 @@ func (p *ptpProcess) updateClockClass(c *net.Conn) {
 			glog.Infof("clock class change value not found via PMC")
 		}
 	} else {
-		glog.Error("error parsing PMC util for clock class change event")
+		glog.Errorf("error parsing PMC util for clock class change event %s", e.Error())
 	}
 }
 

--- a/pkg/dpll/dpll.go
+++ b/pkg/dpll/dpll.go
@@ -827,7 +827,6 @@ func (d *DpllConfig) holdover() {
 			// Ans : continue to calculate offset here and if source is returned and actual offset is within threshold then go to locked state and cancel this timer
 			d.phaseOffset = int64(math.Round((d.slope / 1000) * time.Since(start).Seconds()))
 			glog.Infof("(%s) time since holdover start %f, offset %d nanosecond holdover %s", d.iface, time.Since(start).Seconds(), d.phaseOffset, strconv.FormatBool(d.onHoldover))
-			d.sendDpllEvent()
 			if !d.isLocalOffsetInRange() { // when holdover verify with local max holdover not with regular threshold
 				// once not in range, it will not go back to in range until holdover is closed
 				glog.Infof("offset is out of range: %v, max %v",
@@ -837,6 +836,7 @@ func (d *DpllConfig) holdover() {
 				d.sendDpllEvent()
 				return
 			}
+			d.sendDpllEvent()
 		case <-timeout:
 			d.inSpec = false // not in HO, Out of spec
 			d.state = event.PTP_FREERUN

--- a/pkg/dpll/dpll_test.go
+++ b/pkg/dpll/dpll_test.go
@@ -58,7 +58,7 @@ func getTestData(source event.EventSource, pinType uint32) []DpllTestCase {
 		expectedPhaseStatus:       0, //no phase status event for eec
 		expectedPhaseOffset:       dpll.FaultyPhaseOffset * 1000000,
 		expectedFrequencyStatus:   2, // locked
-		expectedInSpecState:       true,
+		expectedInSpecState:       false,
 		desc:                      "1.locked frequency status, unknonw Phase status ",
 	}, {
 		reply: &nl.DoDeviceGetReply{

--- a/pkg/event/stats.go
+++ b/pkg/event/stats.go
@@ -11,7 +11,7 @@ type DDetails []*DataDetails
 
 // Data ...
 type Data struct {
-	ProcessName EventSource // ts2phc  // dppl
+	ProcessName EventSource // ts2phc  // dpll
 	Details     DDetails    // array of iface and  offset
 	State       PTPState    // have the worst state here
 	logData     string      // iface that is connected to GNSS
@@ -45,7 +45,7 @@ func (d *Data) UpdateState() {
 	state := PTP_UNKNOWN
 	for _, detail := range d.Details { // 2 ts2phc or 2 dpll etc
 		switch detail.State {
-		case PTP_FREERUN: // if its free ru and main state is not holdover then this is the state
+		case PTP_FREERUN: // if its free run and main state is not holdover then this is the state
 			if state != PTP_HOLDOVER {
 				state = detail.State
 			}


### PR DESCRIPTION
This PR does not address the issue of Clock Class being out of spec for the Time Grandmaster (T-GM) with SyncE. However, it introduces a fix to transition the clock state from HOLDOVER to FREERUN when an out-of-spec state is detected.
Key Changes:

    Scenario:
        T-GM → GNSS Loss → Clock Class 7 (in Holdover)
        Out-of-spec state detected → Transition to FREERUN with Clock Class 248

    Note:
        SyncE implementation requires Out-of-Spec Holdover, which is not supported in this PR. Further work will be needed to handle this specific SyncE case.
        
This PR also fixes the updating of clock accuracy for each T-GM state and introduces periodic updates to clock accuracy during the HOLDOVER state based on changes in DPLL offsets.