### PR TITLE
[release-4.17] OCPBUGS-54534: keep in holdover until locked-holdover-acquired

### DIFF
--- a/pkg/dpll/dpll.go
+++ b/pkg/dpll/dpll.go
@@ -10,12 +10,14 @@ import (
 	"sync"
 	"time"
 
+	ptpv1 "github.com/openshift/ptp-operator/api/v1"
+
 	"github.com/golang/glog"
 	"github.com/mdlayher/genetlink"
 	"github.com/openshift/linuxptp-daemon/pkg/config"
 	nl "github.com/openshift/linuxptp-daemon/pkg/dpll-netlink"
 	"github.com/openshift/linuxptp-daemon/pkg/event"
-	ptpv1 "github.com/openshift/ptp-operator/api/v1"
+
 	"golang.org/x/sync/semaphore"
 )
 
@@ -349,7 +351,7 @@ func (d *DpllConfig) nlUpdateState(devices []*nl.DoDeviceGetReply, pins []*nl.Do
 				glog.Info("discarding on invalid lock status: ", nl.GetDpllStatusHR(reply))
 				continue
 			}
-			glog.Info(nl.GetDpllStatusHR(reply))
+			glog.Info(nl.GetDpllStatusHR(reply), " ", d.iface)
 			switch nl.GetDpllType(reply.Type) {
 			case "eec":
 				d.frequencyStatus = int64(reply.LockStatus)
@@ -365,7 +367,7 @@ func (d *DpllConfig) nlUpdateState(devices []*nl.DoDeviceGetReply, pins []*nl.Do
 	for _, pin := range pins {
 		if d.PhaseOffsetPin(pin) {
 			d.SetPhaseOffset(pin.ParentDevice.PhaseOffset)
-			glog.Info("setting phase offset to ", d.phaseOffset, " ns for clock id ", d.clockId)
+			glog.Info("setting phase offset to ", d.phaseOffset, " ns for clock id ", d.clockId, " iface ", d.iface)
 			valid = true
 		}
 	}
@@ -621,47 +623,62 @@ func (d *DpllConfig) MonitorDpll() {
 // stateDecision
 func (d *DpllConfig) stateDecision() {
 	dpllStatus := d.getWorseState(d.phaseStatus, d.frequencyStatus)
+
 	switch dpllStatus {
 	case DPLL_FREERUN, DPLL_INVALID, DPLL_UNKNOWN:
 		d.inSpec = false
 		d.sourceLost = true
+		glog.Infof("on holdover %t has GNSS source %t", d.onHoldover, d.hasGNSSAsSource())
 		if d.hasGNSSAsSource() && d.onHoldover {
-			d.holdoverCloseCh <- true
+			glog.Infof("trying to close holdover (%s)", d.iface)
+			select {
+			case d.holdoverCloseCh <- true:
+				glog.Infof("closing holdover for %s since DPLL flipped to Unlocked", d.iface)
+			default:
+			}
 		}
 		d.state = event.PTP_FREERUN
 		d.phaseOffset = FaultyPhaseOffset
 		glog.Infof("dpll is in FREERUN, state is FREERUN (%s)", d.iface)
 		d.sendDpllEvent()
-	case DPLL_LOCKED:
-		if !d.sourceLost && d.isOffsetInRange() {
-			if d.hasGNSSAsSource() && d.onHoldover {
-				d.holdoverCloseCh <- true
+
+	case DPLL_HOLDOVER:
+		switch {
+		case d.hasPPSAsSource():
+			d.state = event.PTP_FREERUN
+			d.phaseOffset = FaultyPhaseOffset
+			glog.Infof("Follower card DPLL is on holdover - hardware failure or pins misconfigured")
+		case d.hasGNSSAsSource():
+			if !d.inSpec { // d.inSpec is updated by the holdover routine
+				glog.Infof("dpll is not in spec, state is DPLL_HOLDOVER, offset is out of range, state is FREERUN(%s)", d.iface)
+				d.state = event.PTP_FREERUN
+				d.phaseOffset = FaultyPhaseOffset
+				select {
+				case d.holdoverCloseCh <- true:
+					glog.Infof("closing holdover for %s since offset if out of spec", d.iface)
+				default:
+				}
+			} else if !d.onHoldover {
+				d.holdoverCloseCh = make(chan bool)
+				d.onHoldover = true
+				d.state = event.PTP_HOLDOVER
+				glog.Infof("starting holdover (%s)", d.iface)
+				go d.holdover()
+
 			}
-			glog.Infof("dpll is locked, offset is in range, state is LOCKED(%s)", d.iface)
+		}
+		d.sendDpllEvent()
+
+	case DPLL_LOCKED_HO_ACQ:
+		if d.isOffsetInRange() {
 			d.state = event.PTP_LOCKED
 			d.inSpec = true
 		} else {
-			glog.Infof("dpll is locked, offset is out of range, state is FREERUN(%s)", d.iface)
 			d.state = event.PTP_FREERUN
-			d.inSpec = true
+			d.sourceLost = false // phase offset will be the one that was read
 		}
-		d.sendDpllEvent()
-	case DPLL_LOCKED_HO_ACQ, DPLL_HOLDOVER:
-		switch {
-		case d.hasPPSAsSource():
-			if dpllStatus == DPLL_HOLDOVER {
-				d.state = event.PTP_FREERUN
-				d.phaseOffset = FaultyPhaseOffset
-				d.sourceLost = true
-			} else if d.isOffsetInRange() {
-				d.state = event.PTP_LOCKED
-				d.sourceLost = false
-			} else {
-				d.state = event.PTP_FREERUN
-				d.sourceLost = false
-			}
-		case !d.sourceLost && d.isOffsetInRange(): // DPLL in range
-			glog.Infof("dpll is locked, source is not lost, offset is in range, state is DPLL_LOCKED_HO_ACQ or DPLL_HOLDOVER(%s)", d.iface)
+		if d.isOffsetInRange() {
+			glog.Infof("dpll is locked, source is not lost, offset is in range, state is DPLL_LOCKED_HO_ACQ(%s)", d.iface)
 			if d.hasGNSSAsSource() && d.onHoldover {
 				select {
 				case d.holdoverCloseCh <- true:
@@ -671,17 +688,10 @@ func (d *DpllConfig) stateDecision() {
 			}
 			d.inSpec = true
 			d.state = event.PTP_LOCKED
-		case d.sourceLost && d.inSpec:
-			if !d.onHoldover {
-				d.holdoverCloseCh = make(chan bool)
-				d.onHoldover = true
-				d.state = event.PTP_HOLDOVER
-				go d.holdover()
-			}
-			return // do not send event holdover will handle it
-		case !d.inSpec:
-			glog.Infof("dpll is not in spec, state is DPLL_LOCKED_HO_ACQ or DPLL_HOLDOVER, offset is out of range, state is FREERUN(%s)", d.iface)
+		} else {
+			glog.Infof("dpll is not in spec, state is DPLL_LOCKED_HO_ACQ, offset is out of range, state is FREERUN(%s)", d.iface)
 			d.state = event.PTP_FREERUN
+			d.inSpec = false
 			d.phaseOffset = FaultyPhaseOffset
 			select {
 			case d.holdoverCloseCh <- true:

--- a/pkg/dpll/dpll_test.go
+++ b/pkg/dpll/dpll_test.go
@@ -41,11 +41,12 @@ type DpllTestCase struct {
 func getTestData(source event.EventSource, pinType uint32) []DpllTestCase {
 	return []DpllTestCase{{
 		reply: &nl.DoDeviceGetReply{
-			Id:            id,
-			ModuleName:    moduleName,
-			Mode:          1,
+			Id:         id,
+			ModuleName: moduleName,
+			Mode:       1,
+
 			ModeSupported: 0,
-			LockStatus:    2, //LOCKED,
+			LockStatus:    3, //LHAQ,
 			ClockId:       clockid,
 			Type:          2, //1 pps 2 eec
 		},
@@ -56,16 +57,16 @@ func getTestData(source event.EventSource, pinType uint32) []DpllTestCase {
 		expectedState:             event.PTP_FREERUN,
 		expectedPhaseStatus:       0, //no phase status event for eec
 		expectedPhaseOffset:       dpll.FaultyPhaseOffset * 1000000,
-		expectedFrequencyStatus:   2, // locked
+		expectedFrequencyStatus:   3, // LHAQ
 		expectedInSpecState:       false,
-		desc:                      fmt.Sprintf("1.locked frequency status, unknown Phase status : pin %d ", pinType),
+		desc:                      fmt.Sprintf("1.LHAQ frequency status, unknown Phase status : pin %d ", pinType),
 	}, {
 		reply: &nl.DoDeviceGetReply{
 			Id:            id,
 			ModuleName:    moduleName,
 			Mode:          1,
 			ModeSupported: 0,
-			LockStatus:    2, //LOCKED,
+			LockStatus:    3, //LHAQ,
 			ClockId:       clockid,
 			Type:          1, //1 pps 2 eec
 		},
@@ -74,11 +75,11 @@ func getTestData(source event.EventSource, pinType uint32) []DpllTestCase {
 		offset:                    1,
 		expectedIntermediateState: event.PTP_LOCKED,
 		expectedState:             event.PTP_LOCKED,
-		expectedPhaseStatus:       2, //no phase status event for eec
+		expectedPhaseStatus:       3, //no phase status event for eec
 		expectedPhaseOffset:       50,
-		expectedFrequencyStatus:   2, // locked
+		expectedFrequencyStatus:   3, // LHAQ
 		expectedInSpecState:       true,
-		desc:                      fmt.Sprintf("2. with locked frequency status, reading phase status  : pin %d ", pinType),
+		desc:                      fmt.Sprintf("2. with LHAQ frequency status, reading phase status  : pin %d ", pinType),
 	},
 		{
 			reply: &nl.DoDeviceGetReply{
@@ -90,7 +91,7 @@ func getTestData(source event.EventSource, pinType uint32) []DpllTestCase {
 					if pinType == 2 {
 						return 4 // holdover
 					} else {
-						return 4 // locked
+						return 4 // holdover
 					}
 				}(), // holdover,
 				ClockId: clockid,
@@ -104,9 +105,9 @@ func getTestData(source event.EventSource, pinType uint32) []DpllTestCase {
 			expectedState:             event.PTP_FREERUN,
 			expectedPhaseStatus: func() int64 {
 				if pinType == 2 {
-					return 2 // locked
+					return 3 // LHAQ
 				} else {
-					return 4 //holdover
+					return 4 // holdover
 				}
 			}(), //no phase status event for eec
 			expectedPhaseOffset: dpll.FaultyPhaseOffset * 1000000,
@@ -114,7 +115,7 @@ func getTestData(source event.EventSource, pinType uint32) []DpllTestCase {
 				if pinType == 2 {
 					return 4
 				} else {
-					return 2
+					return 3
 				}
 			}(), // holdover to free run
 			expectedInSpecState: func() bool {
@@ -144,7 +145,7 @@ func getTestData(source event.EventSource, pinType uint32) []DpllTestCase {
 			expectedState:             event.PTP_FREERUN,
 			expectedPhaseStatus: func() int64 {
 				if pinType == 2 {
-					return 2
+					return 3
 				} else {
 					return 4
 				}
@@ -154,7 +155,7 @@ func getTestData(source event.EventSource, pinType uint32) []DpllTestCase {
 				if pinType == 2 {
 					return 4
 				} else {
-					return 2
+					return 3
 				}
 			}(),
 			expectedInSpecState: func() bool {
@@ -168,6 +169,7 @@ func getTestData(source event.EventSource, pinType uint32) []DpllTestCase {
 		},
 	}
 }
+
 func TestDpllConfig_MonitorProcessGNSS(t *testing.T) {
 	dpll.MockDpllReplies = make(chan *nl.DoDeviceGetReply, 1)
 	assert.True(t, dpll.MockDpllReplies != nil)
@@ -195,10 +197,11 @@ func TestDpllConfig_MonitorProcessGNSS(t *testing.T) {
 	for _, tt := range getTestData(event.GNSS, 2) {
 		d.SetSourceLost(tt.sourceLost)
 		d.SetPhaseOffset(tt.expectedPhaseOffset)
-		d.SetDependsOn([]event.EventSource{tt.source})
 		dpll.MockDpllReplies <- tt.reply
+		time.Sleep(10 * time.Millisecond)
+		d.SetDependsOn([]event.EventSource{tt.source})
 		d.MonitorDpllMock()
-		time.Sleep(1 * time.Second)
+		time.Sleep(10 * time.Millisecond)
 		assert.Equal(t, tt.expectedIntermediateState, d.State(), tt.desc)
 		time.Sleep(tt.sleep * time.Second)
 		assert.Equal(t, tt.expectedPhaseStatus, d.PhaseStatus(), tt.desc)


### PR DESCRIPTION
This is a manual cherrypick of #407 
Simplify DPLL eventing logic by decoupling holdover and LHAQ states 
Remove "locked" DPLL state handling, keeping in Holdover until the LHAQ state reached.
Fix a corner case when holdover timer keeps running when DPLL goes to unlocked.
Fix a race condition in tests where event source was not fast enough to be set before the event processing
/assign @aneeshkp 
/cc @josephdrichard @jzding @nocturnalastro 