### PR TITLE
OCPBUGS-46370: GM clock class transition to freerun

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -500,7 +500,7 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 					if frequencyTraceable {
 						*configOpts += " --ts2phc.holdover " + strconv.FormatInt(maxHoldoverTimeout, 10)
 					} else {
-						*configOpts += " --ts2phc.holdover " + strconv.FormatInt(inSpecTimer, 10)
+						*configOpts += " --ts2phc.holdover " + strconv.FormatInt(min(inSpecTimer, maxHoldoverTimeout), 10)
 					}
 				} // there is a 5s delay in the NMEA driver, accepting pulses 5s after the last valid NMEA message, so that might need to be subtracted from that value
 				// need more testing to confirm
@@ -508,7 +508,7 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 					if frequencyTraceable {
 						*configOpts += " --servo_offset_threshold " + strconv.FormatInt(maxHoldoverOffSet, 10)
 					} else {
-						*configOpts += " --servo_offset_threshold " + strconv.FormatInt(maxInSpecOffset, 10)
+						*configOpts += " --servo_offset_threshold " + strconv.FormatInt(min(maxInSpecOffset, maxHoldoverOffSet), 10)
 					}
 				}
 				if !strings.Contains(*configOpts, "--servo_num_offset_values") { //if consecutive smaller offsets (less than the threshold) are not observed, the system stays in S2

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -356,7 +356,8 @@ func (e *EventHandler) updateGMState(cfgName string) grandMasterSyncState {
 	}
 	e.gmSyncState[cfgName].gmIFace = gmInterface
 	switch dpllState {
-	case PTP_FREERUN:
+	case PTP_FREERUN: // This is OVER ALL State with HOLDOVER having the highest priority
+		// add check so that clock class won't change if GM was in HOLDOVER state
 		e.gmSyncState[cfgName].state = dpllState
 		// T-GM or T-BC in free-run mode
 		if e.outOfSpec && e.frequencyTraceable {

--- a/pkg/event/event_test.go
+++ b/pkg/event/event_test.go
@@ -24,6 +24,7 @@ var (
 func monkeyPatch() {
 
 	event.PMCGMGetter = func(cfgName string) (protocol.GrandmasterSettings, error) {
+		cfgName = strings.Replace(cfgName, event.TS2PHCProcessName, event.PTP4lProcessName, 1)
 		return protocol.GrandmasterSettings{
 			ClockQuality: fbprotocol.ClockQuality{
 				ClockClass:              0,
@@ -43,22 +44,23 @@ func monkeyPatch() {
 		}, nil
 	}
 	event.PMCGMSetter = func(cfgName string, g protocol.GrandmasterSettings) error {
+		cfgName = strings.Replace(cfgName, event.TS2PHCProcessName, event.PTP4lProcessName, 1)
 		return nil
 	}
 }
 
 type PTPEvents struct {
-	processName        event.EventSource
-	clockState         event.PTPState
-	cfgName            string
-	outOfSpec          bool
-	frequencyTraceable bool
-	values             map[event.ValueType]interface{}
-	wantGMState        string // want is the expected output.
-	wantClockState     string
-	wantProcessState   string
-	desc               string
-	sourceLost         bool
+	processName      event.EventSource
+	clockState       event.PTPState
+	cfgName          string
+	iface            string
+	outOfSpec        bool
+	values           map[event.ValueType]interface{}
+	wantGMState      string // want is the expected output.
+	wantClockState   string
+	wantProcessState string
+	desc             string
+	sourceLost       bool
 }
 
 func TestEventHandler_ProcessEvents(t *testing.T) {
@@ -69,6 +71,7 @@ func TestEventHandler_ProcessEvents(t *testing.T) {
 			cfgName:          "ts2phc.0.config",
 			clockState:       event.PTP_LOCKED,
 			outOfSpec:        false,
+			iface:            "ens1f0",
 			values:           map[event.ValueType]interface{}{event.OFFSET: 0, event.PHASE_STATUS: 3, event.FREQUENCY_STATUS: 3, event.PPS_STATUS: 1},
 			wantGMState:      "GM[0]:[ts2phc.0.config] unknown T-GM-STATUS s0",
 			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 248",
@@ -79,6 +82,7 @@ func TestEventHandler_ProcessEvents(t *testing.T) {
 			processName:      event.GNSS,
 			cfgName:          "ts2phc.0.config",
 			clockState:       event.PTP_LOCKED,
+			iface:            "ens1f0",
 			values:           map[event.ValueType]interface{}{event.OFFSET: 0, event.GPS_STATUS: 3},
 			wantGMState:      "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s0",
 			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 248",
@@ -89,6 +93,7 @@ func TestEventHandler_ProcessEvents(t *testing.T) {
 			processName:      event.TS2PHCProcessName,
 			cfgName:          "ts2phc.0.config",
 			clockState:       event.PTP_LOCKED,
+			iface:            "ens1f0",
 			values:           map[event.ValueType]interface{}{event.OFFSET: 0},
 			wantGMState:      "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s2",
 			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 6",
@@ -99,6 +104,7 @@ func TestEventHandler_ProcessEvents(t *testing.T) {
 			processName:      event.TS2PHCProcessName,
 			cfgName:          "ts2phc.0.config",
 			clockState:       event.PTP_FREERUN,
+			iface:            "ens1f0",
 			values:           map[event.ValueType]interface{}{event.OFFSET: 5000},
 			wantGMState:      "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s0",
 			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 248",
@@ -109,6 +115,7 @@ func TestEventHandler_ProcessEvents(t *testing.T) {
 			processName:      event.TS2PHCProcessName,
 			cfgName:          "ts2phc.0.config",
 			clockState:       event.PTP_LOCKED,
+			iface:            "ens1f0",
 			values:           map[event.ValueType]interface{}{event.OFFSET: 0},
 			wantGMState:      "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s2",
 			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 6",
@@ -120,19 +127,20 @@ func TestEventHandler_ProcessEvents(t *testing.T) {
 			cfgName:          "ts2phc.0.config",
 			clockState:       event.PTP_FREERUN,
 			outOfSpec:        false,
+			iface:            "ens1f0",
 			values:           map[event.ValueType]interface{}{event.OFFSET: 0, event.GPS_STATUS: 0},
-			wantGMState:      "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s0",
-			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 248",
+			wantGMState:      "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s2",
+			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 6",
 			wantProcessState: "gnss[0]:[ts2phc.0.config] ens1f0 gnss_status 0 offset 0 s0",
 			sourceLost:       true,
-			desc:             "GPS is free run ,source is lost when everything else is locked(DPLL to switch to HOLDOVER)",
+			desc:             "GPS is free run ,source is lost when everything else is locked(Do nothing and wait  for DPLL to switch to HOLDOVER)",
 		},
-
 		{
 			processName:      event.DPLL,
 			cfgName:          "ts2phc.0.config",
 			clockState:       event.PTP_HOLDOVER,
 			outOfSpec:        false,
+			iface:            "ens1f0",
 			values:           map[event.ValueType]interface{}{event.OFFSET: 0, event.PHASE_STATUS: 4, event.FREQUENCY_STATUS: 4, event.PPS_STATUS: 1},
 			wantGMState:      "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s1",
 			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 7",
@@ -140,47 +148,36 @@ func TestEventHandler_ProcessEvents(t *testing.T) {
 			desc:             "dpll is on Holdover, where source is lost, move to holdover state",
 		},
 		{
-			processName:        event.DPLL,
-			cfgName:            "ts2phc.0.config",
-			clockState:         event.PTP_FREERUN,
-			outOfSpec:          true,
-			frequencyTraceable: false,
-			values:             map[event.ValueType]interface{}{event.OFFSET: 0, event.PHASE_STATUS: 1, event.FREQUENCY_STATUS: 1, event.PPS_STATUS: 1},
-			wantGMState:        "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s0",
-			wantClockState:     "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 248",
-			wantProcessState:   "dpll[0]:[ts2phc.0.config] ens1f0 frequency_status 1 offset 0 phase_status 1 pps_status 1 s0",
-			desc:               "dpll move to FREERUN from holdover (out of spec)",
+			processName:      event.DPLL,
+			cfgName:          "ts2phc.0.config",
+			clockState:       event.PTP_FREERUN,
+			outOfSpec:        true,
+			iface:            "ens1f0",
+			values:           map[event.ValueType]interface{}{event.OFFSET: 0, event.PHASE_STATUS: 1, event.FREQUENCY_STATUS: 1, event.PPS_STATUS: 1},
+			wantGMState:      "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s0",
+			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 248",
+			wantProcessState: "dpll[0]:[ts2phc.0.config] ens1f0 frequency_status 1 offset 0 phase_status 1 pps_status 1 s0",
+			desc:             "dpll move to FREERUN from holdover (out of spec)",
 		},
 		{
 			processName:      event.GNSS,
 			cfgName:          "ts2phc.0.config",
 			clockState:       event.PTP_LOCKED,
 			outOfSpec:        false,
+			iface:            "ens1f0",
 			values:           map[event.ValueType]interface{}{event.OFFSET: 0, event.GPS_STATUS: 3},
 			wantGMState:      "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s0",
-			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 248",
+			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 140",
 			wantProcessState: "gnss[0]:[ts2phc.0.config] ens1f0 gnss_status 3 offset 0 s2",
 			sourceLost:       false,
 			desc:             "GPS is locked but dpll is in FREERUN and out of spec, yet to switch over in that case GM should stay with last state",
-		},
-		{
-			processName:        event.GNSS,
-			cfgName:            "ts2phc.0.config",
-			clockState:         event.PTP_LOCKED,
-			outOfSpec:          false,
-			frequencyTraceable: false,
-			values:             map[event.ValueType]interface{}{event.OFFSET: 0, event.GPS_STATUS: 3},
-			wantGMState:        "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s0",
-			wantClockState:     "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 248",
-			wantProcessState:   "gnss[0]:[ts2phc.0.config] ens1f0 gnss_status 3 offset 0 s2",
-			sourceLost:         false,
-			desc:               "GPS is locked but dpll is in FREERUN and out of spec, yet to switch over in that case GM should stay with last state",
 		},
 		{
 			processName:      event.DPLL,
 			cfgName:          "ts2phc.0.config",
 			clockState:       event.PTP_LOCKED,
 			outOfSpec:        true,
+			iface:            "ens1f0",
 			values:           map[event.ValueType]interface{}{event.OFFSET: 0, event.PHASE_STATUS: 3, event.FREQUENCY_STATUS: 3, event.PPS_STATUS: 1},
 			wantGMState:      "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s2",
 			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 6",
@@ -192,6 +189,7 @@ func TestEventHandler_ProcessEvents(t *testing.T) {
 			cfgName:          "ts2phc.0.config",
 			clockState:       event.PTP_FREERUN,
 			outOfSpec:        true,
+			iface:            "ens1f0",
 			values:           map[event.ValueType]interface{}{event.OFFSET: 99999, event.NMEA_STATUS: 0},
 			wantGMState:      "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s0",
 			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 248",
@@ -203,13 +201,88 @@ func TestEventHandler_ProcessEvents(t *testing.T) {
 			cfgName:          "ts2phc.0.config",
 			clockState:       event.PTP_LOCKED,
 			outOfSpec:        true,
+			iface:            "ens1f0",
 			values:           map[event.ValueType]interface{}{event.OFFSET: 0, event.NMEA_STATUS: 1},
 			wantGMState:      "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s2",
 			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 6",
 			wantProcessState: "ts2phc[0]:[ts2phc.0.config] ens1f0 nmea_status 1 offset 0 s2",
 			desc:             "everything is in locked state",
 		},
+		{
+			processName:      event.TS2PHCProcessName,
+			cfgName:          "ts2phc.0.config",
+			clockState:       event.PTP_FREERUN,
+			outOfSpec:        true,
+			iface:            "ens2f0",
+			values:           map[event.ValueType]interface{}{event.OFFSET: 5000, event.PPS_STATUS: 1},
+			wantGMState:      "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s0",
+			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 248",
+			wantProcessState: "ts2phc[0]:[ts2phc.0.config] ens2f0 offset 5000 pps_status 1 s0",
+			desc:             "2nd card ts2phc offset spiked",
+		},
+		{
+			processName:      event.TS2PHCProcessName,
+			cfgName:          "ts2phc.0.config",
+			clockState:       event.PTP_LOCKED,
+			outOfSpec:        true,
+			iface:            "ens2f0",
+			values:           map[event.ValueType]interface{}{event.OFFSET: 0, event.NMEA_STATUS: 1},
+			wantGMState:      "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s2",
+			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 6",
+			wantProcessState: "ts2phc[0]:[ts2phc.0.config] ens2f0 nmea_status 1 offset 0 s2",
+			desc:             "2nd card restored ",
+		},
+		{ // add scenario where first GNSS is lost and then DPLL 1 and 2 both  is switching to HOLDOVER
+			processName:      event.GNSS,
+			cfgName:          "ts2phc.0.config",
+			clockState:       event.PTP_FREERUN,
+			outOfSpec:        false,
+			iface:            "ens1f0",
+			values:           map[event.ValueType]interface{}{event.OFFSET: 0, event.GPS_STATUS: 0},
+			wantGMState:      "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s2",
+			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 6",
+			wantProcessState: "gnss[0]:[ts2phc.0.config] ens1f0 gnss_status 0 offset 0 s0",
+			sourceLost:       true,
+			desc:             "Case 2: GPS is free run ,source is lost when everything else is locked(Do nothing and wait  for DPLL to switch to HOLDOVER)",
+		},
+		{
+			processName:      event.DPLL,
+			cfgName:          "ts2phc.0.config",
+			clockState:       event.PTP_HOLDOVER,
+			outOfSpec:        false,
+			iface:            "ens1f0",
+			values:           map[event.ValueType]interface{}{event.OFFSET: 0, event.PHASE_STATUS: 4, event.FREQUENCY_STATUS: 4, event.PPS_STATUS: 1},
+			wantGMState:      "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s1",
+			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 7",
+			wantProcessState: "dpll[0]:[ts2phc.0.config] ens1f0 frequency_status 4 offset 0 phase_status 4 pps_status 1 s1",
+			desc:             "dpll is on Holdover, where source is lost, moving to holdover state",
+		},
+		{
+			processName:      event.DPLL,
+			cfgName:          "ts2phc.0.config",
+			clockState:       event.PTP_HOLDOVER,
+			outOfSpec:        false,
+			iface:            "ens2f0",
+			values:           map[event.ValueType]interface{}{event.OFFSET: 0, event.PHASE_STATUS: 4, event.FREQUENCY_STATUS: 4, event.PPS_STATUS: 0},
+			wantGMState:      "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s1",
+			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 7",
+			wantProcessState: "dpll[0]:[ts2phc.0.config] ens2f0 frequency_status 4 offset 0 phase_status 4 pps_status 0 s1",
+			desc:             "dpll 2 is on Holdover, where source is lost, moving to holdover state",
+		},
+		{ // 2nd card spiking stay in holdover
+			processName:      event.TS2PHCProcessName,
+			cfgName:          "ts2phc.0.config",
+			clockState:       event.PTP_FREERUN,
+			outOfSpec:        false,
+			iface:            "ens2f0",
+			values:           map[event.ValueType]interface{}{event.OFFSET: 5000, event.PPS_STATUS: 0},
+			wantGMState:      "GM[0]:[ts2phc.0.config] ens1f0 T-GM-STATUS s1",
+			wantClockState:   "ptp4l[0]:[ts2phc.0.config] CLOCK_CLASS_CHANGE 7",
+			wantProcessState: "ts2phc[0]:[ts2phc.0.config] ens2f0 offset 5000 pps_status 0 s0",
+			desc:             "2nd card ts2phc offset spiked when in holdover",
+		},
 	}
+
 	logOut := make(chan string, 100)
 	eChannel := make(chan event.EventChannel, 100)
 	closeChn := make(chan bool)
@@ -222,7 +295,7 @@ func TestEventHandler_ProcessEvents(t *testing.T) {
 	time.Sleep(1 * time.Second)
 	for _, test := range tests {
 		select {
-		case eChannel <- sendEvents(test.cfgName, test.processName, test.clockState, test.values, test.outOfSpec, test.frequencyTraceable, test.sourceLost):
+		case eChannel <- sendEvents(test.cfgName, test.iface, test.processName, test.clockState, test.values, test.outOfSpec, test.sourceLost):
 			log.Println("sent data to channel")
 			log.Println(test.cfgName, test.processName, test.clockState, test.outOfSpec, test.values)
 			time.Sleep(1 * time.Second)
@@ -335,21 +408,20 @@ func ProcessTestEvents(c net.Conn, logOut chan<- string) {
 	}
 }
 
-func sendEvents(cfgName string, processName event.EventSource, state event.PTPState,
-	values map[event.ValueType]interface{}, outOfSpec, sourceLost, frequencyTraceable bool) event.EventChannel {
+func sendEvents(cfgName string, iface string, processName event.EventSource, state event.PTPState,
+	values map[event.ValueType]interface{}, outOfSpec bool, sourceLost bool) event.EventChannel {
 	glog.Info("sending Nav status event to event handler Process")
 	return event.EventChannel{
-		ProcessName:        processName,
-		State:              state,
-		IFace:              "ens1f0",
-		CfgName:            cfgName,
-		Values:             values,
-		SourceLost:         sourceLost,
-		ClockType:          "GM",
-		Time:               0,
-		OutOfSpec:          outOfSpec,
-		FrequencyTraceable: frequencyTraceable,
-		WriteToLog:         true,
-		Reset:              false,
+		ProcessName: processName,
+		State:       state,
+		IFace:       iface,
+		CfgName:     cfgName,
+		Values:      values,
+		SourceLost:  sourceLost,
+		ClockType:   "GM",
+		Time:        0,
+		OutOfSpec:   outOfSpec,
+		WriteToLog:  true,
+		Reset:       false,
 	}
 }


### PR DESCRIPTION
This covers the case where LocalHoldoverTimeout is smaller than the one defined by MaxInSpecOffset.
