### PR TITLE
Fix upstream-sync.sh macOS compatibility

### DIFF
--- a/hack/upstream-sync.sh
+++ b/hack/upstream-sync.sh
@@ -161,7 +161,7 @@ scan_bugs() {
     "${MERGE_BASE}..${UPSTREAM_REMOTE}/${UPSTREAM_BRANCH}" | grep -oE "$BUG_PATTERN" || true)
 
   BUG_LIST=$(printf '%s\n' "$bugs_from_titles" "$bugs_from_bodies" "$bugs_from_commits" "$bugs_from_trailers" \
-    | grep -E "^${BUG_PATTERN}$" | sort -u | sed ':a;N;$!ba;s/\n/, /g' || true)
+    | grep -E "^${BUG_PATTERN}$" | sort -u | paste -sd ',' - | sed 's/,/, /g' || true)
 
   if [ -n "$BUG_LIST" ]; then
     log "Bugs found:"
@@ -188,7 +188,7 @@ scan_bugs_from_jira() {
   known_pr_numbers=$(echo "$FILTERED_PRS" | jq -r '.[].number' 2>/dev/null | sort -u)
   if [ -z "$known_pr_numbers" ]; then
     known_pr_numbers=$(git log --format=%s "${MERGE_BASE}..${UPSTREAM_REMOTE}/${UPSTREAM_BRANCH}" \
-      | grep -oP '(?<=Merge pull request #)\d+' | sort -u || true)
+      | grep -oE 'Merge pull request #[0-9]+' | grep -oE '[0-9]+' | sort -u || true)
   fi
 
   if [ -z "$known_pr_numbers" ]; then
@@ -236,7 +236,7 @@ scan_bugs_from_jira() {
 
       for url in $pr_urls; do
         local pr_num
-        pr_num=$(echo "$url" | grep -oP '(?<=/pull/)\d+')
+        pr_num=$(echo "$url" | grep -oE '/pull/[0-9]+' | grep -oE '[0-9]+')
         if echo "$known_pr_numbers" | grep -qx "$pr_num"; then
           log "  ${key} linked to upstream PR #${pr_num}"
           jira_bugs+="${key}"$'\n'
@@ -267,7 +267,7 @@ scan_bugs_from_jira() {
     existing_bugs=$(echo "$BUG_LIST" | tr ',' '\n' | sed 's/^ //')
   fi
   BUG_LIST=$(printf '%s\n%s' "$existing_bugs" "$unique_jira_bugs" \
-    | grep -E "^${BUG_PATTERN}$" | sort -u | sed ':a;N;$!ba;s/\n/, /g' || true)
+    | grep -E "^${BUG_PATTERN}$" | sort -u | paste -sd ',' - | sed 's/,/, /g' || true)
 }
 
 check_existing_sync_pr() {


### PR DESCRIPTION
## Summary
- Replace GNU-specific `sed` and `grep -P` syntax with POSIX equivalents so `upstream-sync.sh` works on both macOS and Linux
- `sed ':a;N;$!ba;s/\n/, /g'` -> `paste -sd ',' - | sed 's/,/, /g'`
- `grep -oP` (Perl lookbehind) -> `grep -oE` with two-stage filter

## Test plan
- [x] Verified `bash -n` syntax check passes on macOS
- [x] Verified `./hack/upstream-sync.sh --dry-run` runs cleanly on macOS
- [x] All replacements use POSIX-standard tools compatible with both macOS and Fedora/RHEL

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>