### PR TITLE
OCPBUGS-80924: [4.21] Allow non-GNSS leap second sources

### DIFF
--- a/addons/intel/common.go
+++ b/addons/intel/common.go
@@ -1,0 +1,62 @@
+// Package intel contains plugins for all supported Intel NICs
+package intel
+
+import (
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/leap"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/ublox"
+)
+
+// GnssOptions defines GNSS-specific options common to Intel NIC plugins
+type GnssOptions struct {
+	Disabled    bool              `json:"disabled"`
+	LeapSources LeapSourceOptions `json:"leapSources"`
+}
+
+// LeapSourceOptions defines enabled or disabled leap second sources
+type LeapSourceOptions struct {
+	GPS     bool `json:"gps"`
+	GLONASS bool `json:"glonass"`
+	BeiDou  bool `json:"beidou"`
+	Galileo bool `json:"galileo"`
+	SBAS    bool `json:"sbas"`
+	NavIC   bool `json:"navic"`
+}
+
+// AllowedLeapSources converts the boolean flags into a map of
+// ublox leap source IDs suitable for leap.SetAllowedLeapSources.
+func (o LeapSourceOptions) AllowedLeapSources() map[uint8]bool {
+	mappings := []struct {
+		enabled bool
+		id      uint8
+	}{
+		{o.GPS, ublox.LeapSourceGPS},
+		{o.GLONASS, ublox.LeapSourceGLONASS},
+		{o.BeiDou, ublox.LeapSourceBeiDou},
+		{o.Galileo, ublox.LeapSourceGalileo},
+		{o.SBAS, ublox.LeapSourceSBAS},
+		{o.NavIC, ublox.LeapSourceNavIC},
+	}
+
+	sources := make(map[uint8]bool)
+	for _, m := range mappings {
+		if m.enabled {
+			sources[m.id] = true
+		}
+	}
+	return sources
+}
+
+// defaultLeapSourceOptions returns LeapSourceOptions with all sources enabled.
+func defaultLeapSourceOptions() LeapSourceOptions {
+	return LeapSourceOptions{
+		GPS: true, GLONASS: true, BeiDou: true,
+		Galileo: true, SBAS: true, NavIC: true,
+	}
+}
+
+// updateLeapManagerSources configures the LeapManager with the given leap source options.
+func updateLeapManagerSources(sources LeapSourceOptions) {
+	if leap.LeapMgr != nil {
+		leap.LeapMgr.SetAllowedLeapSources(sources.AllowedLeapSources())
+	}
+}

--- a/addons/intel/e810.go
+++ b/addons/intel/e810.go
@@ -24,6 +24,7 @@ type E810Opts struct {
 	DpllSettings        map[string]uint64            `json:"settings"`
 	PhaseOffsetPins     map[string]map[string]string `json:"phaseOffsetPins"`
 	PhaseInputs         []PhaseInputs                `json:"interconnections"`
+	Gnss                GnssOptions                  `json:"gnss"`
 }
 
 // GetPhaseInputs implements PhaseInputsProvider
@@ -71,6 +72,7 @@ func OnPTPConfigChangeE810(data *interface{}, nodeProfile *ptpv1.PtpProfile) err
 	autoDetectGNSSSerialPort(nodeProfile)
 
 	var e810Opts E810Opts
+	e810Opts.Gnss.LeapSources = defaultLeapSourceOptions()
 	var err error
 	var optsByteArray []byte
 	var stdout []byte
@@ -159,6 +161,8 @@ func OnPTPConfigChangeE810(data *interface{}, nodeProfile *ptpv1.PtpProfile) err
 			} else {
 				glog.Error("no clock chain set")
 			}
+
+			updateLeapManagerSources(e810Opts.Gnss.LeapSources)
 		}
 	}
 	return nil

--- a/addons/intel/e825.go
+++ b/addons/intel/e825.go
@@ -54,11 +54,6 @@ type E825Opts struct {
 	Gnss             GnssOptions                  `json:"gnss"`
 }
 
-// GnssOptions defines GNSS-specific options for the e825
-type GnssOptions struct {
-	Disabled bool `json:"disabled"`
-}
-
 // allDevices enumerates all defined devices (Devices/DevicePins/DeviceFrequencies/PhaseOffsets)
 func (opts *E825Opts) allDevices() []string {
 	// Enumerate all defined devices (Devices/DevicePins/DeviceFrequencies)
@@ -93,6 +88,7 @@ func OnPTPConfigChangeE825(data *interface{}, nodeProfile *ptpv1.PtpProfile) err
 	pluginData := (*data).(*E825PluginData)
 	glog.Infof("calling onPTPConfigChange for e825 plugin (%s)", *nodeProfile.Name)
 	var e825Opts E825Opts
+	e825Opts.Gnss.LeapSources = defaultLeapSourceOptions()
 	var err error
 	var optsByteArray []byte
 
@@ -169,6 +165,8 @@ func OnPTPConfigChangeE825(data *interface{}, nodeProfile *ptpv1.PtpProfile) err
 
 			// Always enforce GNSS setting (default = enabled)
 			pluginData.setupGnss(e825Opts.Gnss)
+
+			updateLeapManagerSources(e825Opts.Gnss.LeapSources)
 
 			// BC sanity check and pin setup
 			if tbcConfigured(nodeProfile) {

--- a/pkg/leap/leap-file.go
+++ b/pkg/leap/leap-file.go
@@ -29,7 +29,6 @@ const (
 	gpsToTaiDiff           = 19
 	curreLsValidMask       = 0x1
 	timeToLsEventValidMask = 0x2
-	leapSourceGps          = 2
 	leapConfigMapName      = "leap-configmap"
 	MaintenancePeriod      = time.Minute * 1
 	pmcWindowStartHours    = 12
@@ -54,10 +53,11 @@ type LeapManager struct {
 	leapFilePath string
 	leapFileName string
 	// UTC offset and its validity time
-	utcOffset       int
-	utcOffsetTime   time.Time
-	ptp4lConfigPath string
-	pmcLeapSent     bool
+	utcOffset          int
+	utcOffsetTime      time.Time
+	ptp4lConfigPath    string
+	pmcLeapSent        bool
+	allowedLeapSources map[uint8]bool
 }
 
 type LeapEvent struct {
@@ -82,13 +82,14 @@ func New(kubeclient kubernetes.Interface, namespace string) (*LeapManager, error
 		defer lock.Unlock()
 		if LeapMgr == nil {
 			lm := &LeapManager{
-				UbloxLsInd:   make(chan ublox.TimeLs, 2),
-				Close:        make(chan bool),
-				client:       kubeclient,
-				namespace:    namespace,
-				leapFile:     LeapFile{},
-				leapFilePath: defaultLeapFilePath,
-				leapFileName: defaultLeapFileName,
+				UbloxLsInd:         make(chan ublox.TimeLs, 2),
+				Close:              make(chan bool),
+				client:             kubeclient,
+				namespace:          namespace,
+				leapFile:           LeapFile{},
+				leapFilePath:       defaultLeapFilePath,
+				leapFileName:       defaultLeapFileName,
+				allowedLeapSources: map[uint8]bool{ublox.LeapSourceGPS: true},
 			}
 			err := lm.populateLeapData()
 			if err != nil {
@@ -161,6 +162,13 @@ func parseLeapFile(b []byte) (*LeapFile, error) {
 func (l *LeapManager) SetPtp4lConfigPath(path string) {
 	glog.Info("set Leap manager ptp4l config file name to ", path)
 	l.ptp4lConfigPath = path
+}
+
+// SetAllowedLeapSources configures which GNSS leap second sources
+// are accepted by processLeapIndication. Keys are ublox.LeapSourceXxx constants.
+func (l *LeapManager) SetAllowedLeapSources(sources map[uint8]bool) {
+	glog.Infof("set Leap manager allowed leap sources to %v", sources)
+	l.allowedLeapSources = sources
 }
 
 func (l *LeapManager) renderLeapData() (*bytes.Buffer, error) {
@@ -375,8 +383,8 @@ type leapIndResult struct {
 func (l *LeapManager) processLeapIndication(data *ublox.TimeLs) (*leapIndResult, error) {
 
 	glog.Infof("Leap indication: %+v", data)
-	if data.SrcOfCurrLs != leapSourceGps {
-		glog.Info("Discarding Leap event not originating from GPS")
+	if !l.allowedLeapSources[data.SrcOfCurrLs] {
+		glog.Infof("Discarding Leap event from source %d (allowed: %v)", data.SrcOfCurrLs, l.allowedLeapSources)
 		return nil, nil
 	}
 	result := &leapIndResult{}

--- a/pkg/leap/leap-file_test.go
+++ b/pkg/leap/leap-file_test.go
@@ -67,9 +67,10 @@ func Test_RenderLeapFile(t *testing.T) {
 func Test_processLeapIndication_FutureLeapZero(t *testing.T) {
 	leapData := readTestData(t)
 	lm := &LeapManager{
-		UbloxLsInd: make(chan ublox.TimeLs),
-		Close:      make(chan bool),
-		leapFile:   *leapData,
+		UbloxLsInd:         make(chan ublox.TimeLs),
+		Close:              make(chan bool),
+		leapFile:           *leapData,
+		allowedLeapSources: map[uint8]bool{ublox.LeapSourceGPS: true},
 	}
 
 	ind := ublox.TimeLs{
@@ -90,9 +91,10 @@ func Test_processLeapIndication_FutureLeapZero(t *testing.T) {
 func Test_processLeapIndication_FutureLeapNotZero(t *testing.T) {
 	leapData := readTestData(t)
 	lm := &LeapManager{
-		UbloxLsInd: make(chan ublox.TimeLs),
-		Close:      make(chan bool),
-		leapFile:   *leapData,
+		UbloxLsInd:         make(chan ublox.TimeLs),
+		Close:              make(chan bool),
+		leapFile:           *leapData,
+		allowedLeapSources: map[uint8]bool{ublox.LeapSourceGPS: true},
 	}
 
 	ind := ublox.TimeLs{
@@ -119,9 +121,10 @@ func Test_processLeapIndication_FutureLeapNotZero(t *testing.T) {
 func Test_processLeapIndication_MissedLeapZero(t *testing.T) {
 	leapData := readTestData(t)
 	lm := &LeapManager{
-		UbloxLsInd: make(chan ublox.TimeLs),
-		Close:      make(chan bool),
-		leapFile:   *leapData,
+		UbloxLsInd:         make(chan ublox.TimeLs),
+		Close:              make(chan bool),
+		leapFile:           *leapData,
+		allowedLeapSources: map[uint8]bool{ublox.LeapSourceGPS: true},
 	}
 
 	ind := ublox.TimeLs{
@@ -145,9 +148,10 @@ func Test_processLeapIndication_MissedLeapZero(t *testing.T) {
 func Test_processLeapIndication_MissedLeapNotZero(t *testing.T) {
 	leapData := readTestData(t)
 	lm := &LeapManager{
-		UbloxLsInd: make(chan ublox.TimeLs),
-		Close:      make(chan bool),
-		leapFile:   *leapData,
+		UbloxLsInd:         make(chan ublox.TimeLs),
+		Close:              make(chan bool),
+		leapFile:           *leapData,
+		allowedLeapSources: map[uint8]bool{ublox.LeapSourceGPS: true},
 	}
 
 	ind := ublox.TimeLs{
@@ -169,6 +173,71 @@ func Test_processLeapIndication_MissedLeapNotZero(t *testing.T) {
 	fmt.Println(res.updateTime)
 	fmt.Println(res.leapSec)
 	fmt.Println(res.leapTime)
+}
+
+func Test_processLeapIndication_BeiDouAllowed(t *testing.T) {
+	leapData := readTestData(t)
+	lm := &LeapManager{
+		UbloxLsInd:         make(chan ublox.TimeLs),
+		Close:              make(chan bool),
+		leapFile:           *leapData,
+		allowedLeapSources: map[uint8]bool{ublox.LeapSourceGPS: true, ublox.LeapSourceBeiDou: true},
+	}
+
+	ind := ublox.TimeLs{
+		SrcOfCurrLs:   ublox.LeapSourceBeiDou,
+		CurrLs:        18,
+		SrcOfLsChange: ublox.LeapSourceBeiDou,
+		LsChange:      1,
+		TimeToLsEvent: 74329702,
+		DateOfLsGpsWn: 2441,
+		DateOfLsGpsDn: 7,
+		Valid:         3,
+	}
+	res, err := lm.processLeapIndication(&ind)
+	assert.NoError(t, err)
+	assert.NotNil(t, res)
+	assert.Equal(t, int(ind.CurrLs+ind.LsChange+19), res.leapSec)
+}
+
+func Test_processLeapIndication_SourceRejected(t *testing.T) {
+	leapData := readTestData(t)
+	lm := &LeapManager{
+		UbloxLsInd:         make(chan ublox.TimeLs),
+		Close:              make(chan bool),
+		leapFile:           *leapData,
+		allowedLeapSources: map[uint8]bool{ublox.LeapSourceGPS: true},
+	}
+
+	ind := ublox.TimeLs{
+		SrcOfCurrLs:   ublox.LeapSourceBeiDou,
+		CurrLs:        18,
+		SrcOfLsChange: ublox.LeapSourceBeiDou,
+		LsChange:      1,
+		TimeToLsEvent: 74329702,
+		DateOfLsGpsWn: 2441,
+		DateOfLsGpsDn: 7,
+		Valid:         3,
+	}
+	res, err := lm.processLeapIndication(&ind)
+	assert.NoError(t, err)
+	assert.Nil(t, res)
+}
+
+func Test_SetAllowedLeapSources(t *testing.T) {
+	lm := &LeapManager{
+		allowedLeapSources: map[uint8]bool{ublox.LeapSourceGPS: true},
+	}
+	newSources := map[uint8]bool{
+		ublox.LeapSourceGPS:    true,
+		ublox.LeapSourceBeiDou: true,
+		ublox.LeapSourceNavIC:  true,
+	}
+	lm.SetAllowedLeapSources(newSources)
+	assert.True(t, lm.allowedLeapSources[ublox.LeapSourceGPS])
+	assert.True(t, lm.allowedLeapSources[ublox.LeapSourceBeiDou])
+	assert.True(t, lm.allowedLeapSources[ublox.LeapSourceNavIC])
+	assert.False(t, lm.allowedLeapSources[ublox.LeapSourceGLONASS])
 }
 
 func Test_populateLeapDataCmGood(t *testing.T) {
@@ -281,11 +350,12 @@ func Test_handleLeapIndication(t *testing.T) {
 	os.Setenv("NODE_NAME", "test-node-name")
 	client := fake.NewSimpleClientset(cm)
 	lm := &LeapManager{
-		UbloxLsInd:  make(chan ublox.TimeLs),
-		Close:       make(chan bool),
-		client:      client,
-		namespace:   "openshift-ptp",
-		retryUpdate: false,
+		UbloxLsInd:         make(chan ublox.TimeLs),
+		Close:              make(chan bool),
+		client:             client,
+		namespace:          "openshift-ptp",
+		retryUpdate:        false,
+		allowedLeapSources: map[uint8]bool{ublox.LeapSourceGPS: true},
 	}
 	err := lm.populateLeapData()
 	assert.NoError(t, err)

--- a/pkg/ublox/ublox.go
+++ b/pkg/ublox/ublox.go
@@ -367,6 +367,16 @@ func ExtractNavStatus(output string) int64 {
 	return -1
 }
 
+// UBX-NAV-TIMELS SrcOfCurrLs / SrcOfLsChange source identifiers
+const (
+	LeapSourceGPS     uint8 = 2
+	LeapSourceSBAS    uint8 = 3
+	LeapSourceBeiDou  uint8 = 4
+	LeapSourceGalileo uint8 = 5
+	LeapSourceGLONASS uint8 = 6
+	LeapSourceNavIC   uint8 = 7
+)
+
 type TimeLs struct {
 	//Information source for the current number
 	// of leap seconds


### PR DESCRIPTION
Cherry-pick
Add API to enable / disable leap second sources.
By default (and if leapSources is omitted) all satellite sources are enabled. To disable sources, specify them under the plugin gnss->leapSources section:
```
    e825:
      devices:
        - eno8703 
      gnss: 
        disabled: false 
        leapSources: 
          navic: false
```