### PR TITLE
Add missing LISTENING port states to the list of states reported in metrics

### DIFF
--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -64,6 +64,7 @@ const (
 	MASTER
 	FAULTY
 	UNKNOWN
+	LISTENING
 )
 
 type masterOffsetInterface struct { // by slave iface with masked index
@@ -146,7 +147,7 @@ var (
 			Namespace: PTPNamespace,
 			Subsystem: PTPSubsystem,
 			Name:      "interface_role",
-			Help:      "0 = PASSIVE, 1 = SLAVE, 2 = MASTER, 3 = FAULTY, 4 = UNKNOWN",
+			Help:      "0 = PASSIVE, 1 = SLAVE, 2 = MASTER, 3 = FAULTY, 4 = UNKNOWN, 5 = LISTENING",
 		}, []string{"process", "node", "iface"})
 
 	ProcessStatus = prometheus.NewGaugeVec(
@@ -665,6 +666,8 @@ func extractPTP4lEventState(output string) (portId int, role ptpPortRole) {
 		role = MASTER
 	} else if strings.Contains(output, "FAULT_DETECTED") || strings.Contains(output, "SYNCHRONIZATION_FAULT") {
 		role = FAULTY
+	} else if strings.Contains(output, "UNCALIBRATED to LISTENING") || strings.Contains(output, "SLAVE to LISTENING") {
+		role = LISTENING
 	} else {
 		portId = 0
 	}


### PR DESCRIPTION
This is to add support for the LISTENING port state in metrics. Using a new integer value 5 for backward compatibility (so as to not change previous mappings). 
The LISTENING state is reached when multiple follower ports are receiving PTP frames but only one is selected to become a SLAVE, in slave only mode. The other ports state should be LISTENING (whether they receive PTP frames are received or not).