### PR TITLE
Fix unbound variable error in upstream-sync.sh filter_skipped

### DIFF
--- a/hack/upstream-sync.sh
+++ b/hack/upstream-sync.sh
@@ -295,7 +295,7 @@ filter_skipped() {
 
     local skip_reason=""
 
-    for skip_num in "${skip_pr_list[@]}"; do
+    for skip_num in "${skip_pr_list[@]+"${skip_pr_list[@]}"}"; do
       skip_num="${skip_num// /}"
       if [ -n "$skip_num" ] && [ "$skip_num" = "$pr_number" ]; then
         skip_reason="manually skipped (SKIP_PRS)"
@@ -304,7 +304,7 @@ filter_skipped() {
     done
 
     if [ -z "$skip_reason" ]; then
-      for skip_sha in "${skip_commit_list[@]}"; do
+      for skip_sha in "${skip_commit_list[@]+"${skip_commit_list[@]}"}"; do
         skip_sha="${skip_sha// /}"
         if [ -n "$skip_sha" ] && [[ "$pr_sha" == ${skip_sha}* ]]; then
           skip_reason="manually skipped (SKIP_COMMITS)"


### PR DESCRIPTION
Use ${arr[@]+"${arr[@]}"} pattern for empty array expansion under set -u.

Fixing the following error:
```
jacding@jacding-mac linuxptp-daemon % ./hack/upstream-sync.sh

[2026-04-22T18:27:34Z] Starting upstream sync: k8snetworkplumbingwg/linuxptp-daemon (main) -> openshift/linuxptp-daemon (main) via fork jzding/linuxptp-daemon
[2026-04-22T18:27:34Z] Fetching all remotes...
Fetching origin
Fetching upstream
Fetching ocp
Fetching up
[2026-04-22T18:27:38Z] Merge base: 88c063b556a3467cbc19bd3584dbe18beaae8a21
[2026-04-22T18:27:38Z] Upstream HEAD: c0f5adb15aa5a21cfbb5569a77741c4b8270fb66
[2026-04-22T18:27:38Z] 10 new commits to sync
[2026-04-22T18:27:38Z] Searching for upstream PRs merged after 2026-04-13T12:40:39+03:00...
[2026-04-22T18:27:39Z] Found 3 merged upstream PRs in range:
[2026-04-22T18:27:39Z]   #196 - OCPBUGS-83706: Add E825 T-BC input pin configuration
[2026-04-22T18:27:39Z]   #194 - OCPBUGS-83557: Fix T-BC clock class not re-emitted after cloud-event-proxy restart
[2026-04-22T18:27:39Z]   #152 - Report mistakes in HW plugin configuration to the PtpConfig status
[2026-04-22T18:27:39Z] Filtering PRs for skip conditions...
./hack/upstream-sync.sh: line 278: skip_pr_list[@]: unbound variable
```