### PR TITLE
[release-4.20] OCPBUGS-77881: Fix T-BC clock class not re-emitted after cloud-event-proxy restart

### DIFF
--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -615,6 +615,7 @@ func (e *EventHandler) AnnounceClockClass(clockClass fbprotocol.ClockClass, cloc
 func (e *EventHandler) announceClockClass(clockClass fbprotocol.ClockClass, clockAcc fbprotocol.ClockAccuracy, cfgName string) {
 	e.Lock()
 	e.setClockClassLocked(clockClass, clockAcc)
+	e.storeClockClassLocked(cfgName, clockClass, clockAcc)
 	e.Unlock()
 
 	e.emitClockClass(clockClass, cfgName)

--- a/pkg/event/event_socket_test.go
+++ b/pkg/event/event_socket_test.go
@@ -788,3 +788,46 @@ func TestStoreClockClassLocked_MakesEmitClockClassWork(t *testing.T) {
 
 	e.setConn(nil) // cleanup
 }
+
+// --- announceClockClass stores in clkSyncState ---
+
+func TestAnnounceClockClass_PopulatesClkSyncState(t *testing.T) {
+	socketPath := shortSocketPath(t)
+	listener, err := net.Listen("unix", socketPath)
+	assert.NoError(t, err)
+	defer listener.Close()
+
+	received := make(chan string, 10)
+	go acceptAndRead(listener, received)
+
+	e := newTestEventHandler(socketPath)
+	assert.True(t, e.reconnectEventSocket())
+
+	// clkSyncState should be empty initially
+	e.Lock()
+	_, ok := e.clkSyncState["ptp4l.1.config"]
+	e.Unlock()
+	assert.False(t, ok, "clkSyncState should be empty before announceClockClass")
+
+	// announceClockClass should populate clkSyncState AND emit to socket
+	e.announceClockClass(fbprotocol.ClockClass(6), fbprotocol.ClockAccuracy(0x21), "ptp4l.1.config")
+
+	// Verify clkSyncState was populated
+	e.Lock()
+	state, ok := e.clkSyncState["ptp4l.1.config"]
+	e.Unlock()
+	assert.True(t, ok, "clkSyncState should have ptp4l.1.config after announceClockClass")
+	assert.Equal(t, fbprotocol.ClockClass(6), state.clockClass)
+	assert.Equal(t, fbprotocol.ClockAccuracy(0x21), state.clockAccuracy)
+
+	// Verify it was written to socket
+	select {
+	case got := <-received:
+		assert.Contains(t, got, "CLOCK_CLASS_CHANGE 6")
+		assert.Contains(t, got, "ptp4l.1.config")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for clock class message on socket")
+	}
+
+	e.setConn(nil) // cleanup
+}


### PR DESCRIPTION
  ## Problem

  After cloud-event-proxy process is killed and restarts in T-BC mode, clock class
  metrics (`openshift_ptp_clock_class`) are lost and never recovered. The 60-second
  classTicker that should periodically re-emit clock class events produces no output.

  ## Root Cause

  `announceClockClass` calls `setClockClassLocked` (which sets `e.clockClass`) and
  `emitClockClass` (which writes to the socket), but never `storeClockClassLocked`.
  After cloud-event-proxy restarts, `EmitClockClass` and the classTicker check
  `clkSyncState` and find it empty for ptp4l configs, so clock class is never
  re-emitted.

  ## Fix

  Add `storeClockClassLocked` call to `announceClockClass` so `clkSyncState` is
  populated on every clock class announcement. The classTicker's existing `SplitN`
  logic normalizes `ts2phc` config names to `ptp4l` for emission, so no changes
  are needed in `event_tbc.go` or `downstreamAnnounceIWF`.

  ## Testing

  - Verified on helix98 T-BC cluster: after killing cloud-event-proxy process,
    clock class metrics recover and the classTicker emits `CLOCK_CLASS_CHANGE`
    events every 60 seconds.
  - Unit tests:
    - `TestAnnounceClockClass_PopulatesClkSyncState` — verifies announceClockClass stores in clkSyncState and emits to socket
