### PR TITLE
[release-4-19] OCPBUGS-61053: When Locking PTP Source to One NIC With Dual NIC PTP Synchronization Configured, Incorrect Clock Class Reported via REST API

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -177,6 +178,7 @@ type ptpProcess struct {
 	nodeProfile         ptpv1.PtpProfile
 	parentClockClass    float64
 	pmcCheck            bool
+	clockClassRunning   atomic.Bool
 	clockType           event.ClockType
 	ptpClockThreshold   *ptpv1.PtpClockThreshold
 	haProfile           map[string][]string // stores list of interface name for each profile
@@ -197,6 +199,23 @@ func (p *ptpProcess) setStopped(val bool) {
 	p.execMutex.Lock()
 	p.stopped = val
 	p.execMutex.Unlock()
+}
+
+// TriggerPmcCheck sets pmcCheck to true in a thread-safe way
+func (p *ptpProcess) TriggerPmcCheck() {
+	p.execMutex.Lock()
+	p.pmcCheck = true
+	p.execMutex.Unlock()
+}
+
+// ConsumePmcCheck atomically reads and resets the pmcCheck flag.
+// It returns true if a PMC check should be performed.
+func (p *ptpProcess) ConsumePmcCheck() bool {
+	p.execMutex.Lock()
+	val := p.pmcCheck
+	p.pmcCheck = false
+	p.execMutex.Unlock()
+	return val
 }
 
 // Daemon is the main structure for linuxptp instance.
@@ -780,7 +799,7 @@ func (dn *Daemon) GetPhaseOffsetPinFilter(nodeProfile *ptpv1.PtpProfile) map[str
 func (dn *Daemon) HandlePmcTicker() {
 	for _, p := range dn.processManager.process {
 		if p.name == ptp4lProcessName {
-			p.pmcCheck = true
+			p.TriggerPmcCheck()
 		}
 	}
 }
@@ -823,6 +842,12 @@ func processStatus(c *net.Conn, processName, messageTag string, status int64) {
 }
 
 func (p *ptpProcess) updateClockClass(c *net.Conn) {
+	// Per-process single-flight guard
+	if !p.clockClassRunning.CompareAndSwap(false, true) {
+		glog.Infof("clock class update already running for %s, skipping this run", p.configName)
+		return
+	}
+	defer p.clockClassRunning.Store(false)
 	defer func() {
 		if r := recover(); r != nil {
 			glog.Errorf("updateClockClass Recovered in f %#v", r)
@@ -846,7 +871,7 @@ func (p *ptpProcess) updateClockClass(c *net.Conn) {
 				// change to pint every minute or when the clock class changes
 				clockClassOut = fmt.Sprintf("%s[%d]:[%s] CLOCK_CLASS_CHANGE %f\n", p.name, time.Now().Unix(), p.configName, p.parentClockClass)
 				if c == nil {
-					UpdateClockClassMetrics(clockClass) // no socket then update metrics
+					UpdateClockClassMetrics(p.configName, clockClass) // no socket then update metrics
 				} else {
 					_, err := (*c).Write([]byte(clockClassOut))
 					if err != nil {
@@ -946,12 +971,26 @@ func (p *ptpProcess) cmdRun(stdoutToSocket bool, pm *PluginManager) {
 						d.ProcessStatus(p.c, PtpProcessUp)
 					}
 				}
+				// moving outside scanner loop to ensure  clock class update routine
+				// even if process hangs
+				go func() {
+					for {
+						select {
+						case <-p.exitCh:
+							glog.Infof("Exiting pmcCheck%s...", p.name)
+							return
+						default:
+							if p.ConsumePmcCheck() {
+								p.updateClockClass(p.c)
+							}
+							//Add a small sleep to avoid tight CPU loop
+							time.Sleep(100 * time.Millisecond)
+						}
+					}
+				}()
+
 				for scanner.Scan() {
 					output := scanner.Text()
-					if p.pmcCheck {
-						p.pmcCheck = false
-						go p.updateClockClass(p.c)
-					}
 
 					if regexErr != nil || !logFilterRegex.MatchString(output) {
 						fmt.Printf("%s\n", output)
@@ -1025,7 +1064,7 @@ func (p *ptpProcess) processPTPMetrics(output string) {
 		logEntry := synce.ParseLog(output)
 		p.ProcessSynceEvents(logEntry)
 	} else {
-		configName, source, ptpOffset, clockState, iface := extractMetrics(p.messageTag, p.name, p.ifaces, output)
+		configName, source, ptpOffset, clockState, iface := extractMetrics(p.messageTag, p.name, p.ifaces, output, p.c == nil)
 		p.hasCollectedMetrics = true
 		if iface != "" { // for ptp4l/phc2sys this function only update metrics
 			var values map[event.ValueType]interface{}
@@ -1047,6 +1086,17 @@ func (p *ptpProcess) processPTPMetrics(output string) {
 				state = event.PTP_HOLDOVER // consider s1 state as holdover,this passed to event to create metrics and events
 			}
 			p.ProcessTs2PhcEvents(ptpOffset, source, ifaceName, state, values)
+		} else if clockState == HOLDOVER || clockState == LOCKED {
+			// in case of holdover without iface, still need to update clock class for T_G
+			if p.name != ts2phcProcessName && p.name != syncEProcessName { // TGM announce clock class via events
+				p.ConsumePmcCheck() // reset pmc check since we are updating clock class here
+				// on faulty port or recovery of slave port there might be a clock class change
+				go func() {
+					time.Sleep(50 * time.Millisecond)
+					p.updateClockClass(p.c)
+					glog.Infof("clock class updated %f", p.parentClockClass)
+				}()
+			}
 		}
 	}
 }
@@ -1058,6 +1108,9 @@ func (p *ptpProcess) cmdStop() {
 		return
 	}
 	p.setStopped(true)
+	// reset runtime flags
+	p.ConsumePmcCheck()
+	p.clockClassRunning.Store(false)
 	if p.cmd.Process != nil {
 		glog.Infof("Sending TERM to (%s) PID: %d", p.name, p.cmd.Process.Pid)
 		err := p.cmd.Process.Signal(syscall.SIGTERM)
@@ -1138,6 +1191,9 @@ func (p *ptpProcess) ProcessTs2PhcEvents(ptpOffset float64, source string, iface
 	} else {
 		if iface != "" && iface != clockRealTime {
 			iface = utils.GetAlias(iface)
+		}
+		if p.c != nil {
+			return // no metrics when socket is used
 		}
 		switch ptpState {
 		case event.PTP_LOCKED:
@@ -1354,10 +1410,11 @@ func (p *ptpProcess) ProcessSynceEvents(logEntry synce.LogEntry) {
 					ExtendedSSM: 0,
 				})
 				state = sDeviceConfig.LastClockState
-				UpdateSynceQLMetrics(syncEProcessName, p.configName, iface, sDeviceConfig.NetworkOption, sDeviceConfig.Name, "SSM", logEntry.QL)
-				UpdateSynceQLMetrics(syncEProcessName, p.configName, iface, sDeviceConfig.NetworkOption, sDeviceConfig.Name, "Extended SSM", synce.QL_DEFAULT_ENHSSM)
-				UpdateSynceClockQlMetrics(syncEProcessName, p.configName, iface, sDeviceConfig.NetworkOption, sDeviceConfig.Name, int(logEntry.QL)+int(synce.QL_DEFAULT_ENHSSM))
-
+				if p.c == nil { // only update metrics if no socket is used
+					UpdateSynceQLMetrics(syncEProcessName, p.configName, iface, sDeviceConfig.NetworkOption, sDeviceConfig.Name, "SSM", logEntry.QL)
+					UpdateSynceQLMetrics(syncEProcessName, p.configName, iface, sDeviceConfig.NetworkOption, sDeviceConfig.Name, "Extended SSM", synce.QL_DEFAULT_ENHSSM)
+					UpdateSynceClockQlMetrics(syncEProcessName, p.configName, iface, sDeviceConfig.NetworkOption, sDeviceConfig.Name, int(logEntry.QL)+int(synce.QL_DEFAULT_ENHSSM))
+				}
 			} else if sDeviceConfig.ExtendedTlv == synce.ExtendedTLV_ENABLED {
 				var lastQLState *synce.QualityLevelInfo
 				var ok bool
@@ -1381,9 +1438,11 @@ func (p *ptpProcess) ProcessSynceEvents(logEntry synce.LogEntry) {
 						ExtendedSSM: lastQLState.ExtendedSSM,
 						Priority:    0,
 					})
-					UpdateSynceQLMetrics(syncEProcessName, p.configName, iface, sDeviceConfig.NetworkOption, sDeviceConfig.Name, "SSM", lastQLState.SSM)
-					UpdateSynceQLMetrics(syncEProcessName, p.configName, iface, sDeviceConfig.NetworkOption, sDeviceConfig.Name, "Extended SSM", logEntry.ExtQl)
-					UpdateSynceClockQlMetrics(syncEProcessName, p.configName, iface, sDeviceConfig.NetworkOption, sDeviceConfig.Name, int(lastQLState.SSM)+int(logEntry.ExtQl))
+					if p.c == nil {
+						UpdateSynceQLMetrics(syncEProcessName, p.configName, iface, sDeviceConfig.NetworkOption, sDeviceConfig.Name, "SSM", lastQLState.SSM)
+						UpdateSynceQLMetrics(syncEProcessName, p.configName, iface, sDeviceConfig.NetworkOption, sDeviceConfig.Name, "Extended SSM", logEntry.ExtQl)
+						UpdateSynceClockQlMetrics(syncEProcessName, p.configName, iface, sDeviceConfig.NetworkOption, sDeviceConfig.Name, int(lastQLState.SSM)+int(logEntry.ExtQl))
+					}
 
 					state = sDeviceConfig.LastClockState
 				} else if logEntry.QL != synce.QL_DEFAULT_SSM { //else we have only QL

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -84,7 +84,7 @@ func (tc *TestCase) cleanupMetrics() {
 	daemon.FrequencyAdjustment.With(map[string]string{"from": tc.from, "process": tc.process, "node": tc.node, "iface": tc.iface}).Set(CLEANUP)
 	daemon.Delay.With(map[string]string{"from": tc.from, "process": tc.process, "node": tc.node, "iface": tc.iface}).Set(CLEANUP)
 	daemon.ClockState.With(map[string]string{"process": tc.process, "node": tc.node, "iface": tc.iface}).Set(CLEANUP)
-	daemon.ClockClassMetrics.With(map[string]string{"process": tc.process, "node": tc.node}).Set(CLEANUP)
+	daemon.ClockClassMetrics.With(map[string]string{"process": tc.process, "config": "ptp4l.0.config", "node": tc.node}).Set(CLEANUP)
 	daemon.InterfaceRole.With(map[string]string{"process": tc.process, "node": tc.node, "iface": tc.iface}).Set(CLEANUP)
 }
 
@@ -274,7 +274,7 @@ func Test_ProcessPTPMetrics(t *testing.T) {
 			assert.Equal(tc.expectedClockState, testutil.ToFloat64(clockState), "ClockState does not match\n%s", tc.String())
 		}
 		if tc.expectedClockClassMetrics != SKIP {
-			clockClassMetrics := daemon.ClockClassMetrics.With(map[string]string{"process": tc.process, "node": tc.node})
+			clockClassMetrics := daemon.ClockClassMetrics.With(map[string]string{"process": tc.process, "config": "ptp4l.0.config", "node": tc.node})
 			assert.Equal(tc.expectedClockClassMetrics, testutil.ToFloat64(clockClassMetrics), "ClockClassMetrics does not match\n%s", tc.String())
 		}
 		if tc.expectedInterfaceRole != SKIP {

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -142,7 +142,7 @@ var (
 			Subsystem: PTPSubsystem,
 			Name:      "clock_class",
 			Help:      "6 = Locked, 7 = PRC unlocked in-spec, 52/187 = PRC unlocked out-of-spec, 135 = T-BC holdover in-spec, 165 = T-BC holdover out-of-spec, 248 = Default, 255 = Slave Only Clock",
-		}, []string{"process", "node"})
+		}, []string{"process", "node", "config"})
 
 	// InterfaceRole metrics to show current interface role
 	InterfaceRole = prometheus.NewGaugeVec(
@@ -256,7 +256,7 @@ func updatePTPMetrics(from, process, iface string, ptpOffset, maxPtpOffset, freq
 }
 
 // extractMetrics ...
-func extractMetrics(messageTag string, processName string, ifaces config.IFaces, output string) (configName, source string, offset float64, state string, iface string) {
+func extractMetrics(messageTag string, processName string, ifaces config.IFaces, output string, updateMetrics bool) (configName, source string, offset float64, state string, iface string) {
 	configName = strings.Replace(strings.Replace(messageTag, "]", "", 1), "[", "", 1)
 	if configName != "" {
 		configName = strings.Split(configName, MessageTagSuffixSeperator)[0] // remove any suffix added to the configName
@@ -287,8 +287,10 @@ func extractMetrics(messageTag string, processName string, ifaces config.IFaces,
 			if offsetSource == master {
 				masterOffsetSource.set(configName, processName)
 			}
-			updatePTPMetrics(offsetSource, processName, ifaceName, ptpOffset, maxPtpOffset, frequencyAdjustment, delay)
-			updateClockStateMetrics(processName, ifaceName, clockstate)
+			if updateMetrics {
+				updatePTPMetrics(offsetSource, processName, ifaceName, ptpOffset, maxPtpOffset, frequencyAdjustment, delay)
+				updateClockStateMetrics(processName, ifaceName, clockstate)
+			}
 		}
 		source = processName
 		offset = ptpOffset
@@ -302,14 +304,18 @@ func extractMetrics(messageTag string, processName string, ifaces config.IFaces,
 				if role == SLAVE {
 					masterOffsetIface.set(configName, ifaces[portId-1].Name)
 					slaveIface.set(configName, ifaces[portId-1].Name)
+					state = LOCKED // initial state to indicate we are locked when slave is back for clockclass to trigger
 				} else if role == FAULTY {
 					if slaveIface.isFaulty(configName, ifaces[portId-1].Name) &&
 						masterOffsetSource.get(configName) == ptp4lProcessName {
-						updatePTPMetrics(master, processName, masterOffsetIface.get(configName).alias, faultyOffset, faultyOffset, 0, 0)
-						updatePTPMetrics(phc, phc2sysProcessName, clockRealTime, faultyOffset, faultyOffset, 0, 0)
-						updateClockStateMetrics(processName, masterOffsetIface.get(configName).alias, FREERUN)
+						if updateMetrics {
+							updatePTPMetrics(master, processName, masterOffsetIface.get(configName).alias, faultyOffset, faultyOffset, 0, 0)
+							updatePTPMetrics(phc, phc2sysProcessName, clockRealTime, faultyOffset, faultyOffset, 0, 0)
+							updateClockStateMetrics(processName, masterOffsetIface.get(configName).alias, FREERUN)
+						}
 						masterOffsetIface.set(configName, "")
 						slaveIface.set(configName, "")
+						state = HOLDOVER
 					}
 				}
 			}
@@ -528,9 +534,9 @@ func UpdateInterfaceRoleMetrics(process string, iface string, role ptpPortRole) 
 }
 
 // UpdateClockClassMetrics ... update clock class metrics
-func UpdateClockClassMetrics(clockClass float64) {
+func UpdateClockClassMetrics(cfgName string, clockClass float64) {
 	ClockClassMetrics.With(prometheus.Labels{
-		"process": ptp4lProcessName, "node": NodeName}).Set(float64(clockClass))
+		"process": ptp4lProcessName, "config": cfgName, "node": NodeName}).Set(float64(clockClass))
 }
 
 func UpdateProcessStatusMetrics(process, cfgName string, status int64) {
@@ -720,6 +726,7 @@ func addFlagsForMonitor(process string, configOpts *string, conf *Ptp4lConf, std
 func StartMetricsServer(bindAddress string) {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
+
 	go utilwait.Until(func() {
 		err := http.ListenAndServe(bindAddress, mux)
 		if err != nil {


### PR DESCRIPTION
This commit implements logic to correctly update the clock class
when a FAULTY/RECOVERY condition of the port is detected.
Summary :
Ensure PMC clock-class queries run at most once per configName concurrently.
Trigger PMC on port Faulty/Holdover and recovery transitions to refresh GM class.
Run PMC polling outside the log scanner so we still update when ptp4l is silent.

What’s changed
Per-config single-flight guard:
Added a shared sync.Map keyed by configName to serialize updateClockClass across processes referencing the same config.
updateClockClass now CASes on the shared guard and logs when a run is skipped.
Cleanup: guard entry is removed on cmdStop() of the corresponding process.

Faulty/Holdover and recovery handling:
When the clock enters HOLDOVER or LOCKED without a specific iface, we now trigger updateClockClass (after a short delay) so GM class is refreshed on port fault/recovery events, not just on normal offset updates.
PMC polling outside the scanner:
Introduced/relied on a background loop that consumes a pmcCheck flag and calls updateClockClass independent of log scanner activity.
A periodic ticker sets pmcCheck for ptp4l processes; the background loop handles the PMC call even if ptp4l is not emitting logs.

Release note
Improve clock class update robustness: deduplicate PMC queries per config, update on Faulty/Holdover and recovery, and poll PMC independently of log output.