### PR TITLE
[release-4.19] OCPBUGS-56423: Fix interface name for summary metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/k8snetworkplumbingwg/linuxptp-daemon
 
-go 1.23
+go 1.23.0
+
 toolchain go1.24.1
 
 require (

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/synce"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/utils"
 
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/config"
 
@@ -1189,8 +1190,7 @@ func (p *ptpProcess) ProcessTs2PhcEvents(ptpOffset float64, source string, iface
 
 	} else {
 		if iface != "" && iface != clockRealTime {
-			r := []rune(iface)
-			iface = string(r[:len(r)-1]) + "x"
+			iface = utils.GetAlias(iface)
 		}
 		switch ptpState {
 		case event.PTP_LOCKED:

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/synce"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/utils"
 
 	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus/collectors"
@@ -781,14 +782,9 @@ func (m *masterOffsetInterface) getAliasByName(configName string, name string) p
 func (m *masterOffsetInterface) set(configName string, value string) {
 	m.Lock()
 	defer m.Unlock()
-	alias := ""
-	if value != "" {
-		r := []rune(value)
-		alias = string(r[:len(r)-1]) + "x"
-	}
 	m.iface[configName] = ptpInterface{
 		name:  value,
-		alias: alias,
+		alias: utils.GetAlias(value),
 	}
 }
 

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -353,8 +353,8 @@ func extractSummaryMetrics(configName, processName, output string) (iface string
 		fields = append(fields, "") // Making space for the new element
 		//  0             1     2
 		//ptp4l.0.config rms   53 max   74 freq -16642 +/-  40 delay  1089 +/-  20
-		copy(fields[2:], fields[1:])                       // Shifting elements
-		fields[1] = masterOffsetIface.get(configName).name // Copying/inserting the value
+		copy(fields[2:], fields[1:])                        // Shifting elements
+		fields[1] = masterOffsetIface.get(configName).alias // Copying/inserting the value
 		//  0             0       1   2
 		//ptp4l.0.config master rms   53 max   74 freq -16642 +/-  40 delay  1089 +/-  20
 	} else if fields[1] != "CLOCK_REALTIME" {

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/debug"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/utils"
 
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/pmc"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/protocol"
@@ -726,23 +727,13 @@ connect:
 
 				// Update the metrics
 				if !e.stdoutToSocket { // if events not enabled
-					eventIface := event.IFace
-					if eventIface != "" {
-						r := []rune(eventIface)
-						eventIface = string(r[:len(r)-1]) + "x"
-					}
-					e.UpdateClockStateMetrics(event.State, string(event.ProcessName), eventIface)
+					e.UpdateClockStateMetrics(event.State, string(event.ProcessName), utils.GetAlias(event.IFace))
 					//  update all metric that was sent to events
 					e.updateMetrics(event.CfgName, event.ProcessName, event.Values, dataDetails)
 
 					e.updateMetrics(event.CfgName, event.ProcessName, event.Values, dataDetails)
 					if gmState.gmIFace != GM_INTERFACE_UNKNOWN { // race condition ;
-						gmIface := gmState.gmIFace
-						if gmIface != "" {
-							r := []rune(gmIface)
-							gmIface = string(r[:len(r)-1]) + "x"
-						}
-						e.UpdateClockStateMetrics(gmState.state, string(GM), gmIface)
+						e.UpdateClockStateMetrics(gmState.state, string(GM), utils.GetAlias(gmState.gmIFace))
 					}
 				}
 
@@ -910,11 +901,7 @@ func (e *EventHandler) UpdateClockStateMetrics(state PTPState, process, iFace st
 }
 
 func (e *EventHandler) updateMetrics(cfgName string, process EventSource, processData map[ValueType]interface{}, d *DataDetails) {
-	iface := d.IFace
-	if len(d.IFace) > 0 {
-		r := []rune(iface)
-		iface = string(r[:len(r)-1]) + "x"
-	}
+	iface := utils.GetAlias(d.IFace)
 
 	for dataType, value := range processData { // update process with metrics
 		var dataValue float64

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,20 @@
+package utils
+
+import "strings"
+
+// GetAlias masks interface names for metric reporting
+func GetAlias(ifname string) string {
+	alias := ""
+	if ifname != "" {
+		// Aliases the interface name or <interface_name>.<vlan>
+		dotIndex := strings.Index(ifname, ".")
+		if dotIndex == -1 {
+			// e.g. ens1f0 -> ens1fx
+			alias = ifname[:len(ifname)-1] + "x"
+		} else {
+			// e.g ens1f0.100 -> ens1fx.100
+			alias = ifname[:dotIndex-1] + "x" + ifname[dotIndex:]
+		}
+	}
+	return alias
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,27 @@
+package utils_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+type testCase struct {
+	ifname        string
+	expectedAlias string
+}
+
+func Test_GetAlias(t *testing.T) {
+	testCases := []testCase{
+		{"eth0", "ethx"},
+		{"eth1.100", "ethx.100"},
+		{"eth1.100.XYZ", "ethx.100.XYZ"},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s->%s", tc.ifname, tc.expectedAlias), func(t *testing.T) {
+			assert.Equal(t, tc.expectedAlias, utils.GetAlias(tc.ifname))
+		})
+	}
+}


### PR DESCRIPTION

Also allows interfaces with the format `<interface name>.<vlan>` 
to be aliased correctly. And uses common function for aliasing
throughout the code.