### PR TITLE
OCPBUGS-55118: Revert "[release-4.17] OCPBUGS-54693: Add delay in linuxptp-daemon to wait for socket to be ready"

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -903,9 +903,6 @@ func (p *ptpProcess) cmdRun(stdoutToSocket bool) {
 		}
 		// Don't restart after termination
 		if !p.Stopped() {
-			// Wait for a small amount ot time to give a chance for the socket to be up before starting the command
-			// otherwise the initial logs will be lost.
-			time.Sleep(time.Second)
 			err = p.cmd.Start() // this is asynchronous call,
 			if err != nil {
 				glog.Errorf("CmdRun() error starting %s: %v", p.name, err)


### PR DESCRIPTION
Reverts openshift/linuxptp-daemon#416