### PR TITLE
[release-4.20] OCPBUGS-61581: Cloud event proxy for PTP operator doesn't parse the BF3 NIC names correctly

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,19 +1,46 @@
 package utils
 
-import "strings"
+import (
+	"regexp"
 
-// GetAlias masks interface names for metric reporting
+	log "github.com/sirupsen/logrus"
+)
+
+// GetAlias generates a PHC (PTP Hardware Clock) identifier alias from network interface names.
+// It supports Intel and Mellanox naming formats with optional VLAN tags.
+//
+// Supported formats:
+//   - Intel: eth0 -> ethx, ens1f0 -> ens1fx, ens1f0.100 -> ens1fx.100
+//   - Mellanox: enP2s2f0np0 -> enP2s2fx, enP2s2f0np0.100 -> enP2s2fx.100
+//
+// For unsupported formats, returns the original interface name and logs an error.
+//
+// Parameters:
+//   - ifname: Network interface name (e.g., "ens1f0", "enP2s2f0np0", "eth0.100")
+//
+// Returns:
+//   - Alias string for PHC identification, or original name if format is unsupported
 func GetAlias(ifname string) string {
 	alias := ""
 	if ifname != "" {
-		// Aliases the interface name or <interface_name>.<vlan>
-		dotIndex := strings.Index(ifname, ".")
-		if dotIndex == -1 {
-			// e.g. ens1f0 -> ens1fx
-			alias = ifname[:len(ifname)-1] + "x"
+		// Single regex to handle both Intel and Mellanox formats with optional VLAN
+		// Intel format: ens1f0, eth0, ens1f0.100 -> ens1fx, ethx, ens1fx.100
+		// Mellanox format: enP2s2f0np0, enP2s2f0np0.100 -> enP2s2fx, enP2s2fx.100
+		pattern := regexp.MustCompile(`^(.+?)(\d+)(?:np\d+)?(\..+)?$`)
+		matches := pattern.FindStringSubmatch(ifname)
+
+		if len(matches) >= 3 {
+			// matches[1] contains the prefix (everything before the last digit sequence)
+			// matches[2] contains the digit sequence to replace
+			// matches[3] contains the VLAN part (including the dot) or empty string
+			alias = matches[1] + "x"
+			if len(matches) > 3 && matches[3] != "" {
+				alias += matches[3] // append VLAN part if present
+			}
 		} else {
-			// e.g ens1f0.100 -> ens1fx.100
-			alias = ifname[:dotIndex-1] + "x" + ifname[dotIndex:]
+			// Interface doesn't match Intel or Mellanox format, return original interface name
+			log.Errorf("Interface %s does not match Intel or Mellanox naming format, using original interface name", ifname)
+			alias = ifname
 		}
 	}
 	return alias

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -26,6 +26,20 @@ func Test_GetAlias(t *testing.T) {
 		{"eth0", "ethx"},
 		{"eth1.100", "ethx.100"},
 		{"eth1.100.XYZ", "ethx.100.XYZ"},
+		// Mellanox style naming
+		{"enP2s2f0np0", "enP2s2fx"},
+		{"enP1s1f1np1", "enP1s1fx"},
+		{"enP10s5f3np2", "enP10s5fx"},
+		{"ens1f3np3", "ens1fx"},
+		// Mellanox style naming with VLAN
+		{"enP2s2f0np0.100", "enP2s2fx.100"},
+		{"enP1s1f1np1.200", "enP1s1fx.200"},
+		{"enP10s5f3np2.300.XYZ", "enP10s5fx.300.XYZ"},
+		// Fallback cases (interfaces that don't match Intel or Mellanox format)
+		{"wlan", "wlan"},
+		{"lo", "lo"},
+		{"virbr", "virbr"},
+		{"docker", "docker"},
 	}
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%s->%s", tc.ifname, tc.expectedAlias), func(t *testing.T) {


### PR DESCRIPTION
Add support for Mellanox formatted NIC names to identify the PHC when reporting PHC state events:

Intel format: ens1f0, eth0, ens1f0.100 -> ens1fx, ethx, ens1fx.100
Mellanox format: enP2s2f0np0, enP2s2f0np0.100 -> enP2s2fx, enP2s2fx.100

Assisted-by: Cursor AI Editor