### PR TITLE
 Fix gpspipe multiple process and named pipe creation issues[release-4.17]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ fmt:
 	./hack/gofmt.sh
 
 test:
-	go test ./... --tags=unittests -coverprofile=cover.out
+	SKIP_GNSS_MONITORING=1 go test ./... --tags=unittests -coverprofile=cover.out
 
 lint:
 	golangci-lint run

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -253,18 +253,7 @@ func (dn *Daemon) Run() {
 		case <-tickerPmc.C:
 			dn.HandlePmcTicker()
 		case <-dn.stopCh:
-			for _, p := range dn.processManager.process {
-				if p != nil {
-					for _, d := range p.depProcess {
-						if d != nil {
-							d.CmdStop()
-							d = nil
-						}
-					}
-					p.cmdStop()
-					p = nil
-				}
-			}
+			dn.stopAllProcesses()
 			glog.Infof("linuxPTP stop signal received, existing..")
 			return
 		}
@@ -293,28 +282,7 @@ func (dn *Daemon) SetProcessManager(p *ProcessManager) {
 
 func (dn *Daemon) applyNodePTPProfiles() error {
 	glog.Infof("in applyNodePTPProfiles")
-	for _, p := range dn.processManager.process {
-		if p != nil {
-			glog.Infof("stopping process.... %s", p.name)
-			p.cmdStop()
-			if p.depProcess != nil {
-				for _, d := range p.depProcess {
-					if d != nil {
-						d.CmdStop()
-						d = nil
-					}
-				}
-			}
-			p.depProcess = nil
-			//cleanup metrics
-			deleteMetrics(p.ifaces, p.haProfile, p.name, p.configName)
-			if p.name == syncEProcessName && p.syncERelations != nil {
-				deleteSyncEMetrics(p.name, p.configName, p.syncERelations)
-			}
-			p = nil
-		}
-	}
-
+	dn.stopAllProcesses()
 	// All process should have been stopped,
 	// clear process in process manager.
 	// Assigning processManager.process to nil releases
@@ -590,8 +558,45 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 
 		// TODO HARDWARE PLUGIN for e810
 		if pProcess == ts2phcProcessName { //& if the x plugin is enabled
-			if output.gnss_serial_port == "" {
-				output.gnss_serial_port = GPSPIPE_SERIALPORT
+			if clockType == event.GM {
+				if output.gnss_serial_port == "" {
+					output.gnss_serial_port = GPSPIPE_SERIALPORT
+				}
+				// TODO: move this to plugin or call it from hwplugin or leave it here and remove Hardcoded
+				gmInterface := dprocess.ifaces.GetGMInterface().Name
+
+				gpsDaemon := &GPSD{
+					name:        GPSD_PROCESSNAME,
+					execMutex:   sync.Mutex{},
+					cmd:         nil,
+					serialPort:  output.gnss_serial_port,
+					exitCh:      make(chan struct{}),
+					gmInterface: gmInterface,
+					stopped:     false,
+					messageTag:  messageTag,
+					ublxTool:    nil,
+				}
+				gpsDaemon.CmdInit()
+				gpsDaemon.cmdLine = addScheduling(nodeProfile, gpsDaemon.cmdLine)
+				args = strings.Split(gpsDaemon.cmdLine, " ")
+				gpsDaemon.cmd = exec.Command(args[0], args[1:]...)
+				dprocess.depProcess = append(dprocess.depProcess, gpsDaemon)
+
+				// init gpspipe
+				gpsPipeDaemon := &gpspipe{
+					name:       GPSPIPE_PROCESSNAME,
+					execMutex:  sync.Mutex{},
+					cmd:        nil,
+					serialPort: GPSPIPE_SERIALPORT,
+					exitCh:     make(chan struct{}),
+					stopped:    false,
+					messageTag: messageTag,
+				}
+				gpsPipeDaemon.CmdInit()
+				gpsPipeDaemon.cmdLine = addScheduling(nodeProfile, gpsPipeDaemon.cmdLine)
+				args = strings.Split(gpsPipeDaemon.cmdLine, " ")
+				gpsPipeDaemon.cmd = exec.Command(args[0], args[1:]...)
+				dprocess.depProcess = append(dprocess.depProcess, gpsPipeDaemon)
 			}
 			// TODO: move this to plugin or call it from hwplugin or leave it here and remove Hardcoded
 			gmInterface := dprocess.ifaces.GetGMInterface().Name
@@ -1357,4 +1362,45 @@ func (p *ptpProcess) SyncEDeviceByName(name string) *synce.Config {
 		}
 	}
 	return nil
+}
+
+func containsAny(output string, indicators ...string) bool {
+	for _, indicator := range indicators {
+		if strings.Contains(output, indicator) {
+			return true
+		}
+	}
+	return false
+}
+
+func (dn *Daemon) stopAllProcesses() {
+	for _, p := range dn.processManager.process {
+		if p != nil {
+			glog.Infof("stopping process.... %s", p.name)
+
+			// Stop dependencies in reverse order first
+			if p.depProcess != nil {
+				for i := len(p.depProcess) - 1; i >= 0; i-- {
+					d := p.depProcess[i]
+					if d != nil {
+						d.CmdStop()
+						d = nil
+					}
+				}
+			}
+
+			// Stop parent process
+			p.cmdStop()
+			p.depProcess = nil
+
+			// Cleanup metrics
+			deleteMetrics(p.ifaces, p.haProfile, p.name, p.configName)
+
+			if p.name == syncEProcessName && p.syncERelations != nil {
+				deleteSyncEMetrics(p.name, p.configName, p.syncERelations)
+			}
+
+			p = nil
+		}
+	}
 }

--- a/pkg/daemon/gpsd.go
+++ b/pkg/daemon/gpsd.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -22,6 +23,17 @@ const (
 	GPSD_PROCESSNAME     = "gpsd"
 	GNSSMONITOR_INTERVAL = 1 * time.Second
 )
+
+type filteringStderrWriter struct{}
+
+func (w *filteringStderrWriter) Write(p []byte) (n int, err error) {
+	if bytes.Contains(p, []byte("Inappropriate ioctl for device")) {
+		// Suppress this error
+		return len(p), nil
+	}
+	// Write all other output to the real stderr (container logs)
+	return os.Stderr.Write(p)
+}
 
 type GPSD struct {
 	name                 string
@@ -165,7 +177,7 @@ func (g *GPSD) CmdRun(stdoutToSocket bool) {
 	for {
 		glog.Infof("Starting %s...", g.Name())
 		glog.Infof("%s cmd: %+v", g.Name(), g.cmd)
-		g.cmd.Stderr = os.Stderr
+		g.cmd.Stderr = &filteringStderrWriter{}
 		var err error
 		if err != nil {
 			glog.Errorf("CmdRun() error creating StdoutPipe for %s: %v", g.Name(), err)

--- a/pkg/daemon/gpspipe.go
+++ b/pkg/daemon/gpspipe.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sync"
 	"syscall"
 	"time"
@@ -22,6 +23,10 @@ const (
 	GPSD_DIR = "/gpsd"
 )
 
+// Global mutex to protect shared directory and named pipe operations
+// This prevents race conditions when multiple gpspipe instances are created simultaneously
+var gpspipeGlobalMutex sync.Mutex
+
 type gpspipe struct {
 	name       string
 	execMutex  sync.Mutex
@@ -31,6 +36,7 @@ type gpspipe struct {
 	exitCh     chan struct{}
 	stopped    bool
 	messageTag string
+	c          *net.Conn
 }
 
 // Name ... Process name
@@ -63,26 +69,62 @@ func (gp *gpspipe) Stopped() bool {
 
 // CmdStop ... stop gpspipe
 func (gp *gpspipe) CmdStop() {
+	defer func() {
+		// Clean up (delete) the named pipe, this ensures that the named pipe is deleted when the process is terminated
+		// no stale data is left in the named pipe
+		err := os.Remove(GPSPIPE_SERIALPORT)
+		if err != nil && !os.IsNotExist(err) {
+			glog.Errorf("Failed to delete named pipe: %s", GPSPIPE_SERIALPORT)
+		}
+		glog.Infof("Process %s terminated", gp.name)
+	}()
 	glog.Infof("stopping %s...", gp.name)
+
+	// Always set the stopped flag first
+	gp.setStopped(true)
+	gp.ProcessStatus(nil, PtpProcessDown)
+
 	if gp.cmd == nil {
 		return
 	}
-	gp.setStopped(true)
-	processStatus(nil, gp.name, gp.messageTag, PtpProcessDown)
+
 	if gp.cmd.Process != nil {
 		glog.Infof("Sending TERM to (%s) PID: %d", gp.name, gp.cmd.Process.Pid)
-		err := gp.cmd.Process.Signal(syscall.SIGTERM)
-		if err != nil {
+		signalErr := gp.cmd.Process.Signal(syscall.SIGTERM)
+		if signalErr != nil {
 			glog.Errorf("Failed to send term signal to named pipe: %s", GPSPIPE_SERIALPORT)
 			return
 		}
+
+		// Wait for process to terminate with timeout
+		done := make(chan error, 1)
+		go func() {
+			done <- gp.cmd.Wait()
+		}()
+
+		select {
+		case err := <-done:
+			if err != nil {
+				glog.Warningf("Process %s exited with error: %v", gp.name, err)
+			} else {
+				glog.Infof("Process %s terminated gracefully", gp.name)
+			}
+		case <-time.After(5 * time.Second):
+			glog.Warningf("Process %s did not terminate gracefully, sending SIGKILL", gp.name)
+			if err := gp.cmd.Process.Signal(syscall.SIGKILL); err != nil {
+				glog.Errorf("Failed to send SIGKILL to process %s: %v", gp.name, err)
+			}
+			// Add a second timeout to ensure Wait() doesn't hang forever
+			select {
+			case err := <-done:
+				glog.Warningf("Process %s exited after SIGKILL: %v", gp.name, err)
+			case <-time.After(2 * time.Second):
+				glog.Errorf("Process %s failed to exit even after SIGKILL", gp.name)
+			}
+		}
+
 	}
-	// Clean up (delete) the named pipe
-	err := os.Remove(GPSPIPE_SERIALPORT)
-	if err != nil {
-		glog.Errorf("Failed to delete named pipe: %s", GPSPIPE_SERIALPORT)
-	}
-	glog.Infof("Process %s terminated", gp.name)
+
 }
 
 // CmdInit ... initialize gpspipe
@@ -93,51 +135,196 @@ func (gp *gpspipe) CmdInit() {
 	gp.cmdLine = fmt.Sprintf("/usr/local/bin/gpspipe -v -R -l -o %s", gp.SerialPort())
 }
 
+func (gp *gpspipe) ProcessStatus(c *net.Conn, status int64) {
+	if c != nil {
+		gp.c = c
+	}
+	processStatus(gp.c, gp.name, gp.messageTag, status)
+}
+
 // CmdRun ... run gpspipe
 func (gp *gpspipe) CmdRun(stdoutToSocket bool) {
 	defer func() {
-		gp.exitCh <- struct{}{}
+		select {
+		case gp.exitCh <- struct{}{}:
+		default:
+		}
 	}()
-	processStatus(nil, gp.name, gp.messageTag, PtpProcessUp)
+
 	for {
+		// Check if we should stop before starting a new process
+		if gp.Stopped() {
+			gp.ProcessStatus(nil, PtpProcessDown)
+			glog.Infof("Process %s terminated and will not be restarted. Exiting.", gp.name)
+			break
+		}
+
+		// Ensure named pipe is created before starting the process
+		// This handles cases where another process might have deleted the named pipe
+		if err := mkFifo(); err != nil {
+			glog.Errorf("Failed to create named pipe: %v", err)
+			return // Exit the process, let the daemon restart it, since mkFifo is critical for GNSS monitoring
+			// and it panics if it fails
+		}
+
+		gp.ProcessStatus(nil, PtpProcessUp)
 		glog.Infof("Starting %s...", gp.Name())
 		glog.Infof("%s cmd: %+v", gp.Name(), gp.cmd)
 		gp.cmd.Stderr = os.Stderr
-		var err error
+
+		// Start the process
+		err := gp.cmd.Start()
 		if err != nil {
-			glog.Errorf("CmdRun() error creating StdoutPipe for %s: %v", gp.Name(), err)
-			if gp.Stopped() {
-				return
-			}
+			glog.Errorf("CmdRun() error starting %s: %v", gp.Name(), err)
+			// Wait before retrying
 			time.Sleep(1 * time.Second)
 			continue
 		}
-		// Don't restart after termination
-		if !gp.Stopped() {
-			time.Sleep(1 * time.Second)
-			err = gp.cmd.Start() // this is asynchronous call,
-			if err != nil {
-				glog.Errorf("CmdRun() error starting %s: %v", gp.Name(), err)
-			}
-			err = gp.cmd.Wait()
-			if err != nil {
-				glog.Errorf("CmdRun() error waiting for %s: %v, atempting to restart", gp.Name(), err)
-			}
-			newCmd := exec.Command(gp.cmd.Args[0], gp.cmd.Args[1:]...)
-			gp.cmd = newCmd
-		} else {
-			processStatus(nil, gp.name, gp.messageTag, PtpProcessDown)
-			gp.exitCh <- struct{}{}
+
+		// Wait for the process to complete using goroutine pattern
+		err = gp.cmd.Wait()
+		if err != nil {
+			glog.Errorf("CmdRun() error waiting for %s: %v, attempting to restart", gp.Name(), err)
+		}
+
+		// Check if we should stop after process completes
+		if gp.Stopped() {
+			gp.ProcessStatus(nil, PtpProcessDown)
+			glog.Infof("Process %s terminated and will not be restarted. Exiting.", gp.name)
 			break
 		}
+
+		// Create new command for restart
+		gp.cmd = exec.Command(gp.cmd.Args[0], gp.cmd.Args[1:]...)
+		time.Sleep(1 * time.Second)
 	}
 }
 
+// mkFifo creates the named pipe if it doesn't exist, or removes and recreates it if it does
+// Retries up to 5 times with exponential backoff if the operation fails
+// Panics if all attempts fail as this is critical for GNSS monitoring (unless in test environment)
+// Uses global mutex to prevent race conditions when multiple gpspipe instances are created simultaneously
 func mkFifo() error {
-	//TODO:this could be used as mount volume
-	_ = os.Mkdir(GPSD_DIR, os.ModePerm)
-	if err := syscall.Mkfifo(GPSPIPE_SERIALPORT, 0600); err != nil {
+	gpspipeGlobalMutex.Lock()
+	defer gpspipeGlobalMutex.Unlock()
+
+	const maxRetries = 5
+	const baseDelay = 100 * time.Millisecond
+
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		err := createNamedPipe()
+		if err == nil {
+			if attempt == 1 {
+				glog.Infof("Successfully created named pipe: %s", GPSPIPE_SERIALPORT)
+			} else {
+				glog.Infof("Successfully created named pipe: %s (after %d attempts)", GPSPIPE_SERIALPORT, attempt)
+			}
+			return nil
+		}
+
+		if attempt == maxRetries {
+			msg := fmt.Sprintf("Failed to create named pipe after %d attempts: %v", maxRetries, err)
+			if os.Getenv("SKIP_GNSS_MONITORING") == "1" {
+				glog.Warning("Test environment: " + msg)
+				return fmt.Errorf("failed to create named pipe after %d attempts", maxRetries)
+			}
+			glog.Fatalf("CRITICAL: %s. GNSS monitoring cannot continue.", msg)
+		}
+
+		// Exponential backoff: 100ms, 200ms, 400ms, etc.
+		delay := baseDelay * time.Duration(1<<(attempt-1))
+		glog.Warningf("Failed to create named pipe (attempt %d/%d): %v. Retrying in %v...", attempt, maxRetries, err, delay)
+		time.Sleep(delay)
+	}
+
+	return nil // Unreachable, but required by compiler
+}
+
+// createNamedPipe performs the actual named pipe creation logic
+func createNamedPipe() error {
+	// Step 1: Ensure the directory exists
+	if err := ensureDirectoryExists(); err != nil {
 		return err
+	}
+
+	// Step 2: Remove existing named pipe if it exists
+	if err := removeExistingPipe(); err != nil {
+		return err
+	}
+
+	// Step 3: Create the new named pipe
+	if err := createNewPipe(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ensureDirectoryExists creates the GPSD directory if it doesn't exist
+// If the directory exists but has issues, it will be removed and recreated
+func ensureDirectoryExists() error {
+	// Check if directory already exists
+	if _, err := os.Stat(GPSD_DIR); err == nil {
+		// Directory exists, check if it's valid
+		if isValidDirectory(GPSD_DIR) {
+			// Directory is valid, no need to recreate
+			return nil
+		}
+
+		// Directory exists but is invalid, remove it
+		glog.Infof("Directory %s exists but is invalid, removing and recreating", GPSD_DIR)
+		if err = os.RemoveAll(GPSD_DIR); err != nil {
+			return fmt.Errorf("failed to remove invalid directory %s: %v", GPSD_DIR, err)
+		}
+	} else if !os.IsNotExist(err) {
+		// Some other error occurred (not just "doesn't exist")
+		return fmt.Errorf("failed to check directory %s: %v", GPSD_DIR, err)
+	}
+
+	// Create the directory (either it didn't exist or we just removed it)
+	if err := os.MkdirAll(GPSD_DIR, os.ModePerm); err != nil {
+		return fmt.Errorf("failed to create directory %s: %v", GPSD_DIR, err)
+	}
+
+	return nil
+}
+
+// isValidDirectory checks if the directory is valid and usable
+func isValidDirectory(dirPath string) bool {
+	info, err := os.Stat(dirPath)
+	if err != nil || !info.IsDir() {
+		return false
+	}
+	testFile := filepath.Join(dirPath, ".test_write_access")
+	if err = os.WriteFile(testFile, []byte("test"), 0600); err != nil {
+		return false
+	}
+	_ = os.Remove(testFile)
+	return true
+}
+
+// removeExistingPipe removes the named pipe if it already exists
+func removeExistingPipe() error {
+	// Check if named pipe exists
+	if _, err := os.Stat(GPSPIPE_SERIALPORT); err == nil {
+		// Named pipe exists, remove it
+		glog.Infof("Named pipe %s already exists, removing it", GPSPIPE_SERIALPORT)
+		err = os.Remove(GPSPIPE_SERIALPORT)
+		if err != nil {
+			return fmt.Errorf("failed to remove existing named pipe %s: %v", GPSPIPE_SERIALPORT, err)
+		}
+	} else if !os.IsNotExist(err) {
+		// Some other error occurred (not just "doesn't exist")
+		return fmt.Errorf("failed to check named pipe %s: %v", GPSPIPE_SERIALPORT, err)
+	}
+	// If os.IsNotExist(err) is true, the pipe doesn't exist, which is fine
+	return nil
+}
+
+// createNewPipe creates the named pipe using syscall.Mkfifo
+func createNewPipe() error {
+	if err := syscall.Mkfifo(GPSPIPE_SERIALPORT, 0600); err != nil {
+		return fmt.Errorf("failed to create named pipe %s: %v", GPSPIPE_SERIALPORT, err)
 	}
 	return nil
 }

--- a/pkg/daemon/gpspipe_test.go
+++ b/pkg/daemon/gpspipe_test.go
@@ -1,0 +1,244 @@
+package daemon
+
+import (
+	"os"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// Test-specific constants
+const (
+	testGPSdDir           = "/tmp/test_gpsd"
+	testGPSPipeSerialPort = "/tmp/test_gpsd/gpspipe"
+)
+
+// testMkFifo is a test-specific version that doesn't call glog.Fatalf
+func testMkFifo() error {
+	const maxRetries = 5
+	const baseDelay = 100 * time.Millisecond
+
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		err := testCreateNamedPipe()
+		if err == nil {
+			// Success - return immediately
+			return nil
+		}
+
+		// If this is the last attempt, return error instead of panicking
+		if attempt == maxRetries {
+			return err
+		}
+
+		// Calculate delay with exponential backoff
+		delay := baseDelay * time.Duration(1<<(attempt-1)) // 100ms, 200ms, 400ms, 800ms, 1600ms
+		// glog.Warningf("Failed to create named pipe (attempt %d/%d): %v. Retrying in %v...", attempt, maxRetries, err, delay)
+		time.Sleep(delay)
+	}
+
+	return nil
+}
+
+// testCreateNamedPipe performs the actual named pipe creation logic for tests
+func testCreateNamedPipe() error {
+	// Create directory if it doesn't exist
+	if err := os.MkdirAll(testGPSdDir, os.ModePerm); err != nil {
+		return err
+	}
+
+	// Check if named pipe already exists
+	if _, err := os.Stat(testGPSPipeSerialPort); err == nil {
+		// Named pipe exists, remove it first
+		if err = os.Remove(testGPSPipeSerialPort); err != nil {
+			return err
+		}
+	} else if !os.IsNotExist(err) {
+		// Some other error occurred
+		return err
+	}
+
+	// Create the named pipe
+	if err := syscall.Mkfifo(testGPSPipeSerialPort, 0600); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func TestGpspipeProcessLifecycle(t *testing.T) {
+	// Create a gpspipe instance
+	gp := &gpspipe{
+		name:       "gpspipe_test",
+		serialPort: GPSPIPE_SERIALPORT,
+		exitCh:     make(chan struct{}),
+		stopped:    false,
+	}
+	gp.CmdInit()
+
+	// Test that process starts when not stopped
+	if gp.Stopped() {
+		t.Error("Process should not be stopped initially")
+	}
+
+	// Test setting stopped flag
+	gp.setStopped(true)
+	if !gp.Stopped() {
+		t.Error("Process should be stopped after setStopped(true)")
+	}
+
+	// Test resetting stopped flag
+	gp.setStopped(false)
+	if gp.Stopped() {
+		t.Error("Process should not be stopped after setStopped(false)")
+	}
+}
+
+func TestMkFifoSuccess(t *testing.T) {
+	// Clean up any existing test named pipe
+	if err := os.Remove(testGPSPipeSerialPort); err != nil && !os.IsNotExist(err) {
+		t.Logf("Warning: failed to remove existing test named pipe: %v", err)
+	}
+	if err := os.RemoveAll(testGPSdDir); err != nil && !os.IsNotExist(err) {
+		t.Logf("Warning: failed to remove existing test directory: %v", err)
+	}
+
+	// Test creating named pipe
+	mkfifoErr := testMkFifo()
+	if mkfifoErr != nil {
+		t.Errorf("testMkFifo failed: %v", mkfifoErr)
+	}
+
+	// Check that named pipe exists
+	if _, statErr := os.Stat(testGPSPipeSerialPort); os.IsNotExist(statErr) {
+		t.Error("Named pipe was not created")
+	}
+
+	// Clean up
+	if err := os.Remove(testGPSPipeSerialPort); err != nil && !os.IsNotExist(err) {
+		t.Logf("Warning: failed to clean up test named pipe: %v", err)
+	}
+	if err := os.RemoveAll(testGPSdDir); err != nil && !os.IsNotExist(err) {
+		t.Logf("Warning: failed to clean up test directory: %v", err)
+	}
+}
+
+func TestMkFifoRecreation(t *testing.T) {
+	// Clean up any existing test named pipe
+	if err := os.Remove(testGPSPipeSerialPort); err != nil && !os.IsNotExist(err) {
+		t.Logf("Warning: failed to remove existing test named pipe: %v", err)
+	}
+	if err := os.RemoveAll(testGPSdDir); err != nil && !os.IsNotExist(err) {
+		t.Logf("Warning: failed to remove existing test directory: %v", err)
+	}
+
+	// Test creating named pipe
+	mkfifoErr := testMkFifo()
+	if mkfifoErr != nil {
+		t.Errorf("testMkFifo failed: %v", mkfifoErr)
+	}
+
+	// Check that named pipe exists
+	if _, statErr := os.Stat(testGPSPipeSerialPort); os.IsNotExist(statErr) {
+		t.Error("Named pipe was not created")
+	}
+
+	// Test recreating named pipe (should remove and recreate)
+	mkfifoErr = testMkFifo()
+	if mkfifoErr != nil {
+		t.Errorf("testMkFifo failed to recreate: %v", mkfifoErr)
+	}
+
+	// Check that named pipe still exists
+	if _, statErr := os.Stat(testGPSPipeSerialPort); os.IsNotExist(statErr) {
+		t.Error("Named pipe was not recreated")
+	}
+
+	// Clean up
+	if err := os.Remove(testGPSPipeSerialPort); err != nil && !os.IsNotExist(err) {
+		t.Logf("Warning: failed to clean up test named pipe: %v", err)
+	}
+	if err := os.RemoveAll(testGPSdDir); err != nil && !os.IsNotExist(err) {
+		t.Logf("Warning: failed to clean up test directory: %v", err)
+	}
+}
+
+func TestCreateNamedPipe(t *testing.T) {
+	// Clean up any existing test named pipe
+	if err := os.Remove(testGPSPipeSerialPort); err != nil && !os.IsNotExist(err) {
+		t.Logf("Warning: failed to remove existing test named pipe: %v", err)
+	}
+	if err := os.RemoveAll(testGPSdDir); err != nil && !os.IsNotExist(err) {
+		t.Logf("Warning: failed to remove existing test directory: %v", err)
+	}
+
+	// Test the underlying testCreateNamedPipe function
+
+	if err := testCreateNamedPipe(); err != nil {
+		t.Errorf("testCreateNamedPipe failed: %v", err)
+	}
+
+	// Check that named pipe exists
+	if _, statErr := os.Stat(testGPSPipeSerialPort); os.IsNotExist(statErr) {
+		t.Error("Named pipe was not created by testCreateNamedPipe")
+	}
+
+	// Clean up
+	if err := os.Remove(testGPSPipeSerialPort); err != nil && !os.IsNotExist(err) {
+		t.Logf("Warning: failed to clean up test named pipe: %v", err)
+	}
+	if err := os.RemoveAll(testGPSdDir); err != nil && !os.IsNotExist(err) {
+		t.Logf("Warning: failed to clean up test directory: %v", err)
+	}
+}
+
+func TestGpspipeStopBehavior(t *testing.T) {
+	// Create a gpspipe instance
+	gp := &gpspipe{
+		name:       "gpspipe_stop_test",
+		serialPort: GPSPIPE_SERIALPORT,
+		exitCh:     make(chan struct{}),
+		stopped:    false,
+	}
+	gp.CmdInit()
+
+	// Test that CmdStop sets the stopped flag
+	gp.CmdStop()
+	if !gp.Stopped() {
+		t.Error("CmdStop should set the stopped flag")
+	}
+}
+
+func TestMkFifoRetryLogic(t *testing.T) {
+	// This test verifies that the retry logic works correctly
+	// We can't easily test the panic scenario in unit tests, but we can test the retry behavior
+
+	// Clean up any existing test named pipe
+	if err := os.Remove(testGPSPipeSerialPort); err != nil && !os.IsNotExist(err) {
+		t.Logf("Warning: failed to remove existing test named pipe: %v", err)
+	}
+	if err := os.RemoveAll(testGPSdDir); err != nil && !os.IsNotExist(err) {
+		t.Logf("Warning: failed to remove existing test directory: %v", err)
+	}
+
+	// Test that testMkFifo succeeds on first attempt when conditions are good
+	start := time.Now()
+	mkfifoErr := testMkFifo()
+	duration := time.Since(start)
+
+	if mkfifoErr != nil {
+		t.Errorf("testMkFifo failed: %v", mkfifoErr)
+	}
+
+	// Should succeed quickly (no retries needed)
+	if duration > 200*time.Millisecond {
+		t.Errorf("testMkFifo took too long (%v), suggesting unnecessary retries", duration)
+	}
+
+	// Clean up
+	if err := os.Remove(testGPSPipeSerialPort); err != nil && !os.IsNotExist(err) {
+		t.Logf("Warning: failed to clean up test named pipe: %v", err)
+	}
+	if err := os.RemoveAll(testGPSdDir); err != nil && !os.IsNotExist(err) {
+		t.Logf("Warning: failed to clean up test directory: %v", err)
+	}
+}


### PR DESCRIPTION
Cherry pick form upstream PR https://github.com/k8snetworkplumbingwg/linuxptp-daemon/pull/58
and downstream 4.20 commit https://github.com/openshift/linuxptp-daemon/commit/dcd31fd57f0dcb5f2e922b2c52cb2ae7a969d6ce

This PR improves process management and error handling for the gpsd and gpspipe daemons by:

Adding proper process termination with timeouts (graceful SIGTERM, then SIGKILL if needed)
Improving restart logic and reducing tight restart loops
Enhancing named pipe (FIFO) creation with retries and better error messages

Problem
The gpspipe process was experiencing two critical issues:
Multiple processes running simultaneously: The restart logic in CmdRun() was creating new processes before properly checking if the previous process should be stopped, leading to multiple gpspipe processes running at the same time.
Named pipe creation errors: The mkFifo() function was failing when a named pipe already existed, causing the error "Error creating named pipe, GNSS monitoring will not work as expected

Solution:
Added proper gp.Stopped() checks at the beginning of each loop iteration in CmdRun()
Enhanced mkFifo() function to check for existing named pipes and remove them before creation
Added graceful shutdown with SIGTERM signal.

Also implmented filteringStderrWriter to selectively suppressing known noisy errors like "Inappropriate ioctl for device" from being logged, while still allowing all other stderr output to pass through.