### PR TITLE
fix fips complaint issue

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -11,4 +11,4 @@ fi
 export GO15VENDOREXPERIMENT=1
 export GOBIN=${PWD}/bin
 export GOPATH=${PWD}/.gopath
-go build --mod=vendor -tags no_openssl "$@" -o bin/ptp ${REPO_PATH}/cmd
+go build --mod=vendor "$@" -o bin/ptp ${REPO_PATH}/cmd


### PR DESCRIPTION
Fix fips complaint issue to enable fips support 
Go compliance shim [14] [openshift-4.18][linuxptp-daemon]: non-compliant: eliminated no_openssl