### PR TITLE
OCPBUGS-85360, OCPBUGS-85361: Sync from upstream (12-May-2026)

### DIFF
--- a/.github/workflows/aws-ci.yaml
+++ b/.github/workflows/aws-ci.yaml
@@ -10,7 +10,29 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name }}-${{ github.event.pull_request.head.ref }}
   cancel-in-progress: true
 jobs:
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      has-code-changes: ${{ steps.filter.outputs.has-code-changes }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check for production code changes
+        id: filter
+        run: |
+          BASE=${{ github.event.pull_request.base.sha }}
+          HEAD=${{ github.event.pull_request.head.sha }}
+          CHANGED=$(git diff --name-only "$BASE" "$HEAD" | grep -cvE '^\.(github/|gitignore)|^docs/|\.md$' || true)
+          if [ "$CHANGED" -gt 0 ]; then
+            echo "has-code-changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-code-changes=false" >> "$GITHUB_OUTPUT"
+          fi
+
   deploy-ec2:
+    needs: check-changes
+    if: needs.check-changes.outputs.has-code-changes == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 115
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,8 +14,16 @@ name: "CodeQL Advanced"
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '.github/**'
+      - 'docs/**'
+      - '**.md'
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+      - '.github/**'
+      - 'docs/**'
+      - '**.md'
   schedule:
     - cron: '20 21 * * 4'
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,21 +19,10 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Coverage Gate
+        if: github.event_name == 'pull_request'
+        run: make coverage-gate BASE_REF=${{ github.event.pull_request.base.sha }}
+
       - name: Generate Coverage
+        if: github.event_name == 'push'
         run: make test
-
-      - name: Generate Base Coverage
-        if: github.event_name == 'pull_request'
-        run: |
-          git checkout ${{ github.event.pull_request.base.sha }}
-          make test
-          go run github.com/vladopajic/go-test-coverage/v2@v2.17.1 -p coverage.out --breakdown-file-name base-coverage.json
-          git checkout ${{ github.sha }}
-
-      - name: Check Coverage Regressions
-        if: github.event_name == 'pull_request'
-        uses: vladopajic/go-test-coverage@v2
-        with:
-          profile: coverage.out
-          base-breakdown-file: base-coverage.json
-          diff-threshold: 0

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,39 @@
+name: "Coverage Quality Gate"
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  coverage:
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip-coverage')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Generate Coverage
+        run: make test
+
+      - name: Generate Base Coverage
+        if: github.event_name == 'pull_request'
+        run: |
+          git checkout ${{ github.event.pull_request.base.sha }}
+          make test
+          go run github.com/vladopajic/go-test-coverage/v2@v2.17.1 -p coverage.out --breakdown-file-name base-coverage.json
+          git checkout ${{ github.sha }}
+
+      - name: Check Coverage Regressions
+        if: github.event_name == 'pull_request'
+        uses: vladopajic/go-test-coverage@v2
+        with:
+          profile: coverage.out
+          base-breakdown-file: base-coverage.json
+          diff-threshold: 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,16 @@
 name: Test
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - '.github/**'
+      - 'docs/**'
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '.github/**'
+      - 'docs/**'
+      - '**.md'
 
 jobs:
   build:

--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,10 @@ fmt:
 	./hack/gofmt.sh
 
 test:
-	SKIP_GNSS_MONITORING=1 go test ./... --tags=unittests -coverprofile=coverage.raw.out
-	# Filter out generated code and mocks
-	grep -vE "zz_generated|\.pb\.go|mock_" coverage.raw.out > coverage.out
+	./hack/unit-test.sh
+
+coverage-gate:
+	./hack/coverage-gate.sh $(BASE_REF)
 
 lint:
 	golangci-lint run

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,9 @@ fmt:
 	./hack/gofmt.sh
 
 test:
-	SKIP_GNSS_MONITORING=1 go test ./... --tags=unittests -coverprofile=coverage.out
+	SKIP_GNSS_MONITORING=1 go test ./... --tags=unittests -coverprofile=coverage.raw.out
+	# Filter out generated code and mocks
+	grep -vE "zz_generated|\.pb\.go|mock_" coverage.raw.out > coverage.out
 
 lint:
 	golangci-lint run

--- a/README.md
+++ b/README.md
@@ -87,3 +87,27 @@ $ kubectl get pods -n openshift-ptp
 NAME                    READY   STATUS    RESTARTS   AGE
 linuxptp-daemon-txmpn   1/1     Running   0          105m
 ```
+
+## Test Coverage
+
+Run `make coverage-gate` to compare test coverage of your branch against the upstream main branch. The script auto-detects the upstream remote and its tracking branch.
+
+```sh
+$ make coverage-gate
+
+Base coverage (up-main): 45.4%
+Current coverage:            45.4%
+Difference:                  0%
+✅ Coverage unchanged.
+```
+
+You can also compare against a specific branch:
+
+```sh
+$ BASE_REF=release-4.20 make coverage-gate
+
+Base coverage (release-4.20): 40.9%
+Current coverage:            45.4%
+Difference:                  4.5%
+🎉 Coverage increased by 4.5%, good job!
+```

--- a/hack/coverage-gate.sh
+++ b/hack/coverage-gate.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Compare test coverage of the current branch against a base ref.
+# Usage: hack/coverage-gate.sh [base-ref]
+# When base-ref is omitted, auto-detects the local branch tracking
+# the upstream k8snetworkplumbingwg remote's default branch.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+resolve_base_ref() {
+  if [ -n "$1" ]; then
+    echo "$1"
+    return
+  fi
+
+  # Find the remote pointing to k8snetworkplumbingwg
+  UPSTREAM_REMOTE=$(git remote -v | grep 'k8snetworkplumbingwg/.*fetch' | awk '{print $1}' | head -1)
+  if [ -z "${UPSTREAM_REMOTE}" ]; then
+    echo "main"
+    return
+  fi
+
+  git fetch "${UPSTREAM_REMOTE}" --quiet
+
+  # Find the default branch of the upstream remote
+  UPSTREAM_HEAD=$(git remote show "${UPSTREAM_REMOTE}" | sed -n '/HEAD branch/s/.*: //p')
+  UPSTREAM_REF="${UPSTREAM_REMOTE}/${UPSTREAM_HEAD}"
+
+  # Find or create a local branch tracking this remote branch
+  LOCAL_BRANCH=$(git branch --list --format='%(refname:short) %(upstream:short)' | grep " ${UPSTREAM_REF}$" | awk '{print $1}' | head -1)
+  if [ -z "${LOCAL_BRANCH}" ]; then
+    LOCAL_BRANCH="up-${UPSTREAM_HEAD}"
+    echo "==> Creating tracking branch '${LOCAL_BRANCH}' for '${UPSTREAM_REF}'..." >&2
+    git branch "${LOCAL_BRANCH}" "${UPSTREAM_REF}" --quiet
+    git branch --set-upstream-to="${UPSTREAM_REF}" "${LOCAL_BRANCH}" --quiet >/dev/null
+  fi
+
+  # Update tracking branch to latest without checkout
+  git branch -f "${LOCAL_BRANCH}" "${UPSTREAM_REF}" --quiet
+
+  echo "${LOCAL_BRANCH}"
+}
+
+BASE_REF=$(resolve_base_ref "$1")
+
+echo "==> Running tests on current branch..."
+"${SCRIPT_DIR}/unit-test.sh"
+CURRENT_COV=$(go tool cover -func=coverage.out | grep ^total | awk '{print $3}' | tr -d '%')
+
+echo "==> Running tests on base ref '${BASE_REF}'..."
+CURRENT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || git rev-parse HEAD)
+TMPTEST=$(mktemp)
+cp "${SCRIPT_DIR}/unit-test.sh" "${TMPTEST}"
+STASHED=false
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  git stash --quiet
+  STASHED=true
+fi
+git checkout "${BASE_REF}" --quiet
+bash "${TMPTEST}"
+rm -f "${TMPTEST}"
+BASE_COV=$(go tool cover -func=coverage.out | grep ^total | awk '{print $3}' | tr -d '%')
+git checkout "${CURRENT_BRANCH}" --quiet
+if [ "${STASHED}" = true ]; then
+  git stash pop --quiet
+fi
+
+DIFF=$(echo "${CURRENT_COV} - ${BASE_COV}" | bc)
+echo ""
+echo "Base coverage (${BASE_REF}): ${BASE_COV}%"
+echo "Current coverage:            ${CURRENT_COV}%"
+echo "Difference:                  ${DIFF}%"
+
+if (( $(echo "${DIFF} < 0" | bc -l) )); then
+  echo "❌ FAIL: Coverage decreased by ${DIFF}%"
+  exit 1
+elif (( $(echo "${DIFF} > 0" | bc -l) )); then
+  echo "🎉 Coverage increased by ${DIFF}%, good job!"
+else
+  echo "✅ Coverage unchanged."
+fi

--- a/hack/coverage-gate.sh
+++ b/hack/coverage-gate.sh
@@ -35,8 +35,12 @@ resolve_base_ref() {
     git branch --set-upstream-to="${UPSTREAM_REF}" "${LOCAL_BRANCH}" --quiet >/dev/null
   fi
 
-  # Update tracking branch to latest without checkout
-  git branch -f "${LOCAL_BRANCH}" "${UPSTREAM_REF}" --quiet
+  # Update tracking branch to latest. If it's checked out (here or elsewhere),
+  # return the upstream ref directly to avoid checkout conflicts.
+  if ! git branch -f "${LOCAL_BRANCH}" "${UPSTREAM_REF}" --quiet 2>/dev/null; then
+    echo "${UPSTREAM_REF}"
+    return
+  fi
 
   echo "${LOCAL_BRANCH}"
 }

--- a/hack/coverage-gate.sh
+++ b/hack/coverage-gate.sh
@@ -35,12 +35,8 @@ resolve_base_ref() {
     git branch --set-upstream-to="${UPSTREAM_REF}" "${LOCAL_BRANCH}" --quiet >/dev/null
   fi
 
-  # Update tracking branch to latest. If it's checked out (here or elsewhere),
-  # return the upstream ref directly to avoid checkout conflicts.
-  if ! git branch -f "${LOCAL_BRANCH}" "${UPSTREAM_REF}" --quiet 2>/dev/null; then
-    echo "${UPSTREAM_REF}"
-    return
-  fi
+  # Update tracking branch to latest without checkout
+  git branch -f "${LOCAL_BRANCH}" "${UPSTREAM_REF}" --quiet
 
   echo "${LOCAL_BRANCH}"
 }

--- a/hack/unit-test.sh
+++ b/hack/unit-test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Run unit tests and generate filtered coverage profile.
+set -e
+SKIP_GNSS_MONITORING=1 go test ./... --tags=unittests -coverprofile=coverage.raw.out
+grep -vE "zz_generated|\.pb\.go|mock_" coverage.raw.out > coverage.out

--- a/pkg/controller/hardwareconfig_controller.go
+++ b/pkg/controller/hardwareconfig_controller.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/daemon"
+	hc "github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/hardwareconfig"
 	ptpv1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v1"
 	ptpv2alpha1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v2alpha1"
 )
@@ -408,14 +409,8 @@ func (r *HardwareConfigReconciler) recordUpdateFailure(ctx context.Context, conf
 
 // ptpProfileNameMatchesActive reports whether relatedProfile is considered active.
 func ptpProfileNameMatchesActive(relatedProfile string, activePTPProfiles map[string]bool) bool {
-	if activePTPProfiles[relatedProfile] {
-		return true
-	}
-	// Also accept a match when an active profile entry carries the ptpconfig resource name
-	// as a prefix separated by "_".
-	suffix := "_" + relatedProfile
 	for activeProfile := range activePTPProfiles {
-		if strings.HasSuffix(activeProfile, suffix) {
+		if hc.ProfileNamesMatch(activeProfile, relatedProfile) {
 			return true
 		}
 	}

--- a/pkg/controller/hardwareconfig_controller_test.go
+++ b/pkg/controller/hardwareconfig_controller_test.go
@@ -105,7 +105,7 @@ func TestCalculateNodeHardwareConfigs(t *testing.T) {
 		{
 			name:                 "no hardware configs",
 			nodeName:             "test-node",
-			activeProfiles:       []string{"grandmaster"},
+			activeProfiles:       []string{"ptpconfig_grandmaster"},
 			hwConfigs:            []ptpv2alpha1.HardwareConfig{},
 			expectedConfigsCount: 0,
 			expectedConfigNames:  []string{},
@@ -114,7 +114,7 @@ func TestCalculateNodeHardwareConfigs(t *testing.T) {
 		{
 			name:           "single hardware config with matching active profile",
 			nodeName:       "test-node",
-			activeProfiles: []string{"grandmaster"},
+			activeProfiles: []string{"ptpconfig_grandmaster"},
 			hwConfigs: []ptpv2alpha1.HardwareConfig{
 				createTestHardwareConfig("gm-config", "grandmaster-profile", "grandmaster"),
 			},
@@ -125,7 +125,7 @@ func TestCalculateNodeHardwareConfigs(t *testing.T) {
 		{
 			name:           "single hardware config with non-matching active profile",
 			nodeName:       "test-node",
-			activeProfiles: []string{"boundary-clock"},
+			activeProfiles: []string{"ptpconfig_boundary-clock"},
 			hwConfigs: []ptpv2alpha1.HardwareConfig{
 				createTestHardwareConfig("gm-config", "grandmaster-profile", "grandmaster"),
 			},
@@ -136,7 +136,7 @@ func TestCalculateNodeHardwareConfigs(t *testing.T) {
 		{
 			name:           "multiple hardware configs, all matching",
 			nodeName:       "worker-node",
-			activeProfiles: []string{"boundary-clock", "ordinary-clock"},
+			activeProfiles: []string{"ptpconfig_boundary-clock", "ptpconfig_ordinary-clock"},
 			hwConfigs: []ptpv2alpha1.HardwareConfig{
 				createTestHardwareConfig("bc-config", "boundary-clock-profile", "boundary-clock"),
 				createTestHardwareConfig("oc-config", "ordinary-clock-profile", "ordinary-clock"),
@@ -148,7 +148,7 @@ func TestCalculateNodeHardwareConfigs(t *testing.T) {
 		{
 			name:           "multiple hardware configs, partial matching",
 			nodeName:       "worker-node",
-			activeProfiles: []string{"boundary-clock"},
+			activeProfiles: []string{"ptpconfig_boundary-clock"},
 			hwConfigs: []ptpv2alpha1.HardwareConfig{
 				createTestHardwareConfig("bc-config", "boundary-clock-profile", "boundary-clock"),
 				createTestHardwareConfig("oc-config", "ordinary-clock-profile", "ordinary-clock"),
@@ -160,7 +160,7 @@ func TestCalculateNodeHardwareConfigs(t *testing.T) {
 		{
 			name:           "hardware config without related profile",
 			nodeName:       "test-node",
-			activeProfiles: []string{"grandmaster"},
+			activeProfiles: []string{"ptpconfig_grandmaster"},
 			hwConfigs: []ptpv2alpha1.HardwareConfig{
 				createTestHardwareConfig("no-profile-config", "some-profile", ""), // Empty relatedPtpProfileName
 			},
@@ -300,7 +300,7 @@ func TestCheckIfChangedConfigsAffectActiveProfiles(t *testing.T) {
 		},
 		{
 			name:            "config added but not associated with active profile",
-			activeProfiles:  []string{"active-profile"},
+			activeProfiles:  []string{"ptpconfig_active-profile"},
 			oldConfigs:      []ptpv2alpha1.HardwareConfig{},
 			newConfigs:      []ptpv2alpha1.HardwareConfig{createTestHardwareConfig("config1", "profile1", "other-profile")},
 			expectedRestart: false,
@@ -308,7 +308,7 @@ func TestCheckIfChangedConfigsAffectActiveProfiles(t *testing.T) {
 		},
 		{
 			name:            "config added and associated with active profile",
-			activeProfiles:  []string{"active-profile"},
+			activeProfiles:  []string{"ptpconfig_active-profile"},
 			oldConfigs:      []ptpv2alpha1.HardwareConfig{},
 			newConfigs:      []ptpv2alpha1.HardwareConfig{createTestHardwareConfig("config1", "profile1", "active-profile")},
 			expectedRestart: true,
@@ -316,7 +316,7 @@ func TestCheckIfChangedConfigsAffectActiveProfiles(t *testing.T) {
 		},
 		{
 			name:            "config removed and was associated with active profile",
-			activeProfiles:  []string{"active-profile"},
+			activeProfiles:  []string{"ptpconfig_active-profile"},
 			oldConfigs:      []ptpv2alpha1.HardwareConfig{createTestHardwareConfig("config1", "profile1", "active-profile")},
 			newConfigs:      []ptpv2alpha1.HardwareConfig{},
 			expectedRestart: true,
@@ -324,7 +324,7 @@ func TestCheckIfChangedConfigsAffectActiveProfiles(t *testing.T) {
 		},
 		{
 			name:            "config modified and associated with active profile",
-			activeProfiles:  []string{"active-profile"},
+			activeProfiles:  []string{"ptpconfig_active-profile"},
 			oldConfigs:      []ptpv2alpha1.HardwareConfig{createTestHardwareConfig("config1", "profile1", "active-profile")},
 			newConfigs:      []ptpv2alpha1.HardwareConfig{createTestHardwareConfig("config1", "profile1-modified", "active-profile")},
 			expectedRestart: true,
@@ -332,7 +332,7 @@ func TestCheckIfChangedConfigsAffectActiveProfiles(t *testing.T) {
 		},
 		{
 			name:            "config unchanged - no restart",
-			activeProfiles:  []string{"active-profile"},
+			activeProfiles:  []string{"ptpconfig_active-profile"},
 			oldConfigs:      []ptpv2alpha1.HardwareConfig{createTestHardwareConfig("config1", "profile1", "active-profile")},
 			newConfigs:      []ptpv2alpha1.HardwareConfig{createTestHardwareConfig("config1", "profile1", "active-profile")},
 			expectedRestart: false,
@@ -340,7 +340,7 @@ func TestCheckIfChangedConfigsAffectActiveProfiles(t *testing.T) {
 		},
 		{
 			name:           "multiple configs, only changed one affects active profile",
-			activeProfiles: []string{"active-profile"},
+			activeProfiles: []string{"ptpconfig_active-profile"},
 			oldConfigs: []ptpv2alpha1.HardwareConfig{
 				createTestHardwareConfig("config1", "profile1", "other-profile"),
 				createTestHardwareConfig("config2", "profile2", "active-profile"),
@@ -391,7 +391,7 @@ func TestReconcileWhenNothingChanged(t *testing.T) {
 func TestReconcileWhenHardwareConfigChanged(t *testing.T) {
 	mockHandler := &MockHardwareConfigHandler{}
 	mockTrigger := &MockHardwareConfigRestartTrigger{
-		CurrentProfiles: []string{"active-profile"},
+		CurrentProfiles: []string{"ptpconfig_active-profile"},
 	}
 
 	reconciler := &HardwareConfigReconciler{
@@ -420,7 +420,7 @@ func TestReconcileWhenHardwareConfigChanged(t *testing.T) {
 func TestReconcileWhenHardwareConfigChangedButNotAssociated(t *testing.T) {
 	mockHandler := &MockHardwareConfigHandler{}
 	mockTrigger := &MockHardwareConfigRestartTrigger{
-		CurrentProfiles: []string{"active-profile"},
+		CurrentProfiles: []string{"ptpconfig_active-profile"},
 	}
 
 	reconciler := &HardwareConfigReconciler{
@@ -481,7 +481,7 @@ func TestReconcileEmptyToSomething(t *testing.T) {
 func TestReconcileMultipleConfigsInSequence(t *testing.T) {
 	mockHandler := &MockHardwareConfigHandler{}
 	mockTrigger := &MockHardwareConfigRestartTrigger{
-		CurrentProfiles: []string{"active-profile"},
+		CurrentProfiles: []string{"ptpconfig_active-profile"},
 	}
 
 	reconciler := &HardwareConfigReconciler{

--- a/pkg/daemon/daemon_internal_test.go
+++ b/pkg/daemon/daemon_internal_test.go
@@ -954,13 +954,13 @@ func TestProcessTBCTransitionHardwareConfig_HardwareConfigIntegration(t *testing
 
 	// Verify the profile association
 	hasConfig := hcm.HasHardwareConfigForProfile(&ptpv1.PtpProfile{
-		Name: stringPointer("01-tbc-tr"),
+		Name: stringPointer("t-bc_01-tbc-tr"),
 	})
 	assert.True(t, hasConfig, "Should have hardware config for profile 01-tbc-tr")
 
 	// Get configs for the profile
 	profiles := hcm.GetHardwareConfigsForProfile(&ptpv1.PtpProfile{
-		Name: stringPointer("01-tbc-tr"),
+		Name: stringPointer("t-bc_01-tbc-tr"),
 	})
 	assert.Len(t, profiles, 1, "Should get exactly one hardware profile")
 	assert.NotNil(t, profiles[0].Name, "Hardware profile should have a name")
@@ -1042,7 +1042,7 @@ func TestProcessTBCTransitionHardwareConfig_ProcessLogFile(t *testing.T) {
 			perPortState: map[string]event.PTPState{"ens4f1": event.PTP_NOTSET},
 		},
 		nodeProfile: ptpv1.PtpProfile{
-			Name: stringPointer("01-tbc-tr"), // Matches relatedPtpProfileName from config
+			Name: stringPointer("t-bc_01-tbc-tr"), // Matches relatedPtpProfileName from config (qualified by operator)
 			PtpSettings: map[string]string{
 				"leadingInterface": "ens4f1",
 				"clockId[ens4f1]":  "123456789",

--- a/pkg/hardwareconfig/clockchain_resolution.go
+++ b/pkg/hardwareconfig/clockchain_resolution.go
@@ -157,6 +157,19 @@ func findLeadingInterfaceFromUpstreamPortWithResolver(upstreamPort string, resol
 	return leadingInterface, nil
 }
 
+// ProfileNamesMatch reports whether a PtpConfig profile name (stored) matches a
+// HardwareConfig's RelatedPtpProfileName (requested).
+func ProfileNamesMatch(stored, requested string) bool {
+	if strings.TrimSpace(requested) == "" {
+		return false
+	}
+	parts := strings.SplitN(stored, "_", 2)
+	if len(parts) > 1 && parts[1] == requested {
+		return true
+	}
+	return false
+}
+
 // ResolveClockChain resolves a minimal hardwareconfig by deriving structure and behavior
 // from ptpconfig and behavior profile templates.
 // Board label remapping from ConfigMap will be applied if configMapLoader is set.
@@ -182,12 +195,15 @@ func (hcm *HardwareConfigManager) ResolveClockChain(hwConfig *ptpv2alpha1.Hardwa
 			return nil, fmt.Errorf("hardwareconfig %s has clockType but no relatedPtpProfileName specified", hwConfig.Name)
 		}
 
-		// Search through all profiles in PtpConfig to find the matching one
+		// Search through all profiles in PtpConfig to find the matching one.
 		for i := range ptpConfig.Spec.Profile {
-			if ptpConfig.Spec.Profile[i].Name != nil &&
-				*ptpConfig.Spec.Profile[i].Name == relatedProfileName {
+			if ptpConfig.Spec.Profile[i].Name == nil {
+				continue
+			}
+			name := *ptpConfig.Spec.Profile[i].Name
+			if ProfileNamesMatch(name, relatedProfileName) {
 				ptpProfile = &ptpConfig.Spec.Profile[i]
-				glog.Infof("Found matching PTP profile '%s' for hardwareconfig '%s'", relatedProfileName, hwConfig.Name)
+				glog.Infof("Found matching PTP profile '%s' for hardwareconfig '%s'", name, hwConfig.Name)
 				break
 			}
 		}

--- a/pkg/hardwareconfig/clockchain_resolution_test.go
+++ b/pkg/hardwareconfig/clockchain_resolution_test.go
@@ -152,7 +152,7 @@ func TestClockChainResolution(t *testing.T) {
 			var ptpProfile *ptpv1.PtpProfile
 			for i := range ptpConfig.Spec.Profile {
 				if ptpConfig.Spec.Profile[i].Name != nil &&
-					*ptpConfig.Spec.Profile[i].Name == hwConfig.Spec.RelatedPtpProfileName {
+					ProfileNamesMatch(*ptpConfig.Spec.Profile[i].Name, hwConfig.Spec.RelatedPtpProfileName) {
 					ptpProfile = &ptpConfig.Spec.Profile[i]
 					break
 				}
@@ -319,7 +319,7 @@ func TestClockChainResolution_DualUpstream(t *testing.T) {
 	var ptpProfile *ptpv1.PtpProfile
 	for i := range ptpConfig.Spec.Profile {
 		if ptpConfig.Spec.Profile[i].Name != nil &&
-			*ptpConfig.Spec.Profile[i].Name == hwConfig.Spec.RelatedPtpProfileName {
+			ProfileNamesMatch(*ptpConfig.Spec.Profile[i].Name, hwConfig.Spec.RelatedPtpProfileName) {
 			ptpProfile = &ptpConfig.Spec.Profile[i]
 			break
 		}
@@ -428,4 +428,47 @@ func findConditionByName(conditions []ptpv2alpha1.Condition, name string) *ptpv2
 		}
 	}
 	return nil
+}
+
+func TestProfileNamesMatch(t *testing.T) {
+	tests := []struct {
+		stored    string
+		requested string
+		want      bool
+	}{
+		// Unqualified stored name without prefix does not match (no exact-match branch).
+		{"01-tbc-tr", "01-tbc-tr", false},
+		// PtpConfig resource name carried as prefix (Kubernetes CR names have no underscores,
+		// so the first "_" is always the separator).
+		{"t-bc_01-tbc-tr", "01-tbc-tr", true},
+		{"my-ptpconfig_01-tbc-tr", "01-tbc-tr", true},
+		// Wrong profile name.
+		{"t-bc_01-tbc-tr", "00-tbc-tt", false},
+		// Stored has no prefix and names differ.
+		{"other-profile", "01-tbc-tr", false},
+		// Prefix shares characters with profile but has no "_" separator.
+		{"x01-tbc-tr", "01-tbc-tr", false},
+
+		// Profile name itself contains underscores — only the first "_" is the separator,
+		// so "foo_bar" is the full profile name, not a false sub-match of "bar".
+		{"prefix_foo_bar", "foo_bar", true},
+		{"prefix_foo_bar", "bar", false},
+
+		// False-positive regression: old HasSuffix would match "a_b_c" against "c".
+		{"a_b_c", "c", false},
+
+		// Empty / whitespace requested is always rejected.
+		{"", "", false},
+		{"t-bc_", "", false},
+		{"t-bc_profile", "  ", false},
+		{"", "something", false},
+
+		// Stored is empty, requested is non-empty.
+		{"", "profile", false},
+	}
+
+	for _, tc := range tests {
+		got := ProfileNamesMatch(tc.stored, tc.requested)
+		assert.Equal(t, tc.want, got, "ProfileNamesMatch(%q, %q)", tc.stored, tc.requested)
+	}
 }

--- a/pkg/hardwareconfig/hardware-vendor/dell/XR8720t/delays.yaml
+++ b/pkg/hardwareconfig/hardware-vendor/dell/XR8720t/delays.yaml
@@ -52,24 +52,24 @@ connections:
   # NAC to Timing Module routing/wiring
   - from: "NAC0 phase out 1kHz"
     to: "DPLL phase in 1kHz"
-    delayPs: -4000
+    delayPs: -5000
   - from: "NAC0 phase out 1Hz"
     to: "DPLL phase in 1Hz"
-    delayPs: -4000
+    delayPs: -5000
 
 
   # DPLL to NAC (during holdover)
   - from: "DPLL phase out 1kHz"
     to: "NAC0 phase in 1kHz"
-    delayPs: 5000
+    delayPs: -5000
   - from: "DPLL phase out 1Hz"
     to: "NAC0 phase in 1Hz"
-    delayPs: 5000
+    delayPs: -5000
 
 
   - from: "DPLL ESync out"
     to: "CF ESync in"
-    delayPs: 40000
+    delayPs: -25000
 
 
 # 3. Logic: Where do we compensate for the delay

--- a/pkg/hardwareconfig/hardwareconfig.go
+++ b/pkg/hardwareconfig/hardwareconfig.go
@@ -400,7 +400,7 @@ func (hcm *HardwareConfigManager) HasHardwareConfigForProfile(nodeProfile *ptpv1
 	}
 
 	for _, hwConfig := range hcm.hardwareConfigs {
-		if hwConfig.Spec.RelatedPtpProfileName == *nodeProfile.Name {
+		if ProfileNamesMatch(*nodeProfile.Name, hwConfig.Spec.RelatedPtpProfileName) {
 			return true
 		}
 	}
@@ -415,7 +415,7 @@ func (hcm *HardwareConfigManager) GetHardwareConfigsForProfile(nodeProfile *ptpv
 
 	var relevantConfigs []ptpv2alpha1.HardwareProfile
 	for _, hwConfig := range hcm.hardwareConfigs {
-		if hwConfig.Spec.RelatedPtpProfileName == *nodeProfile.Name {
+		if ProfileNamesMatch(*nodeProfile.Name, hwConfig.Spec.RelatedPtpProfileName) {
 			relevantConfigs = append(relevantConfigs, hwConfig.Spec.Profile)
 		}
 	}
@@ -432,7 +432,7 @@ func (hcm *HardwareConfigManager) ApplyHardwareConfigsForProfile(nodeProfile *pt
 	// Find enriched hardware configs for this profile
 	var relevantConfigs []enrichedHardwareConfig
 	for _, hwConfig := range hcm.hardwareConfigs {
-		if hwConfig.Spec.RelatedPtpProfileName == *nodeProfile.Name {
+		if ProfileNamesMatch(*nodeProfile.Name, hwConfig.Spec.RelatedPtpProfileName) {
 			relevantConfigs = append(relevantConfigs, hwConfig)
 		}
 	}
@@ -1841,7 +1841,7 @@ func (hcm *HardwareConfigManager) ApplyConditionForProfile(nodeProfile *ptpv1.Pt
 	// Find enriched hardware configs for this profile
 	var relevantConfigs []enrichedHardwareConfig
 	for _, hwConfig := range hcm.hardwareConfigs {
-		if hwConfig.Spec.RelatedPtpProfileName == *nodeProfile.Name {
+		if ProfileNamesMatch(*nodeProfile.Name, hwConfig.Spec.RelatedPtpProfileName) {
 			relevantConfigs = append(relevantConfigs, hwConfig)
 		}
 	}
@@ -2068,7 +2068,7 @@ func (hcm *HardwareConfigManager) ReadyHardwareConfigForProfile(name string) boo
 		return false
 	}
 	for _, hw := range hcm.hardwareConfigs {
-		if hw.Spec.RelatedPtpProfileName == name {
+		if ProfileNamesMatch(name, hw.Spec.RelatedPtpProfileName) {
 			return true
 		}
 	}
@@ -2214,7 +2214,7 @@ func (hcm *HardwareConfigManager) GetHoldoverParameters(profileName string, cloc
 	defer hcm.mu.RUnlock()
 
 	for _, hwConfig := range hcm.hardwareConfigs {
-		if hwConfig.Spec.RelatedPtpProfileName == profileName {
+		if ProfileNamesMatch(profileName, hwConfig.Spec.RelatedPtpProfileName) {
 			if params, found := hwConfig.holdoverParams[clockID]; found {
 				return params
 			}

--- a/pkg/hardwareconfig/hardwareconfig_gnrd_test.go
+++ b/pkg/hardwareconfig/hardwareconfig_gnrd_test.go
@@ -82,7 +82,7 @@ func TestGNRDHardwareConfigFullFlow(t *testing.T) {
 	// Apply hardware configs for profile (this applies defaults and init)
 	t.Logf("\n=== Phase 2: Applying Hardware Config for Profile ===")
 	profile := &ptpv1.PtpProfile{
-		Name: stringPtr("01-tbc-tr"),
+		Name: stringPtr("t-bc_01-tbc-tr"),
 	}
 
 	capturedDpllCommands = nil // Reset to capture only init commands

--- a/pkg/hardwareconfig/hardwareconfig_test.go
+++ b/pkg/hardwareconfig/hardwareconfig_test.go
@@ -46,7 +46,7 @@ func TestApplyHardwareConfigsForProfile(t *testing.T) {
 		{
 			name:         "successful hardware config application",
 			testDataFile: "testdata/wpc-hwconfig.yaml",
-			profileName:  "01-tbc-tr",
+			profileName:  "t-bc_01-tbc-tr",
 		},
 		{
 			name:         "no matching profile",
@@ -154,7 +154,7 @@ func TestHardwareConfigManagerOperations(t *testing.T) {
 
 	// Test HasHardwareConfigForProfile
 	profile := &ptpv1.PtpProfile{
-		Name: stringPtr("01-tbc-tr"),
+		Name: stringPtr("t-bc_01-tbc-tr"),
 	}
 	assert.True(t, hcm.HasHardwareConfigForProfile(profile))
 
@@ -163,7 +163,7 @@ func TestHardwareConfigManagerOperations(t *testing.T) {
 	assert.False(t, hcm.HasHardwareConfigForProfile(profile))
 
 	// Test GetHardwareConfigsForProfile
-	profile.Name = stringPtr("01-tbc-tr")
+	profile.Name = stringPtr("t-bc_01-tbc-tr")
 	configs := hcm.GetHardwareConfigsForProfile(profile)
 	assert.Len(t, configs, 1)
 	assert.Equal(t, "tbc", *configs[0].Name)
@@ -1443,13 +1443,13 @@ func TestHoldoverParametersExtraction(t *testing.T) {
 	hcm.mu.Unlock()
 
 	// Retrieve using API
-	retrieved1 := hcm.GetHoldoverParameters("test-profile", clockID1)
+	retrieved1 := hcm.GetHoldoverParameters("ptpconfig_test-profile", clockID1)
 	assert.NotNil(t, retrieved1, "Should retrieve holdover params for clock1")
 	if retrieved1 != nil {
 		assert.Equal(t, uint64(200), retrieved1.MaxInSpecOffset, "Retrieved MaxInSpecOffset should match")
 	}
 
-	retrieved2 := hcm.GetHoldoverParameters("test-profile", clockID2)
+	retrieved2 := hcm.GetHoldoverParameters("ptpconfig_test-profile", clockID2)
 	assert.NotNil(t, retrieved2, "Should retrieve holdover params for clock2")
 	if retrieved2 != nil {
 		assert.Equal(t, uint64(100), retrieved2.MaxInSpecOffset, "Retrieved MaxInSpecOffset should use default")
@@ -1460,7 +1460,7 @@ func TestHoldoverParametersExtraction(t *testing.T) {
 	assert.Nil(t, retrieved3, "Should return nil for non-existent profile")
 
 	// Test non-existent clock ID
-	retrieved4 := hcm.GetHoldoverParameters("test-profile", 0xDEADBEEF)
+	retrieved4 := hcm.GetHoldoverParameters("ptpconfig_test-profile", 0xDEADBEEF)
 	assert.Nil(t, retrieved4, "Should return nil for non-existent clock ID")
 
 	t.Logf("✓ Holdover parameter extraction and retrieval working correctly")

--- a/pkg/hardwareconfig/testdata/tbc-gnrd-dual-upstream.yaml
+++ b/pkg/hardwareconfig/testdata/tbc-gnrd-dual-upstream.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-ptp
 spec:
   profile:
-  - name: 00-tbc-tt
+  - name: t-bc-dual-upstream_00-tbc-tt
     ptp4lConf: |
       [eno8803]
       masterOnly 1
@@ -98,7 +98,7 @@ spec:
     ptpSettings:
       controllingProfile: 01-tbc-tr
       logReduce: "false"
-  - name: 01-tbc-tr
+  - name: t-bc-dual-upstream_01-tbc-tr
     phc2sysOpts: -r -n 24 -N 8 -R 16 -u 0 -m -s eno8703
     ptp4lConf: |
       [eno8703]

--- a/pkg/hardwareconfig/testdata/tbc-gnrd.yaml
+++ b/pkg/hardwareconfig/testdata/tbc-gnrd.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-ptp
 spec:
   profile:
-  - name: 00-tbc-tt
+  - name: t-bc_00-tbc-tt
     ptp4lConf: |
       [eno4]
       masterOnly 1
@@ -131,7 +131,7 @@ spec:
     ptpSettings:
       controllingProfile: 01-tbc-tr
       logReduce: "false"
-  - name: 01-tbc-tr
+  - name: t-bc_01-tbc-tr
     phc2sysOpts: -r -n 24 -N 8 -R 16 -u 0 -m -s eno2
     ptp4lConf: |
       # The interface name is hardware-specific


### PR DESCRIPTION
## Upstream PRs included

- [#205](https://github.com/k8snetworkplumbingwg/linuxptp-daemon/pull/205) OCPBUGS-85360: Output phase adjustment sign fix (OCPBUGS-85360)
- [#204](https://github.com/k8snetworkplumbingwg/linuxptp-daemon/pull/204) OCPBUGS-85361: Fix ptp and hardware profile matching logic (OCPBUGS-85361)
- [#198](https://github.com/k8snetworkplumbingwg/linuxptp-daemon/pull/198) Skip CI workflows for non-production changes
- [#197](https://github.com/k8snetworkplumbingwg/linuxptp-daemon/pull/197) add coverage gate to block PRs with decreasing coverage

## Skipped PRs

- ~~[#201](https://github.com/k8snetworkplumbingwg/linuxptp-daemon/pull/201) coverage-gate: skip force-update of tracking branch when checked out~~ — all changed files are upstream-only (not present downstream)