### PR TITLE
[release-4.16] OCPBUGS-55281: update event to fix T-GM regression failure

### DIFF
--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -635,9 +635,6 @@ connect:
 			// Update the in MemData
 			dataDetails := e.addEvent(event)
 
-			if event.WriteToLog && logDataValues != "" {
-				logOut = append(logOut, logDataValues)
-			}
 			// Computes GM state
 			gmState := e.updateGMState(event.CfgName)
 			// right now if GPS offset || mode is bad then consider source lost
@@ -646,9 +643,8 @@ connect:
 			}
 
 			logDataValues = dataDetails.logData
-
-			if gmState.gmLog != "" && gmState.gmIFace != GM_INTERFACE_UNKNOWN {
-				logOut = append(logOut, gmState.gmLog)
+			if event.WriteToLog && logDataValues != "" {
+				logOut = append(logOut, logDataValues)
 			}
 
 			// only if config has this special name
@@ -665,6 +661,11 @@ connect:
 				debug.UpdateTs2phcState(string(d.State), 0, debug.OverallTs2phcKey)
 			}
 			debug.UpdateGMState(string(gmState.state))
+
+			if gmState.gmLog != "" && gmState.gmIFace != GM_INTERFACE_UNKNOWN {
+				logOut = append(logOut, gmState.gmLog)
+			}
+
 			// Update the metrics
 			if !e.stdoutToSocket { // if events not enabled
 				eventIface := event.IFace


### PR DESCRIPTION

This PR restores a critical logic block that was incorrectly removed in a previous commit. The removed code was responsible for:

    missing  logDataValues from dataDetails.logData for log output
    if event.WriteToLog && logDataValues != "" {
	logOut = append(logOut, logDataValues)
}