### PR TITLE
[release-4.20] OCPBUGS-61830: Suppress spurious log when GetAlias received master or an already aliased Intel or Mellanox interface

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -2,8 +2,6 @@ package utils
 
 import (
 	"regexp"
-
-	log "github.com/sirupsen/logrus"
 )
 
 // GetAlias generates a PHC (PTP Hardware Clock) identifier alias from network interface names.
@@ -23,6 +21,12 @@ import (
 func GetAlias(ifname string) string {
 	alias := ""
 	if ifname != "" {
+		// Check if it's already an aliased interface (ends with 'x' before optional VLAN)
+		alreadyAliasedPattern := regexp.MustCompile(`^(.+?)x(\..+)?$`)
+		if alreadyAliasedPattern.MatchString(ifname) {
+			return ifname
+		}
+
 		// Single regex to handle both Intel and Mellanox formats with optional VLAN
 		// Intel format: ens1f0, eth0, ens1f0.100 -> ens1fx, ethx, ens1fx.100
 		// Mellanox format: enP2s2f0np0, enP2s2f0np0.100 -> enP2s2fx, enP2s2fx.100
@@ -39,7 +43,6 @@ func GetAlias(ifname string) string {
 			}
 		} else {
 			// Interface doesn't match Intel or Mellanox format, return original interface name
-			log.Errorf("Interface %s does not match Intel or Mellanox naming format, using original interface name", ifname)
 			alias = ifname
 		}
 	}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -35,6 +35,15 @@ func Test_GetAlias(t *testing.T) {
 		{"enP2s2f0np0.100", "enP2s2fx.100"},
 		{"enP1s1f1np1.200", "enP1s1fx.200"},
 		{"enP10s5f3np2.300.XYZ", "enP10s5fx.300.XYZ"},
+		// Already aliased interfaces (should return as-is)
+		{"ens7fx", "ens7fx"},
+		{"ethx", "ethx"},
+		{"enP2s2fx", "enP2s2fx"},
+		{"ens1fx.100", "ens1fx.100"},
+		{"ens20f20.100", "ens20fx.100"},
+		{"enP10s5fx.300.XYZ", "enP10s5fx.300.XYZ"},
+		// Special master interface
+		{"master", "master"},
 		// Fallback cases (interfaces that don't match Intel or Mellanox format)
 		{"wlan", "wlan"},
 		{"lo", "lo"},


### PR DESCRIPTION
Suppress spurious log when GetAlias received "master" or an already aliased Intel or Mellanox interface