### PR TITLE
OCPBUGS-45308: PTP holdover time should be kept for 4 hours 

### DIFF
--- a/addons/intel/e810.go
+++ b/addons/intel/e810.go
@@ -74,12 +74,33 @@ func getDefaultUblxCmds() []E810UblxCmds {
 		ReportOutput: false,
 		Args:         []string{"-p", "CFG-MSG,0xf0,0x03,0"},
 	}
+	// Ublx command to disable VTG messages
+	cfgMsgDisableVTG := E810UblxCmds{
+		ReportOutput: false,
+		Args:         []string{"-z", "CFG-MSGOUT-NMEA_ID_VTG_I2C,0"},
+	}
+	// Ublx command to disable GST messages
+	cfgMsgDisableGST := E810UblxCmds{
+		ReportOutput: false,
+		Args:         []string{"-z", "CFG-MSGOUT-NMEA_ID_GST_I2C,0"},
+	}
+	// Ublx command to disable ZDA messages
+	cfgMsgDisableZDA := E810UblxCmds{
+		ReportOutput: false,
+		Args:         []string{"-z", "CFG-MSGOUT-NMEA_ID_ZDA_I2C,0"},
+	}
+	// Ublx command to disable GBS messages
+	cfgMsgDisableGBS := E810UblxCmds{
+		ReportOutput: false,
+		Args:         []string{"-z", "CFG-MSGOUT-NMEA_ID_GBS_I2C,0"},
+	}
 	// Ublx command to save configuration to storage
 	cfgSave := E810UblxCmds{
 		ReportOutput: false,
 		Args:         []string{"-p", "SAVE"},
 	}
-	return []E810UblxCmds{cfgMsgNavClock, cfgMsgNavStatus, cfgMsgDisableSA, cfgMsgDisableSV, cfgSave}
+	return []E810UblxCmds{cfgMsgNavClock, cfgMsgNavStatus, cfgMsgDisableSA, cfgMsgDisableSV,
+		cfgMsgDisableVTG, cfgMsgDisableGST, cfgMsgDisableZDA, cfgMsgDisableGBS, cfgSave}
 }
 
 func OnPTPConfigChangeE810(data *interface{}, nodeProfile *ptpv1.PtpProfile) error {

--- a/addons/intel/e810.go
+++ b/addons/intel/e810.go
@@ -64,12 +64,22 @@ func getDefaultUblxCmds() []E810UblxCmds {
 		Args:         []string{"-p", "CFG-MSG,1,3,1"},
 	}
 
+	// Ublx command to disable SA messages
+	cfgMsgDisableSA := E810UblxCmds{
+		ReportOutput: false,
+		Args:         []string{"-p", "CFG-MSG,0xf0,0x02,0"},
+	}
+	// Ublx command to disable SV messages
+	cfgMsgDisableSV := E810UblxCmds{
+		ReportOutput: false,
+		Args:         []string{"-p", "CFG-MSG,0xf0,0x03,0"},
+	}
 	// Ublx command to save configuration to storage
 	cfgSave := E810UblxCmds{
 		ReportOutput: false,
 		Args:         []string{"-p", "SAVE"},
 	}
-	return []E810UblxCmds{cfgMsgNavClock, cfgMsgNavStatus, cfgSave}
+	return []E810UblxCmds{cfgMsgNavClock, cfgMsgNavStatus, cfgMsgDisableSA, cfgMsgDisableSV, cfgSave}
 }
 
 func OnPTPConfigChangeE810(data *interface{}, nodeProfile *ptpv1.PtpProfile) error {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -815,9 +815,7 @@ func (p *ptpProcess) cmdRun(stdoutToSocket bool) {
 // for ts2phc along with processing metrics need to identify event
 func (p *ptpProcess) processPTPMetrics(output string) {
 	if p.name == ts2phcProcessName &&
-		(strings.Contains(output, NMEASourceDisabledIndicator) ||
-			strings.Contains(output, InvalidMasterTimestampIndicator) ||
-			strings.Contains(output, NMEASourceDisabledIndicator2)) &&
+		strings.Contains(output, NMEASourceDisabledIndicator) &&
 		!leap.LeapMgr.IsLeapInWindow(time.Now().UTC(), -2*time.Second, time.Second) { //TODO identify which interface lost nmea or 1pps
 		iface := p.ifaces.GetGMInterface().Name
 		p.ProcessTs2PhcEvents(faultyOffset, ts2phcProcessName, iface, map[event.ValueType]interface{}{event.NMEA_STATUS: int64(0)})

--- a/pkg/daemon/gpspipe.go
+++ b/pkg/daemon/gpspipe.go
@@ -2,12 +2,13 @@ package daemon
 
 import (
 	"fmt"
-	"github.com/openshift/linuxptp-daemon/pkg/config"
 	"os"
 	"os/exec"
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/openshift/linuxptp-daemon/pkg/config"
 
 	"github.com/golang/glog"
 )
@@ -89,7 +90,7 @@ func (gp *gpspipe) CmdInit() {
 	if gp.name == "" {
 		gp.name = GPSPIPE_PROCESSNAME
 	}
-	gp.cmdLine = fmt.Sprintf("/usr/local/bin/gpspipe -v -r -l -o %s", gp.SerialPort())
+	gp.cmdLine = fmt.Sprintf("/usr/local/bin/gpspipe -v -R -l -o %s", gp.SerialPort())
 }
 
 // CmdRun ... run gpspipe

--- a/pkg/debug/debug.go
+++ b/pkg/debug/debug.go
@@ -1,0 +1,214 @@
+package debug
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	DpllKey          = "DPLL"
+	Ts2phcKey        = "TS2PHC"
+	GnssKey          = "GNSS"
+	GmKey            = "GM"
+	OverallTs2phcKey = "OVER-ALL-TS2PHC"
+	OverallDpllKey   = "OVER-ALL-DPLL"
+	ClockClassKey    = "CC"
+)
+
+// Define some Unicode symbols for the icons
+var (
+	iconLocked     = "Locked"   // GNSS lock
+	iconFreeRun    = "FreeRun"  // Open lock
+	iconHoldOver   = "HoldOver" // Hold icon
+	iconAntenna    = "GNSS"
+	ts2phcIcon     = "ts2phc"
+	iconClockClass = "ClockClass"
+	dpllIcon       = "dpll"
+	state          = map[string]StateDB{}
+	requiredKeys   = []string{GmKey, GnssKey, OverallTs2phcKey, OverallDpllKey, ClockClassKey}
+	resetGM        bool
+)
+
+// StateDB stores the state of the system
+type StateDB struct {
+	State  interface{}
+	Offset interface{}
+}
+
+// getSate returns the icon corresponding to the given state string
+func getSate(s string) string {
+	ss := ""
+	switch s {
+	case "s0":
+		ss = iconFreeRun
+	case "s2", "s3":
+		ss = iconLocked
+	case "s1":
+		ss = iconHoldOver
+	}
+	return ss
+}
+
+// Node represents each node's state and offset
+type Node struct {
+	name   string
+	state  interface{}
+	iface  string
+	offset interface{}
+}
+
+// UpdateGMState updates the state of the Grand Master Clock (GM) and prints the tree if necessary
+func UpdateGMState(s string) {
+	if st, ok := state[GmKey]; !ok || st.State != s || resetGM {
+		state[GmKey] = StateDB{State: s}
+		resetGM = false
+		PrintTree()
+	}
+}
+
+// UpdateTs2phcState updates the state of the TS2PHC and sets resetGM to true if necessary
+func UpdateTs2phcState(s string, offset interface{}, iface string) {
+	key := Ts2phcKey + "-" + iface
+	if iface == OverallTs2phcKey {
+		key = iface
+	}
+	if st, ok := state[key]; !ok || st.State.(string) != s {
+		state[key] = StateDB{State: s, Offset: offset}
+		resetGM = true
+	}
+}
+
+// UpdateDPLLState updates the state of the DPLL and sets resetGM to true if necessary
+func UpdateDPLLState(s string, offset interface{}, iface string) {
+	key := DpllKey + "-" + iface
+	if iface == OverallDpllKey {
+		key = iface
+	}
+	if st, ok := state[key]; !ok || st.State.(string) != s {
+		state[key] = StateDB{State: s, Offset: offset}
+		resetGM = true
+	}
+}
+
+// UpdateGNSSState updates the state of the GNSS and sets resetGM to true if necessary
+func UpdateGNSSState(s string, offset interface{}) {
+	if st, ok := state[GnssKey]; !ok || st.State.(string) != s {
+		state[GnssKey] = StateDB{State: s, Offset: offset}
+		resetGM = true
+	}
+}
+
+// UpdateClockClass updates the state of the Clock Class and sets resetGM to true if necessary
+func UpdateClockClass(ClassTo uint8) {
+	if st, ok := state[ClockClassKey]; !ok || ClassTo != st.State.(uint8) {
+		state[ClockClassKey] = StateDB{State: ClassTo}
+		resetGM = true
+	}
+}
+
+// printTreeNode prints a tree node with its children
+func printTreeNode(parent Node, children []Node, indent string, isLast bool) {
+	// Print the parent node with the appropriate indent
+	connector := "├──"
+	if isLast {
+		connector = "└──"
+	}
+
+	fmt.Printf("%s%s %s (State:%v)\n", indent, connector, parent.name, parent.state)
+
+	// Print the children nodes with an increased indent
+	childIndent := indent + "    "
+	for i, child := range children {
+		isLastChild := i == len(children)-1
+		printTreeNode(child, nil, childIndent, isLastChild)
+		fmt.Printf("%s    └── State: %s Iface: %s  Offset %v\n", childIndent, child.state, child.iface, child.offset)
+	}
+}
+
+// printTree prints the entire tree with its nodes
+func printTree(root Node, rootChildren map[Node][]Node) {
+	// Print the root node (GM)
+	fmt.Println(root.name + " (State:" + root.state.(string) + ")")
+	i := 0
+	for child, children := range rootChildren {
+		isLast := i == len(rootChildren)-1
+		printTreeNode(child, children, "*", isLast)
+		i++
+	}
+}
+
+// PrintTree prints the tree if all required keys are present
+func PrintTree() {
+	if !hasAllKeys(requiredKeys) {
+		return
+	}
+	clockClass := Node{
+		name:  iconClockClass,
+		state: state[ClockClassKey].State,
+	}
+
+	ss := getSate(state[GmKey].State.(string))
+	root := Node{
+		name:  "GM (Grand Master Clock)",
+		state: ss, // GM is synchronized
+	}
+	ss = getSate(state[GnssKey].State.(string))
+	gnss := Node{
+		name:  iconAntenna,
+		state: ss,
+	}
+
+	// Define the child nodes (ts2phc and DPLL)
+	ss = getSate(state[OverallTs2phcKey].State.(string))
+	ts2phc := Node{
+		name:  OverallTs2phcKey,
+		state: ss,
+	}
+	ss = getSate(state[OverallDpllKey].State.(string))
+	dpll := Node{
+		name:  OverallDpllKey,
+		state: ss,
+	}
+
+	// Define child nodes for ts2phc and DPLL
+	ts2phcChildren := []Node{}
+	dpllChildren := []Node{}
+
+	for k, v := range state {
+		if k == OverallTs2phcKey || k == OverallDpllKey || k == GmKey || k == GnssKey || k == ClockClassKey {
+			continue
+		}
+		ss = getSate(v.State.(string))
+		if strings.Split(k, "-")[0] == Ts2phcKey {
+			ts2phcChildren = append(ts2phcChildren, Node{name: ts2phcIcon, state: ss, iface: strings.Split(k, "-")[1], offset: v.Offset})
+		} else if strings.Split(k, "-")[0] == DpllKey {
+			dpllChildren = append(dpllChildren, Node{name: dpllIcon, state: ss, iface: strings.Split(k, "-")[1], offset: v.Offset})
+		}
+	}
+	// Map the children to their respective parent nodes
+	rootChildren := map[Node][]Node{
+		gnss:       {},
+		clockClass: {},
+		ts2phc:     ts2phcChildren,
+		dpll:       dpllChildren,
+	}
+
+	// Print the tree
+	printTree(root, rootChildren)
+}
+
+// hasAllKeys checks if all required keys are present in the state
+func hasAllKeys(keys []string) bool {
+	for _, key := range keys {
+		if _, ok := state[key]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// ClearState clears the state and resets resetGM
+func ClearState() {
+	state = map[string]StateDB{}
+	resetGM = false
+}

--- a/pkg/debug/debug_test.go
+++ b/pkg/debug/debug_test.go
@@ -1,0 +1,19 @@
+package debug_test
+
+import (
+	"github.com/openshift/linuxptp-daemon/pkg/debug"
+	"testing"
+)
+
+func TestPrintALLState_ChangesStateAndSetsResetGM(t *testing.T) {
+	debug.UpdateGMState("s2")
+	debug.UpdateDPLLState("s1", 100, "eth0")
+	debug.UpdateDPLLState("s1", 100, "eth1")
+	debug.UpdateGNSSState("s1", 100)
+	debug.UpdateTs2phcState("s1", 100, "eth0")
+	debug.UpdateTs2phcState("s1", 100, "eth2")
+	debug.UpdateDPLLState("s1", 0, debug.OverallDpllKey)
+	debug.UpdateTs2phcState("s1", 0, debug.OverallTs2phcKey)
+	debug.UpdateClockClass(2)
+	debug.PrintTree()
+}

--- a/pkg/dpll/dpll_test.go
+++ b/pkg/dpll/dpll_test.go
@@ -9,7 +9,6 @@ import (
 
 	nl "github.com/openshift/linuxptp-daemon/pkg/dpll-netlink"
 
-	"github.com/golang/glog"
 	"github.com/openshift/linuxptp-daemon/pkg/config"
 	"github.com/openshift/linuxptp-daemon/pkg/dpll"
 	"github.com/openshift/linuxptp-daemon/pkg/event"
@@ -58,8 +57,8 @@ func getTestData(source event.EventSource, pinType uint32) []DpllTestCase {
 		expectedPhaseStatus:       0, //no phase status event for eec
 		expectedPhaseOffset:       dpll.FaultyPhaseOffset * 1000000,
 		expectedFrequencyStatus:   2, // locked
-		expectedInSpecState:       true,
-		desc:                      "1.locked frequency status, unknonw Phase status ",
+		expectedInSpecState:       false,
+		desc:                      fmt.Sprintf("1.locked frequency status, unknonw Phase status : pin %d ", pinType),
 	}, {
 		reply: &nl.DoDeviceGetReply{
 			Id:            id,
@@ -72,14 +71,14 @@ func getTestData(source event.EventSource, pinType uint32) []DpllTestCase {
 		},
 		sourceLost:                false,
 		source:                    source,
-		offset:                    5,
+		offset:                    1,
 		expectedIntermediateState: event.PTP_LOCKED,
 		expectedState:             event.PTP_LOCKED,
 		expectedPhaseStatus:       2, //no phase status event for eec
 		expectedPhaseOffset:       50,
 		expectedFrequencyStatus:   2, // locked
 		expectedInSpecState:       true,
-		desc:                      "2. with locked frequency status, reading phase status ",
+		desc:                      fmt.Sprintf("2. with locked frequency status, reading phase status  : pin %d ", pinType),
 	},
 		{
 			reply: &nl.DoDeviceGetReply{
@@ -100,8 +99,8 @@ func getTestData(source event.EventSource, pinType uint32) []DpllTestCase {
 			sourceLost:                true,
 			sleep:                     2,
 			source:                    source,
-			offset:                    5,
-			expectedIntermediateState: event.PTP_FREERUN,
+			offset:                    1,
+			expectedIntermediateState: event.PTP_HOLDOVER,
 			expectedState:             event.PTP_FREERUN,
 			expectedPhaseStatus: func() int64 {
 				if pinType == 2 {
@@ -125,7 +124,7 @@ func getTestData(source event.EventSource, pinType uint32) []DpllTestCase {
 					return true
 				}
 			}(),
-			desc: "3. Holdover frequency/Phase status status times out in 1sec ",
+			desc: fmt.Sprintf("3. Holdover frequency/Phase status status times out in 1sec  : pin %d ", pinType),
 		},
 		{
 			reply: &nl.DoDeviceGetReply{
@@ -165,7 +164,7 @@ func getTestData(source event.EventSource, pinType uint32) []DpllTestCase {
 					return true
 				}
 			}(),
-			desc: "4.Out of holdover state.or stays in free run for pps , gns:=declare outofSpec Freerun within a sec",
+			desc: fmt.Sprintf("4.Out of holdover state.or stays in free run for pps , gns:=declare outofSpec Freerun within a sec : pin %d ", pinType),
 		},
 	}
 }
@@ -176,7 +175,7 @@ func TestDpllConfig_MonitorProcessGNSS(t *testing.T) {
 	closeChn := make(chan bool)
 	// event has to be running before dpll is started
 	eventProcessor := event.Init("node", false, "/tmp/go.sock", eChannel, closeChn, nil, nil, nil)
-	d := dpll.NewDpll(clockid, 1400, 2, 10, "ens01",
+	d := dpll.NewDpll(clockid, 10, 2, 5, "ens01",
 		[]event.EventSource{event.GNSS}, dpll.MOCK, map[string]map[string]string{})
 	d.CmdInit()
 	eventChannel := make(chan event.EventChannel, 10)
@@ -207,7 +206,6 @@ func TestDpllConfig_MonitorProcessGNSS(t *testing.T) {
 		assert.Equal(t, tt.expectedPhaseOffset/1000000, d.PhaseOffset(), tt.desc)
 		assert.Equal(t, tt.expectedState, d.State(), tt.desc)
 		assert.Equal(t, tt.expectedInSpecState, d.InSpec())
-
 	}
 	closeChn <- true
 }
@@ -219,7 +217,7 @@ func TestDpllConfig_MonitorProcessPPS(t *testing.T) {
 	closeChn := make(chan bool)
 	// event has to be running before dpll is started
 	eventProcessor := event.Init("node", false, "/tmp/go.sock", eChannel, closeChn, nil, nil, nil)
-	d := dpll.NewDpll(clockid, 1400, 2, 10, "ens01",
+	d := dpll.NewDpll(clockid, 10, 2, 5, "ens01",
 		[]event.EventSource{event.GNSS}, dpll.MOCK, map[string]map[string]string{})
 	d.CmdInit()
 	eventChannel := make(chan event.EventChannel, 10)
@@ -259,7 +257,6 @@ func TestSysfs(t *testing.T) {
 	//assert.Nil(t, err)
 	fcontentStr := strings.ReplaceAll("-26644444444444444", "\n", "")
 	index, err2 := strconv.ParseInt(fcontentStr, 10, 64)
-	glog.Errorf("errr %s", err2)
 	assert.Nil(t, err2)
 	assert.GreaterOrEqual(t, index, int64(-26644444444444444))
 }
@@ -276,11 +273,11 @@ func TestSlopeAndTimer(t *testing.T) {
 
 	testCase := []dpllTestCase{
 		{
-			localMaxHoldoverOffSet: 6000,
-			localHoldoverTimeout:   100,
-			maxInSpecOffset:        100,
-			expectedSlope:          60000,
-			expectedTimeout:        2,
+			localMaxHoldoverOffSet: 6000,       // in ns
+			localHoldoverTimeout:   100,        // in sec
+			maxInSpecOffset:        100,        // in ns
+			expectedSlope:          6000 / 100, // 60ns rate of change
+			expectedTimeout:        2,          // 100/60 = 2 sec (maxInSpecOffset /slope)
 		},
 	}
 	for _, tt := range testCase {

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -9,12 +9,15 @@ import (
 	"sync"
 	"time"
 
-	"github.com/openshift/linuxptp-daemon/pkg/leap"
+	"github.com/openshift/linuxptp-daemon/pkg/debug"
+
 	"github.com/openshift/linuxptp-daemon/pkg/pmc"
+
 	"github.com/openshift/linuxptp-daemon/pkg/protocol"
 
 	fbprotocol "github.com/facebook/time/ptp/protocol"
 	"github.com/golang/glog"
+	"github.com/openshift/linuxptp-daemon/pkg/leap"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -101,7 +104,6 @@ const (
 	PTP4l      EventSource = "ptp4l"
 	PHC2SYS    EventSource = "phc2sys"
 	PPS        EventSource = "1pps"
-	SYNCE      EventSource = "syncE"
 	MONITORING EventSource = "monitoring"
 )
 
@@ -213,6 +215,8 @@ func (e *EventChannel) GetLogData() string {
 			logData = append(logData, fmt.Sprintf("%s %f", k, val))
 		case string:
 			logData = append(logData, fmt.Sprintf("%s %s", k, val))
+		case byte:
+			logData = append(logData, fmt.Sprintf("%s %#x", k, val))
 		default:
 			continue //ignore string for metrics
 		}
@@ -293,7 +297,6 @@ func (e *EventHandler) updateGMState(cfgName string) grandMasterSyncState {
 	ts2phcState := PTP_FREERUN
 	gnssSrcLost := e.isSourceLost(cfgName)
 	gmInterface := e.getGNSSInterface(cfgName)
-
 	if gmInterface == GM_INTERFACE_UNKNOWN {
 		glog.Infof("GM-GNSS interface is not yet identified, gm state reporting delayed.")
 		return grandMasterSyncState{gmIFace: gmInterface}
@@ -324,7 +327,7 @@ func (e *EventHandler) updateGMState(cfgName string) grandMasterSyncState {
 		}
 	} else {
 		e.gmSyncState[cfgName].state = PTP_FREERUN
-		e.gmSyncState[cfgName].clockClass = 248
+		e.gmSyncState[cfgName].clockClass = protocol.ClockClassFreerun
 		e.gmSyncState[cfgName].lastLoggedTime = time.Now().Unix()
 		e.gmSyncState[cfgName].gmIFace = gmInterface
 		e.gmSyncState[cfgName].gmLog = fmt.Sprintf("%s[%d]:[%s] %s T-GM-STATUS %s\n", GM, e.gmSyncState[cfgName].lastLoggedTime, cfgName, gmInterface, e.gmSyncState[cfgName].state)
@@ -334,6 +337,7 @@ func (e *EventHandler) updateGMState(cfgName string) grandMasterSyncState {
 	switch dpllState {
 	case PTP_FREERUN:
 		e.gmSyncState[cfgName].state = dpllState
+		// T-GM or T-BC in free-run mode
 		if e.outOfSpec {
 			// T-GM in holdover, out of holdover specification
 			e.gmSyncState[cfgName].clockClass = protocol.ClockClassOutOfSpec
@@ -388,11 +392,11 @@ func (e *EventHandler) updateGMState(cfgName string) grandMasterSyncState {
 			}
 		case PTP_FREERUN:
 			switch ts2phcState {
-			case PTP_FREERUN, PTP_LOCKED:
+			case PTP_FREERUN, PTP_LOCKED, PTP_UNKNOWN, PTP_NOTSET: // when GNSS is lost ts2phc will stop printing and will wait to move to HOLDOVER
 				e.gmSyncState[cfgName].state = PTP_FREERUN
 				e.gmSyncState[cfgName].clockClass = protocol.ClockClassFreerun
 			}
-		default:
+		default: // bad case
 			e.gmSyncState[cfgName].state = ts2phcState
 			switch ts2phcState {
 			case PTP_FREERUN:
@@ -527,7 +531,7 @@ func (e *EventHandler) ProcessEvents() {
 			}
 		}
 	}()
-
+	var lastgmState PTPState
 connect:
 	select {
 	case <-e.closeCh:
@@ -586,11 +590,11 @@ connect:
 			// ts2phc[123455]:[ts2phc.0.config] 12345 s0 offset/gps
 			// replace ts2phc logs here
 			if event.Reset { // clean up
+				debug.ClearState() // clear any state data used for debug
 				if event.ProcessName == TS2PHC {
 					e.unregisterMetrics(event.CfgName, "")
 					delete(e.data, event.CfgName) // this will delete all index
 					e.clockClass = protocol.ClockClassUninitialized
-
 				} else {
 					// Check if the index is within the slice bounds
 					for indexToRemove, d := range e.data[event.CfgName] {
@@ -608,16 +612,33 @@ connect:
 			}
 			var logOut []string
 			logDataValues := ""
-
 			// Update the in MemData
 			dataDetails := e.addEvent(event)
-			logDataValues = dataDetails.logData
+			// Computes GM state
+			gmState := e.updateGMState(event.CfgName)
+			// right now if GPS offset || mode is bad then consider source lost
+			if e.gmSyncState[event.CfgName] != nil {
+				e.gmSyncState[event.CfgName].sourceLost = event.OutOfSpec
+			}
 
+			logDataValues = dataDetails.logData
 			if event.WriteToLog && logDataValues != "" {
 				logOut = append(logOut, logDataValues)
 			}
-			// Computes GM state
-			gmState := e.updateGMState(event.CfgName)
+			// only if config has this special name
+			d := e.GetData(event.CfgName, event.ProcessName)
+
+			switch event.ProcessName {
+			case GNSS:
+				debug.UpdateGNSSState(string(event.State), event.Values[OFFSET])
+			case DPLL:
+				debug.UpdateDPLLState(string(event.State), event.Values[OFFSET], event.IFace)
+				debug.UpdateDPLLState(string(d.State), 0, debug.OverallDpllKey)
+			case TS2PHC:
+				debug.UpdateTs2phcState(string(event.State), event.Values[OFFSET], event.IFace)
+				debug.UpdateTs2phcState(string(d.State), 0, debug.OverallTs2phcKey)
+			}
+			debug.UpdateGMState(string(gmState.state))
 
 			if gmState.gmLog != "" && gmState.gmIFace != GM_INTERFACE_UNKNOWN {
 				logOut = append(logOut, gmState.gmLog)
@@ -633,6 +654,7 @@ connect:
 				e.UpdateClockStateMetrics(event.State, string(event.ProcessName), eventIface)
 				//  update all metric that was sent to events
 				e.updateMetrics(event.CfgName, event.ProcessName, event.Values, dataDetails)
+
 				if gmState.gmIFace != GM_INTERFACE_UNKNOWN { // race condition ;
 					gmIface := gmState.gmIFace
 					if gmIface != "" {
@@ -642,9 +664,13 @@ connect:
 					e.UpdateClockStateMetrics(gmState.state, string(GM), gmIface)
 				}
 			}
-
-			if uint8(gmState.clockClass) != uint8(e.clockClass) {
-				glog.Infof("clock class change request from %d to %d", uint8(e.clockClass), uint8(gmState.clockClass))
+			// If the clockClass of gmState is not protocol.ClockClassUninitialized and there is a change in clockClass or clockAccuracy,
+			// log the change and update the clock class.
+			if gmState.clockClass != protocol.ClockClassUninitialized &&
+				uint8(gmState.clockClass) != uint8(e.clockClass) {
+				glog.Infof("clock class change request from %d to %d ",
+					uint8(e.clockClass), uint8(gmState.clockClass))
+				debug.UpdateClockClass(uint8(gmState.clockClass))
 				go func() {
 					select {
 					case clockClassRequestCh <- ClockClassRequest{
@@ -657,6 +683,10 @@ connect:
 						glog.Error("clock class request busy updating previous request, will try next event")
 					}
 				}()
+			}
+			if lastgmState != gmState.state {
+				glog.Infof("PTP State: GM State %v, Clock Class %d Time %s sourceLost %v", gmState.state, gmState.clockClass, time.Now(), gmState.sourceLost)
+				lastgmState = gmState.state
 			}
 
 			if len(logOut) > 0 {
@@ -675,6 +705,7 @@ connect:
 					}
 				}
 			}
+
 		case <-e.closeCh:
 			return
 		}
@@ -691,17 +722,16 @@ func (e *EventHandler) updateCLockClass(cfgName string, clkClass fbprotocol.Cloc
 	}
 	switch clockType {
 	case GM:
-		g.TimePropertiesDS.TimeTraceable = true
 		g.TimePropertiesDS.PtpTimescale = true
 		g.TimePropertiesDS.FrequencyTraceable = true
 		g.TimePropertiesDS.CurrentUtcOffsetValid = true
 		g.TimePropertiesDS.CurrentUtcOffset = int32(leap.GetUtcOffset())
 		switch clkClass {
 		case fbprotocol.ClockClass6: // T-GM connected to a PRTC in locked mode (e.g., PRTC traceable to GNSS)
-			// update only when ClockClass is changed
+			// update only when ClockClass is changed or clockAccuracy changes
 			if g.ClockQuality.ClockClass != fbprotocol.ClockClass6 {
 				g.ClockQuality.ClockClass = fbprotocol.ClockClass6
-				g.ClockQuality.ClockAccuracy = fbprotocol.ClockAccuracyNanosecond100
+				g.TimePropertiesDS.TimeTraceable = true
 				g.TimePropertiesDS.TimeSource = fbprotocol.TimeSourceGNSS
 				// T-REC-G.8275.1-202211-I section 6.3.5
 				g.ClockQuality.OffsetScaledLogVariance = 0x4e5d
@@ -710,8 +740,8 @@ func (e *EventHandler) updateCLockClass(cfgName string, clkClass fbprotocol.Cloc
 		case protocol.ClockClassOutOfSpec: // GM out of holdover specification, traceable to Category 3
 			if g.ClockQuality.ClockClass != protocol.ClockClassOutOfSpec {
 				g.ClockQuality.ClockClass = protocol.ClockClassOutOfSpec
-				g.ClockQuality.ClockAccuracy = fbprotocol.ClockAccuracyUnknown
-				g.TimePropertiesDS.TimeSource = fbprotocol.TimeSourceGNSS
+				g.TimePropertiesDS.TimeTraceable = false
+				g.TimePropertiesDS.TimeSource = fbprotocol.TimeSourceInternalOscillator
 				// T-REC-G.8275.1-202211-I section 6.3.5
 				g.ClockQuality.OffsetScaledLogVariance = 0xffff
 				err = gmSetterFn(cfgName, g)
@@ -719,8 +749,8 @@ func (e *EventHandler) updateCLockClass(cfgName string, clkClass fbprotocol.Cloc
 		case fbprotocol.ClockClass7: // T-GM in holdover, within holdover specification
 			if g.ClockQuality.ClockClass != fbprotocol.ClockClass7 {
 				g.ClockQuality.ClockClass = fbprotocol.ClockClass7
-				g.ClockQuality.ClockAccuracy = fbprotocol.ClockAccuracyUnknown
-				g.TimePropertiesDS.TimeSource = fbprotocol.TimeSourceGNSS
+				g.TimePropertiesDS.TimeTraceable = true
+				g.TimePropertiesDS.TimeSource = fbprotocol.TimeSourceInternalOscillator
 				// T-REC-G.8275.1-202211-I section 6.3.5
 				g.ClockQuality.OffsetScaledLogVariance = 0xffff
 				err = gmSetterFn(cfgName, g)
@@ -728,9 +758,8 @@ func (e *EventHandler) updateCLockClass(cfgName string, clkClass fbprotocol.Cloc
 		case protocol.ClockClassFreerun: // T-GM or T-BC in free-run mode
 			if g.ClockQuality.ClockClass != protocol.ClockClassFreerun {
 				g.ClockQuality.ClockClass = protocol.ClockClassFreerun
-				g.ClockQuality.ClockAccuracy = fbprotocol.ClockAccuracyUnknown
-				g.TimePropertiesDS.TimeSource = fbprotocol.TimeSourceGNSS
-				g.TimePropertiesDS.TimeSource = fbprotocol.TimeSourceNTP
+				g.TimePropertiesDS.TimeTraceable = false
+				g.TimePropertiesDS.TimeSource = fbprotocol.TimeSourceInternalOscillator
 				// T-REC-G.8275.1-202211-I section 6.3.5
 				g.ClockQuality.OffsetScaledLogVariance = 0xffff
 				err = gmSetterFn(cfgName, g)
@@ -740,7 +769,6 @@ func (e *EventHandler) updateCLockClass(cfgName string, clkClass fbprotocol.Cloc
 		}
 	default:
 	}
-
 	return err, g.ClockQuality.ClockClass
 }
 
@@ -758,10 +786,7 @@ func (e *EventHandler) GetPTPState(source EventSource, cfgName string) PTPState 
 
 // UpdateClockStateMetrics ...
 func (e *EventHandler) UpdateClockStateMetrics(state PTPState, process, iFace string) {
-	r := []rune(iFace)
-	iFace = string(r[:len(r)-1]) + "x"
-	labels := prometheus.Labels{}
-	labels = prometheus.Labels{
+	labels := prometheus.Labels{
 		"process": process, "node": e.nodeName, "iface": iFace}
 	if state == PTP_LOCKED {
 		e.clockMetric.With(labels).Set(1)
@@ -843,7 +868,7 @@ func (e *EventHandler) updateMetrics(cfgName string, process EventSource, proces
 			s.Labels = map[string]string{"from": pName, "node": e.nodeName,
 				"process": string(process), "iface": iface}
 			s.Value = dataValue
-			d.Metrics[dataType].GaugeMetric.With(s.Labels).Set(dataValue)
+			d.Metrics[dataType].GaugeMetric.With(s.Labels).Set(s.Value)
 		}
 	}
 
@@ -908,10 +933,11 @@ func (e *EventHandler) addEvent(event EventChannel) *DataDetails {
 func (e *EventHandler) UpdateClockClass(c net.Conn, clk ClockClassRequest) {
 	classErr, clockClass := e.updateCLockClass(clk.cfgName, clk.clockClass, clk.clockType,
 		PMCGMGetter, PMCGMSetter)
+	glog.Infof("received %s,%v,%s", clk.cfgName, clk.clockClass, clk.clockType)
 	if classErr != nil {
 		glog.Errorf("error updating clock class %s", classErr)
 	} else {
-		glog.Infof("updated clock class for last clock class %d to %d ", e.clockClass, clockClass)
+		glog.Infof("updated clock class for last clock class %d to %d", e.clockClass, clockClass)
 		e.clockClass = clockClass
 		clockClassOut := fmt.Sprintf("%s[%d]:[%s] CLOCK_CLASS_CHANGE %d\n", PTP4l, time.Now().Unix(), clk.cfgName, clockClass)
 		if e.stdoutToSocket {

--- a/pkg/event/event_test.go
+++ b/pkg/event/event_test.go
@@ -53,6 +53,7 @@ type PTPEvents struct {
 	processName      event.EventSource
 	clockState       event.PTPState
 	cfgName          string
+	iface            string
 	outOfSpec        bool
 	values           map[event.ValueType]interface{}
 	wantGMState      string // want is the expected output.
@@ -70,6 +71,7 @@ func TestEventHandler_ProcessEvents(t *testing.T) {
 			cfgName:          "ts2phc.0.config",
 			clockState:       event.PTP_LOCKED,
 			outOfSpec:        false,
+			iface:            "ens1f0",
 			values:           map[event.ValueType]interface{}{event.OFFSET: 0, event.PHASE_STATUS: 3, event.FREQUENCY_STATUS: 3, event.PPS_STATUS: 1},
 			wantGMState:      "GM[0]:[ts2phc.0.config] unknown T-GM-STATUS s0",
 			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 248",
@@ -80,6 +82,7 @@ func TestEventHandler_ProcessEvents(t *testing.T) {
 			processName:      event.GNSS,
 			cfgName:          "ts2phc.0.config",
 			clockState:       event.PTP_LOCKED,
+			iface:            "ens1f0",
 			values:           map[event.ValueType]interface{}{event.OFFSET: 0, event.GPS_STATUS: 3},
 			wantGMState:      "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s0",
 			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 248",
@@ -90,6 +93,7 @@ func TestEventHandler_ProcessEvents(t *testing.T) {
 			processName:      event.TS2PHCProcessName,
 			cfgName:          "ts2phc.0.config",
 			clockState:       event.PTP_LOCKED,
+			iface:            "ens1f0",
 			values:           map[event.ValueType]interface{}{event.OFFSET: 0},
 			wantGMState:      "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s2",
 			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 6",
@@ -100,6 +104,7 @@ func TestEventHandler_ProcessEvents(t *testing.T) {
 			processName:      event.TS2PHCProcessName,
 			cfgName:          "ts2phc.0.config",
 			clockState:       event.PTP_FREERUN,
+			iface:            "ens1f0",
 			values:           map[event.ValueType]interface{}{event.OFFSET: 5000},
 			wantGMState:      "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s0",
 			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 248",
@@ -110,6 +115,7 @@ func TestEventHandler_ProcessEvents(t *testing.T) {
 			processName:      event.TS2PHCProcessName,
 			cfgName:          "ts2phc.0.config",
 			clockState:       event.PTP_LOCKED,
+			iface:            "ens1f0",
 			values:           map[event.ValueType]interface{}{event.OFFSET: 0},
 			wantGMState:      "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s2",
 			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 6",
@@ -121,6 +127,7 @@ func TestEventHandler_ProcessEvents(t *testing.T) {
 			cfgName:          "ts2phc.0.config",
 			clockState:       event.PTP_FREERUN,
 			outOfSpec:        false,
+			iface:            "ens1f0",
 			values:           map[event.ValueType]interface{}{event.OFFSET: 0, event.GPS_STATUS: 0},
 			wantGMState:      "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s2",
 			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 6",
@@ -128,12 +135,12 @@ func TestEventHandler_ProcessEvents(t *testing.T) {
 			sourceLost:       true,
 			desc:             "GPS is free run ,source is lost when everything else is locked(Do nothing and wait  for DPLL to switch to HOLDOVER)",
 		},
-
 		{
 			processName:      event.DPLL,
 			cfgName:          "ts2phc.0.config",
 			clockState:       event.PTP_HOLDOVER,
 			outOfSpec:        false,
+			iface:            "ens1f0",
 			values:           map[event.ValueType]interface{}{event.OFFSET: 0, event.PHASE_STATUS: 4, event.FREQUENCY_STATUS: 4, event.PPS_STATUS: 1},
 			wantGMState:      "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s1",
 			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 7",
@@ -145,6 +152,7 @@ func TestEventHandler_ProcessEvents(t *testing.T) {
 			cfgName:          "ts2phc.0.config",
 			clockState:       event.PTP_FREERUN,
 			outOfSpec:        true,
+			iface:            "ens1f0",
 			values:           map[event.ValueType]interface{}{event.OFFSET: 0, event.PHASE_STATUS: 1, event.FREQUENCY_STATUS: 1, event.PPS_STATUS: 1},
 			wantGMState:      "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s0",
 			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 140",
@@ -156,6 +164,7 @@ func TestEventHandler_ProcessEvents(t *testing.T) {
 			cfgName:          "ts2phc.0.config",
 			clockState:       event.PTP_LOCKED,
 			outOfSpec:        false,
+			iface:            "ens1f0",
 			values:           map[event.ValueType]interface{}{event.OFFSET: 0, event.GPS_STATUS: 3},
 			wantGMState:      "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s0",
 			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 140",
@@ -168,6 +177,7 @@ func TestEventHandler_ProcessEvents(t *testing.T) {
 			cfgName:          "ts2phc.0.config",
 			clockState:       event.PTP_LOCKED,
 			outOfSpec:        true,
+			iface:            "ens1f0",
 			values:           map[event.ValueType]interface{}{event.OFFSET: 0, event.PHASE_STATUS: 3, event.FREQUENCY_STATUS: 3, event.PPS_STATUS: 1},
 			wantGMState:      "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s2",
 			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 6",
@@ -179,6 +189,7 @@ func TestEventHandler_ProcessEvents(t *testing.T) {
 			cfgName:          "ts2phc.0.config",
 			clockState:       event.PTP_FREERUN,
 			outOfSpec:        true,
+			iface:            "ens1f0",
 			values:           map[event.ValueType]interface{}{event.OFFSET: 99999, event.NMEA_STATUS: 0},
 			wantGMState:      "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s0",
 			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 248",
@@ -190,13 +201,88 @@ func TestEventHandler_ProcessEvents(t *testing.T) {
 			cfgName:          "ts2phc.0.config",
 			clockState:       event.PTP_LOCKED,
 			outOfSpec:        true,
+			iface:            "ens1f0",
 			values:           map[event.ValueType]interface{}{event.OFFSET: 0, event.NMEA_STATUS: 1},
 			wantGMState:      "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s2",
 			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 6",
 			wantProcessState: "ts2phc[0]:[ts2phc.0.config] ens1f0 nmea_status 1 offset 0 s2",
 			desc:             "everything is in locked state",
 		},
+		{
+			processName:      event.TS2PHCProcessName,
+			cfgName:          "ts2phc.0.config",
+			clockState:       event.PTP_FREERUN,
+			outOfSpec:        true,
+			iface:            "ens2f0",
+			values:           map[event.ValueType]interface{}{event.OFFSET: 5000, event.PPS_STATUS: 1},
+			wantGMState:      "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s0",
+			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 248",
+			wantProcessState: "ts2phc[0]:[ts2phc.0.config] ens2f0 offset 5000 pps_status 1 s0",
+			desc:             "2nd card ts2phc offset spiked",
+		},
+		{
+			processName:      event.TS2PHCProcessName,
+			cfgName:          "ts2phc.0.config",
+			clockState:       event.PTP_LOCKED,
+			outOfSpec:        true,
+			iface:            "ens2f0",
+			values:           map[event.ValueType]interface{}{event.OFFSET: 0, event.NMEA_STATUS: 1},
+			wantGMState:      "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s2",
+			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 6",
+			wantProcessState: "ts2phc[0]:[ts2phc.0.config] ens2f0 nmea_status 1 offset 0 s2",
+			desc:             "2nd card restored ",
+		},
+		{ // add scenario where first GNSS is lost and then DPLL 1 and 2 both  is switching to HOLDOVER
+			processName:      event.GNSS,
+			cfgName:          "ts2phc.0.config",
+			clockState:       event.PTP_FREERUN,
+			outOfSpec:        false,
+			iface:            "ens1f0",
+			values:           map[event.ValueType]interface{}{event.OFFSET: 0, event.GPS_STATUS: 0},
+			wantGMState:      "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s2",
+			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 6",
+			wantProcessState: "gnss[0]:[ts2phc.0.config] ens1f0 gnss_status 0 offset 0 s0",
+			sourceLost:       true,
+			desc:             "Case 2: GPS is free run ,source is lost when everything else is locked(Do nothing and wait  for DPLL to switch to HOLDOVER)",
+		},
+		{
+			processName:      event.DPLL,
+			cfgName:          "ts2phc.0.config",
+			clockState:       event.PTP_HOLDOVER,
+			outOfSpec:        false,
+			iface:            "ens1f0",
+			values:           map[event.ValueType]interface{}{event.OFFSET: 0, event.PHASE_STATUS: 4, event.FREQUENCY_STATUS: 4, event.PPS_STATUS: 1},
+			wantGMState:      "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s1",
+			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 7",
+			wantProcessState: "dpll[0]:[ts2phc.0.config] ens1f0 frequency_status 4 offset 0 phase_status 4 pps_status 1 s1",
+			desc:             "dpll is on Holdover, where source is lost, moving to holdover state",
+		},
+		{
+			processName:      event.DPLL,
+			cfgName:          "ts2phc.0.config",
+			clockState:       event.PTP_HOLDOVER,
+			outOfSpec:        false,
+			iface:            "ens2f0",
+			values:           map[event.ValueType]interface{}{event.OFFSET: 0, event.PHASE_STATUS: 4, event.FREQUENCY_STATUS: 4, event.PPS_STATUS: 0},
+			wantGMState:      "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s1",
+			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 7",
+			wantProcessState: "dpll[0]:[ts2phc.0.config] ens2f0 frequency_status 4 offset 0 phase_status 4 pps_status 0 s1",
+			desc:             "dpll 2 is on Holdover, where source is lost, moving to holdover state",
+		},
+		{ // 2nd card spiking stay in holdover
+			processName:      event.TS2PHCProcessName,
+			cfgName:          "ts2phc.0.config",
+			clockState:       event.PTP_FREERUN,
+			outOfSpec:        false,
+			iface:            "ens2f0",
+			values:           map[event.ValueType]interface{}{event.OFFSET: 5000, event.PPS_STATUS: 0},
+			wantGMState:      "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s1",
+			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 7",
+			wantProcessState: "ts2phc[0]:[ts2phc.0.config] ens2f0 offset 5000 pps_status 0 s0",
+			desc:             "2nd card ts2phc offset spiked when in holdover",
+		},
 	}
+
 	logOut := make(chan string, 100)
 	eChannel := make(chan event.EventChannel, 100)
 	closeChn := make(chan bool)
@@ -209,7 +295,7 @@ func TestEventHandler_ProcessEvents(t *testing.T) {
 	time.Sleep(1 * time.Second)
 	for _, test := range tests {
 		select {
-		case eChannel <- sendEvents(test.cfgName, test.processName, test.clockState, test.values, test.outOfSpec, test.sourceLost):
+		case eChannel <- sendEvents(test.cfgName, test.iface, test.processName, test.clockState, test.values, test.outOfSpec, test.sourceLost):
 			log.Println("sent data to channel")
 			log.Println(test.cfgName, test.processName, test.clockState, test.outOfSpec, test.values)
 			time.Sleep(1 * time.Second)
@@ -322,13 +408,13 @@ func ProcessTestEvents(c net.Conn, logOut chan<- string) {
 	}
 }
 
-func sendEvents(cfgName string, processName event.EventSource, state event.PTPState,
+func sendEvents(cfgName string, iface string, processName event.EventSource, state event.PTPState,
 	values map[event.ValueType]interface{}, outOfSpec bool, sourceLost bool) event.EventChannel {
 	glog.Info("sending Nav status event to event handler Process")
 	return event.EventChannel{
 		ProcessName: processName,
 		State:       state,
-		IFace:       "ens1f0",
+		IFace:       iface,
 		CfgName:     cfgName,
 		Values:      values,
 		SourceLost:  sourceLost,

--- a/pkg/event/event_test.go
+++ b/pkg/event/event_test.go
@@ -155,7 +155,7 @@ func TestEventHandler_ProcessEvents(t *testing.T) {
 			iface:            "ens1f0",
 			values:           map[event.ValueType]interface{}{event.OFFSET: 0, event.PHASE_STATUS: 1, event.FREQUENCY_STATUS: 1, event.PPS_STATUS: 1},
 			wantGMState:      "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s0",
-			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 140",
+			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 248",
 			wantProcessState: "dpll[0]:[ts2phc.0.config] ens1f0 frequency_status 1 offset 0 phase_status 1 pps_status 1 s0",
 			desc:             "dpll move to FREERUN from holdover (out of spec)",
 		},


### PR DESCRIPTION
**Enhancements to Logging and Clock Class Announcements for T-GM State Management**

This PR introduces structured logging that includes the state tree, providing users with detailed insights into the relationships between all components involved in the Time Grandmaster (T-GM) state decision process. By exposing state transitions and dependencies, this enhancement simplifies troubleshooting and improves the overall observability of T-GM behavior.

Additionally, this PR removes the use of ClockClass 140 (OutOfSpec) and implements the following improvements:  
- Announces **ClockClass 6** during the `LOCKED` state.  
- Announces **ClockClass 7** during the `HOLDOVER` state until one of the following conditions is met:  
  - The holdover duration times out.  
  - The `inSpecOffset` threshold is reached.  

These changes enhance state accuracy and ensure consistent clock class announcements.

