### PR TITLE
[release-4.16] OCPBUGS-55767: No event when gpsd process restarted

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -776,15 +776,14 @@ func (p *ptpProcess) cmdRun(stdoutToSocket bool) {
 		glog.Infof("Starting %s...", p.name)
 		glog.Infof("%s cmd: %+v", p.name, p.cmd)
 
-		//
-		// don't discard process stderr output
-		//
-		p.cmd.Stderr = os.Stderr
 		cmdReader, err := p.cmd.StdoutPipe()
+
 		if err != nil {
 			glog.Errorf("CmdRun() error creating StdoutPipe for %s: %v", p.name, err)
 			break
 		}
+		// don't discard process stderr output
+		p.cmd.Stderr = p.cmd.Stdout
 		if !stdoutToSocket {
 			scanner := bufio.NewScanner(cmdReader)
 			processStatus(nil, p.name, p.messageTag, PtpProcessUp)


### PR DESCRIPTION
The issue was that linuxptp logged severity-level errors to stderr, and the NMEA string timeout was being treated as an error. Our application wasn't capturing stderr, so it was missing those messages. I've now updated it to pipe both stderr and stdout to the same reader.
Now this was corrceted in 4.18 and above, but not found in 4.17 . Log severity was introduced in 4.16