### PR TITLE
OCPBUGS-80949,OKD-322: Update Dockerfile to work on CentOS/RHEL 10

### DIFF
--- a/addons/redhat/Dockerfile.ocp
+++ b/addons/redhat/Dockerfile.ocp
@@ -16,8 +16,9 @@ RUN yum -y update && yum -y update glibc && yum --setopt=skip_missing_names_on_i
   iproute \
   procps-ng \
   chrony \
-  gpsd-minimal \
-  gpsd-minimal-clients \
+  # gpsd-minimal and gpsd-minimal-clients were renamed to gpsd and gpsd-clients in RHEL 10
+  # try the old names first, fall back to new names if it fails
+  && (yum -y install gpsd-minimal gpsd-minimal-clients || yum -y install gpsd gpsd-clients) \
   && yum clean all
 
 # Create symlinks for executables to match references


### PR DESCRIPTION
The OKD team is attempting to use CentOS 10 on 4.22. While attempting to build this, liinuxptp-daemon was failing to build due to gpsd-minimal and gpsd-minimal-clients not being a valid package. This is due to gpsd-minimal being renamed to gpsd. See [rhel 10 docs](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/10/html/considerations_in_adopting_rhel_10/infrastructure-services). This PR checks if the base OS is CentOS/RHEL 10, then installs the correct package based on the version.