### PR TITLE
OCPBUGS-45266: Reduce unwanted NMEA messages

### DIFF
--- a/addons/intel/e810.go
+++ b/addons/intel/e810.go
@@ -76,12 +76,33 @@ func getDefaultUblxCmds() []E810UblxCmds {
 		ReportOutput: false,
 		Args:         []string{"-p", "CFG-MSG,0xf0,0x03,0"},
 	}
+	// Ublx command to disable VTG messages
+	cfgMsgDisableVTG := E810UblxCmds{
+		ReportOutput: false,
+		Args:         []string{"-z", "CFG-MSGOUT-NMEA_ID_VTG_I2C,0"},
+	}
+	// Ublx command to disable GST messages
+	cfgMsgDisableGST := E810UblxCmds{
+		ReportOutput: false,
+		Args:         []string{"-z", "CFG-MSGOUT-NMEA_ID_GST_I2C,0"},
+	}
+	// Ublx command to disable ZDA messages
+	cfgMsgDisableZDA := E810UblxCmds{
+		ReportOutput: false,
+		Args:         []string{"-z", "CFG-MSGOUT-NMEA_ID_ZDA_I2C,0"},
+	}
+	// Ublx command to disable GBS messages
+	cfgMsgDisableGBS := E810UblxCmds{
+		ReportOutput: false,
+		Args:         []string{"-z", "CFG-MSGOUT-NMEA_ID_GBS_I2C,0"},
+	}
 	// Ublx command to save configuration to storage
 	cfgSave := E810UblxCmds{
 		ReportOutput: false,
 		Args:         []string{"-p", "SAVE"},
 	}
-	return []E810UblxCmds{cfgMsgNavClock, cfgMsgNavStatus, cfgMsgDisableSA, cfgMsgDisableSV, cfgSave}
+	return []E810UblxCmds{cfgMsgNavClock, cfgMsgNavStatus, cfgMsgDisableSA, cfgMsgDisableSV,
+		cfgMsgDisableVTG, cfgMsgDisableGST, cfgMsgDisableZDA, cfgMsgDisableGBS, cfgSave}
 }
 
 func OnPTPConfigChangeE810(data *interface{}, nodeProfile *ptpv1.PtpProfile) error {

--- a/pkg/daemon/gpspipe.go
+++ b/pkg/daemon/gpspipe.go
@@ -2,12 +2,13 @@ package daemon
 
 import (
 	"fmt"
-	"github.com/openshift/linuxptp-daemon/pkg/config"
 	"os"
 	"os/exec"
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/openshift/linuxptp-daemon/pkg/config"
 
 	"github.com/golang/glog"
 )
@@ -89,7 +90,7 @@ func (gp *gpspipe) CmdInit() {
 	if gp.name == "" {
 		gp.name = GPSPIPE_PROCESSNAME
 	}
-	gp.cmdLine = fmt.Sprintf("/usr/local/bin/gpspipe -v -r -l -o %s", gp.SerialPort())
+	gp.cmdLine = fmt.Sprintf("/usr/local/bin/gpspipe -v -R -l -o %s", gp.SerialPort())
 }
 
 // CmdRun ... run gpspipe


### PR DESCRIPTION
This commit reduces the number of NMEA messages going to the log and through the `ts2phc` to the essential two message types: GNRMC and GNGGA.

/cc @aneeshkp @jzding @josephdrichard 