### PR TITLE
OCPBUGS-77473: Fix offset spike caused by not full window in holdover

### DIFF
--- a/pkg/event/event_tbc.go
+++ b/pkg/event/event_tbc.go
@@ -213,9 +213,12 @@ func (e *EventHandler) updateBCState(event EventChannel, c net.Conn) clockSyncSt
 		leadingIFace:  gSycState.leadingIFace,
 	}
 
-	if gSycState.state == PTP_FREERUN {
+	switch gSycState.state {
+	case PTP_FREERUN:
 		e.clkSyncState[cfgName].clockOffset = FaultyPhaseOffset
-	} else {
+	case PTP_HOLDOVER:
+		e.clkSyncState[cfgName].clockOffset = e.getCalculatedHoldoverOffset(cfgName)
+	default:
 		e.clkSyncState[cfgName].clockOffset = e.getLargestOffset(cfgName)
 	}
 
@@ -459,6 +462,17 @@ func (e *EventHandler) getLargestOffset(cfgName string) int64 {
 	}
 	glog.Info("Largest offset ", worstOffset)
 	return worstOffset
+}
+
+func (e *EventHandler) getCalculatedHoldoverOffset(cfgName string) int64 {
+	if data, ok := e.data[cfgName]; ok {
+		for _, d := range data {
+			if d.ProcessName == DPLL {
+				return int64(d.window.LastInserted())
+			}
+		}
+	}
+	return FaultyPhaseOffset // No DPLL entries yet return faulty
 }
 
 func (e *EventHandler) freeRunCondition(cfgName string) bool {


### PR DESCRIPTION
Instead use the caculated offset as it should be when in holdover

Co-Author: Vitaly Grinberg <vgrinber@redhat.com>