### PR TITLE
OCPBUGS-57037: 2-port Ordinary Clock backport from 4.19 to 4.18

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -143,6 +143,10 @@ func main() {
 		daemon.StartMetricsServer("0.0.0.0:9091")
 	}
 
+	// Wait for one ticker interval before loading the profile
+	// This allows linuxptp-daemon connection to the cloud-event-proxy container to
+	// be up and running before PTP state logs are printed.
+	time.Sleep(time.Second * time.Duration(cp.updateInterval/2))
 	for {
 		select {
 		case <-tickerPull.C:

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -64,6 +64,7 @@ const (
 	MASTER
 	FAULTY
 	UNKNOWN
+	LISTENING
 )
 
 type masterOffsetInterface struct { // by slave iface with masked index
@@ -146,7 +147,7 @@ var (
 			Namespace: PTPNamespace,
 			Subsystem: PTPSubsystem,
 			Name:      "interface_role",
-			Help:      "0 = PASSIVE, 1 = SLAVE, 2 = MASTER, 3 = FAULTY, 4 = UNKNOWN",
+			Help:      "0 = PASSIVE, 1 = SLAVE, 2 = MASTER, 3 = FAULTY, 4 = UNKNOWN, 5 = LISTENING",
 		}, []string{"process", "node", "iface"})
 
 	ProcessStatus = prometheus.NewGaugeVec(
@@ -665,6 +666,8 @@ func extractPTP4lEventState(output string) (portId int, role ptpPortRole) {
 		role = MASTER
 	} else if strings.Contains(output, "FAULT_DETECTED") || strings.Contains(output, "SYNCHRONIZATION_FAULT") {
 		role = FAULTY
+	} else if strings.Contains(output, "UNCALIBRATED to LISTENING") || strings.Contains(output, "SLAVE to LISTENING") {
+		role = LISTENING
 	} else {
 		portId = 0
 	}

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -666,7 +666,8 @@ func extractPTP4lEventState(output string) (portId int, role ptpPortRole) {
 		role = MASTER
 	} else if strings.Contains(output, "FAULT_DETECTED") || strings.Contains(output, "SYNCHRONIZATION_FAULT") {
 		role = FAULTY
-	} else if strings.Contains(output, "UNCALIBRATED to LISTENING") || strings.Contains(output, "SLAVE to LISTENING") {
+	} else if strings.Contains(output, "UNCALIBRATED to LISTENING") || strings.Contains(output, "SLAVE to LISTENING") ||
+		strings.Contains(output, "INITIALIZING to LISTENING") {
 		role = LISTENING
 	} else {
 		portId = 0


### PR DESCRIPTION
The following PR backports the following PRs / commit from 4.19 to 4.18:
 
- [https://github.com/k8snetworkplumbingwg/linuxptp-daemon/pull/29](https://github.com/k8snetworkplumbingwg/linuxptp-daemon/pull/29). 4.19   f87624ad393cc09cfd2d9d755b2d9a7758238501
- [https://github.com/k8snetworkplumbingwg/linuxptp-daemon/pull/18](https://github.com/k8snetworkplumbingwg/linuxptp-daemon/pull/18). 4.19 f87624ad393cc09cfd2d9d755b2d9a7758238501
- https://github.com/openshift/linuxptp-daemon/pull/374 4.19 e88d5f81aef061194843bfabd36dbc2c1bb53466