### PR TITLE
Enhance Holdover Management and Fault Reporting and holdover in ts2phc/Dpll

### DIFF
--- a/pkg/ublox/ublox_test.go
+++ b/pkg/ublox/ublox_test.go
@@ -88,8 +88,7 @@ func TestFindProtoVersion(t *testing.T) {
 func Test_Query(t *testing.T) {
 	t.Skip("Skipping test, ubxtool needs to be installed")
 	u := ublox.UBlox{}
-	//assert.Nil(t, e)
-	assert.NotNil(t, u)
+	assert.NotNil(t, &u)
 	ss, s, err := u.Query("-V", regexp.MustCompile("Version"))
 	assert.NotEmpty(t, ss)
 	assert.NotEmpty(t, s[0])


### PR DESCRIPTION

1. Removed NMEA lost updates from metrics and added fault reporting. The ts2phc holdover feature will now manage ts2phc to continue running even when NMEA updates are lost.
2. Added logic to handle Holdover with consideration for whether frequency traceability is available (SyncE enabled) or not. 

Three variables are used in the PTP configuration to manage Holdover: `LocalMaxHoldoverOffset`, `LocalHoldoverTimeout`, and `MaxInSpecOffset`. 

- Holdover timing transitions based on whether frequency traceability is enabled:
  - If SyncE is not enabled (frequency traceability is false), a slope calculation is used to determine the time to reach `MaxInSpecOffset`.
  - If SyncE is enabled, `LocalHoldoverTimeout` is used to calculate the total holdover duration.
  
Additionally, updated the logic for clock class transitions:
- Changed the behavior to announce a transition to FREE RUN from class 7 when `MaxInSpecOffset` is reached and SyncE is not available.
- Added logic to manage ClockClass 140 when crossing `MaxInSpecOffset` with SyncE enabled. 

