### PR TITLE
[release-4.22] OCPBUGS-87839: add live gate to ensure replay completes before live data

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -350,6 +350,56 @@ func (p *ptpProcess) setStopped(val bool) {
 	p.execMutex.Unlock()
 }
 
+type liveGate struct {
+	lock sync.RWMutex
+	c    chan struct{}
+	once func()
+}
+
+// Reset creates a new blocking gate. All ptp4l process connections
+// will block on this gate until openLiveGate is called (by the /emit-logs handler).
+func (l *liveGate) Reset() {
+	if !l.lock.TryLock() {
+		return
+	}
+	defer l.lock.Unlock()
+	l.c = make(chan struct{})
+	l.once = sync.OnceFunc(func() {
+		close(l.c)
+	})
+	glog.Info("liveGate: reset (blocked)")
+}
+
+// Open unblocks all ptp4l process connections waiting on the gate.
+// Safe to call multiple times (uses sync.Once).
+func (l *liveGate) Open() {
+	l.lock.RLock()
+	defer l.lock.RUnlock()
+	if l.once != nil {
+		l.once()
+	}
+}
+
+// liveGateTimeout is the safety timeout for waitForLiveGate. If the gate
+// is not opened within this duration, live data proceeds without the replay
+// guarantee. Exposed as a var so tests can shorten it.
+var liveGateTimeout = 60 * time.Second
+
+// Wait blocks until the gate opens or a safety timeout expires.
+func (l *liveGate) Wait(timeout time.Duration) {
+	l.lock.RLock()
+	defer l.lock.RUnlock()
+	if l.c == nil {
+		return
+	}
+	select {
+	case <-l.c:
+		glog.V(4).Info("waitForLiveGate: gate opened, proceeding")
+	case <-time.After(timeout):
+		glog.Warning("liveGate: timeout after 60s, proceeding without replay guarantee")
+	}
+}
+
 // Daemon is the main structure for linuxptp instance.
 // It contains all the necessary data to run linuxptp instance.
 type Daemon struct {
@@ -381,65 +431,13 @@ type Daemon struct {
 	pmcPollInterval int
 
 	// Allow vendors to include plugins
-	pluginManager  plugin.PluginManager
-	saFileWatcher  *fsnotify.Watcher
-	ptpClient      *ptpclient.Clientset
-	unknownPlugins []string
+	pluginManager plugin.PluginManager
+	saFileWatcher *fsnotify.Watcher
 
 	// liveGate blocks ptp4l process connections from writing to the event
 	// socket until the replay (/emit-logs) completes. This ensures CEP
 	// processes replay state before any live data arrives.
-	liveGateMu   sync.Mutex
-	liveGate     chan struct{}
-	liveGateOnce *sync.Once
-}
-
-// resetLiveGate creates a new blocking gate. All ptp4l process connections
-// will block on this gate until openLiveGate is called (by the /emit-logs handler).
-func (dn *Daemon) resetLiveGate() {
-	dn.liveGateMu.Lock()
-	dn.liveGate = make(chan struct{})
-	dn.liveGateOnce = &sync.Once{}
-	dn.liveGateMu.Unlock()
-	glog.Info("liveGate: reset (blocked)")
-}
-
-// openLiveGate unblocks all ptp4l process connections waiting on the gate.
-// Safe to call multiple times (uses sync.Once).
-func (dn *Daemon) openLiveGate() {
-	dn.liveGateMu.Lock()
-	once := dn.liveGateOnce
-	gate := dn.liveGate
-	dn.liveGateMu.Unlock()
-	if once != nil && gate != nil {
-		once.Do(func() {
-			close(gate)
-			glog.Info("liveGate: opened (replay complete, live data may flow)")
-		})
-	}
-}
-
-// liveGateTimeout is the safety timeout for waitForLiveGate. If the gate
-// is not opened within this duration, live data proceeds without the replay
-// guarantee. Exposed as a var so tests can shorten it.
-var liveGateTimeout = 60 * time.Second
-
-// waitForLiveGate blocks until the gate opens or a safety timeout expires.
-func (dn *Daemon) waitForLiveGate() {
-	dn.liveGateMu.Lock()
-	gate := dn.liveGate
-	dn.liveGateMu.Unlock()
-	if gate == nil {
-		glog.V(4).Info("waitForLiveGate: gate is nil, returning immediately")
-		return
-	}
-	glog.V(4).Info("waitForLiveGate: blocking until gate opens")
-	select {
-	case <-gate:
-		glog.V(4).Info("waitForLiveGate: gate opened, proceeding")
-	case <-time.After(liveGateTimeout):
-		glog.Warning("liveGate: timeout after 60s, proceeding without replay guarantee")
-	}
+	liveGate *liveGate
 }
 
 // UpdateHardwareConfig implements controller.HardwareConfigUpdateHandler.
@@ -577,6 +575,7 @@ func New(
 		readyTracker:          tracker,
 		stopCh:                stopCh,
 		saFileWatcher:         saFileWatch,
+		liveGate:              &liveGate{},
 	}
 	pm.daemon = dn
 	return dn
@@ -801,7 +800,7 @@ func (dn *Daemon) applyNodePTPProfiles() error {
 	glog.Infof("All profiles applied, starting %d processes", len(dn.processManager.process))
 	// Reset the live gate BEFORE starting processes so that socket-writers
 	// block until /emit-logs completes replay after the sidecar restart.
-	dn.resetLiveGate()
+	dn.liveGate.Reset()
 	// Start all the process
 	for _, p := range dn.processManager.process {
 		if p != nil {
@@ -1628,7 +1627,7 @@ connect:
 		}
 	}
 	glog.V(4).Infof("socket-writer[%s]: dial succeeded, waiting for liveGate", p.name)
-	p.dn.waitForLiveGate()
+	p.dn.liveGate.Wait(liveGateTimeout)
 	glog.V(4).Infof("socket-writer[%s]: liveGate passed, sending LIVE_START", p.name)
 	if _, err2 := fmt.Fprintf(p.c, "%s\n", liveStartCommand); err2 != nil {
 		glog.Errorf("failed to write LIVE_START marker: %v", err2)

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"cmp"
 	"fmt"
+	"io"
 	"math"
 	"net"
 	"os"
@@ -1570,8 +1571,112 @@ func (p *ptpProcess) processTBCTransitionLegacy(output string, pm *plugin.Plugin
 }
 
 // cmdRun runs given ptpProcess and restarts on errors
-//
-//nolint:gocyclo // complexity is acceptable for this function
+// processOutput handles shared per-line processing for all process types:
+// chronyd prefix, plugin processing, clock ID replacement, log filtering,
+// metrics extraction, TBC transition check, and HA failover.
+func (p *ptpProcess) processOutput(output string, pm *plugin.PluginManager, profileClockType string) string {
+	if p.name == chronydProcessName {
+		output = fmt.Sprintf("%s[%d]%s: %s", chronydProcessName, p.cmd.Process.Pid, p.messageTag, output)
+	}
+	output = pm.ProcessLog(p.name, output)
+	output = p.replaceClockID(output)
+	printWhenNotEmpty(logfilter.FilterOutput(p.logFilters, output))
+	p.processPTPMetrics(output)
+	if p.name == ptp4lProcessName {
+		if profileClockType == TBC {
+			p.tBCTransitionCheck(output, pm)
+		}
+	} else if p.name == phc2sysProcessName && len(p.haProfile) > 0 {
+		p.announceHAFailOver(nil, output)
+	}
+	return output
+}
+
+// runScanner reads process stdout without delay so the pipe never backs
+// up, processes each line, and pushes the result to lineCh for the
+// socket-writer. It closes lineCh when the scanner finishes.
+func (p *ptpProcess) runScanner(cmdReader io.Reader, lineCh chan<- string, pm *plugin.PluginManager, profileClockType string) {
+	scanner := bufio.NewScanner(cmdReader)
+	for scanner.Scan() {
+		output := p.processOutput(scanner.Text(), pm, profileClockType)
+		select {
+		case lineCh <- output:
+		default:
+			glog.Warning("liveGate: lineCh full, dropping line for socket forwarding")
+		}
+	}
+	close(lineCh)
+}
+
+// runSocketWriter connects to the event socket, waits for the live gate
+// (replay) to complete, drains stale lines, then forwards live lines to
+// CEP. On write failure it reconnects automatically.
+func (p *ptpProcess) runSocketWriter(lineCh <-chan string, doneCh chan<- struct{}) {
+	var err error
+connect:
+	glog.V(4).Infof("socket-writer[%s]: attempting dial to event socket", p.name)
+	select {
+	case <-p.exitCh:
+		glog.V(4).Infof("socket-writer[%s]: exitCh during dial, returning", p.name)
+		doneCh <- struct{}{}
+		return
+	default:
+		p.c, err = dialSocket()
+		if err != nil {
+			glog.V(4).Infof("socket-writer[%s]: dial failed: %v, retrying", p.name, err)
+			goto connect
+		}
+	}
+	glog.V(4).Infof("socket-writer[%s]: dial succeeded, waiting for liveGate", p.name)
+	p.dn.waitForLiveGate()
+	glog.V(4).Infof("socket-writer[%s]: liveGate passed, sending LIVE_START", p.name)
+	if _, err2 := fmt.Fprintf(p.c, "%s\n", liveStartCommand); err2 != nil {
+		glog.Errorf("failed to write LIVE_START marker: %v", err2)
+		goto connect
+	}
+	glog.V(4).Infof("socket-writer[%s]: LIVE_START sent, draining stale buffer", p.name)
+	{
+		drained := 0
+	drainLoop:
+		for {
+			select {
+			case _, ok := <-lineCh:
+				if !ok {
+					glog.V(4).Infof("socket-writer[%s]: lineCh closed during drain", p.name)
+					doneCh <- struct{}{}
+					return
+				}
+				drained++
+			default:
+				break drainLoop
+			}
+		}
+		glog.V(4).Infof("socket-writer[%s]: drained %d stale lines, sending processStatus UP", p.name, drained)
+	}
+
+	processStatus(p.c, p.name, p.messageTag, PtpProcessUp)
+	for _, d := range p.depProcess {
+		if d != nil {
+			d.ProcessStatus(p.c, PtpProcessUp)
+		}
+	}
+	glog.V(4).Infof("socket-writer[%s]: starting line forwarding loop", p.name)
+
+	for output := range lineCh {
+		if p.name == phc2sysProcessName && len(p.haProfile) > 0 {
+			p.announceHAFailOver(p.c, output)
+		}
+		line := removeMessageSuffix(output) + "\n"
+		_, err2 := p.c.Write([]byte(line))
+		if err2 != nil {
+			glog.V(4).Infof("socket-writer[%s]: write error: %v, reconnecting. line=%s", p.name, err2, output)
+			goto connect
+		}
+	}
+	glog.V(4).Infof("socket-writer[%s]: lineCh closed, forwarding done", p.name)
+	doneCh <- struct{}{}
+}
+
 func (p *ptpProcess) cmdRun(stdoutToSocket bool, pm *plugin.PluginManager) {
 	cmd := p.cmd
 	stopped := p.getAndSetStopped(false)
@@ -1579,7 +1684,7 @@ func (p *ptpProcess) cmdRun(stdoutToSocket bool, pm *plugin.PluginManager) {
 		glog.Infof("%s is already running", p.name)
 		return
 	}
-	doneCh := make(chan struct{}) // Done setting up logging.  Go ahead and wait for process
+	doneCh := make(chan struct{})
 	defer func() {
 		if stdoutToSocket && p.c != nil {
 			if err := p.c.Close(); err != nil {
@@ -1603,7 +1708,6 @@ func (p *ptpProcess) cmdRun(stdoutToSocket bool, pm *plugin.PluginManager) {
 			break
 		}
 
-		// don't discard process stderr output
 		cmd.Stderr = cmd.Stdout
 
 		if !stdoutToSocket {
@@ -1611,136 +1715,25 @@ func (p *ptpProcess) cmdRun(stdoutToSocket bool, pm *plugin.PluginManager) {
 			processStatus(nil, p.name, p.messageTag, PtpProcessUp)
 			go func() {
 				for scanner.Scan() {
-					output := scanner.Text()
-					if p.name == chronydProcessName {
-						output = fmt.Sprintf("%s[%d]%s: %s", chronydProcessName, p.cmd.Process.Pid, p.messageTag, output)
-					}
-					output = pm.ProcessLog(p.name, output)
-					// for ts2phc from 4.2 onwards replace /dev/ptpX by actual interface
-					output = p.replaceClockID(output)
-					printWhenNotEmpty(logfilter.FilterOutput(p.logFilters, output))
-					p.processPTPMetrics(output)
-					if p.name == ptp4lProcessName {
-						if profileClockType == TBC {
-							p.tBCTransitionCheck(output, pm)
-						}
-					} else if p.name == phc2sysProcessName && len(p.haProfile) > 0 {
-						p.announceHAFailOver(nil, output) // do not use go routine since order of execution is important here
-					}
+					p.processOutput(scanner.Text(), pm, profileClockType)
 				}
 				doneCh <- struct{}{}
 			}()
 		} else {
-			// lineCh bridges the scanner goroutine (which must start immediately
-			// to drain ptp4l's stdout pipe) with the socket-writer goroutine
-			// (which waits for the live gate before forwarding to CEP).
 			lineCh := make(chan string, 256)
-
-			// Scanner goroutine: reads ptp4l stdout without delay so the pipe
-			// never backs up, processes metrics and prints to pod logs.
-			go func() {
-				scanner := bufio.NewScanner(cmdReader)
-				for scanner.Scan() {
-					output := scanner.Text()
-					if p.name == chronydProcessName {
-						output = fmt.Sprintf("%s[%d]%s: %s", chronydProcessName, p.cmd.Process.Pid, p.messageTag, output)
-					}
-					output = pm.ProcessLog(p.name, output)
-					output = p.replaceClockID(output)
-					printWhenNotEmpty(logfilter.FilterOutput(p.logFilters, output))
-
-					p.processPTPMetrics(output)
-					if p.name == ptp4lProcessName {
-						if profileClockType == TBC {
-							p.tBCTransitionCheck(output, pm)
-						}
-					} else if p.name == phc2sysProcessName && len(p.haProfile) > 0 {
-						p.announceHAFailOver(nil, output)
-					}
-					select {
-					case lineCh <- output:
-					default:
-						glog.Warning("liveGate: lineCh full, dropping line for socket forwarding")
-					}
-				}
-				close(lineCh)
-			}()
-
-			// Socket-writer goroutine: connects to the event socket, waits for
-			// the live gate (replay) to complete, then forwards lines to CEP.
-			go func() {
-			connect:
-				glog.V(4).Infof("socket-writer[%s]: attempting dial to event socket", p.name)
-				select {
-				case <-p.exitCh:
-					glog.V(4).Infof("socket-writer[%s]: exitCh during dial, returning", p.name)
-					doneCh <- struct{}{}
-					return
-				default:
-					p.c, err = dialSocket()
-					if err != nil {
-						glog.V(4).Infof("socket-writer[%s]: dial failed: %v, retrying", p.name, err)
-						goto connect
-					}
-				}
-				glog.V(4).Infof("socket-writer[%s]: dial succeeded, waiting for liveGate", p.name)
-				p.dn.waitForLiveGate()
-				glog.V(4).Infof("socket-writer[%s]: liveGate passed, sending LIVE_START", p.name)
-				if _, err2 := fmt.Fprintf(p.c, "%s\n", liveStartCommand); err2 != nil {
-					glog.Errorf("failed to write LIVE_START marker: %v", err2)
-					goto connect
-				}
-				glog.V(4).Infof("socket-writer[%s]: LIVE_START sent, draining stale buffer", p.name)
-				drained := 0
-			drainLoop:
-				for {
-					select {
-					case _, ok := <-lineCh:
-						if !ok {
-							glog.V(4).Infof("socket-writer[%s]: lineCh closed during drain", p.name)
-							doneCh <- struct{}{}
-							return
-						}
-						drained++
-					default:
-						break drainLoop
-					}
-				}
-				glog.V(4).Infof("socket-writer[%s]: drained %d stale lines, sending processStatus UP", p.name, drained)
-
-				processStatus(p.c, p.name, p.messageTag, PtpProcessUp)
-				for _, d := range p.depProcess {
-					if d != nil {
-						d.ProcessStatus(p.c, PtpProcessUp)
-					}
-				}
-				glog.V(4).Infof("socket-writer[%s]: starting line forwarding loop", p.name)
-
-				for output := range lineCh {
-					if p.name == phc2sysProcessName && len(p.haProfile) > 0 {
-						p.announceHAFailOver(p.c, output)
-					}
-					line := removeMessageSuffix(output) + "\n"
-					_, err2 := p.c.Write([]byte(line))
-					if err2 != nil {
-						glog.V(4).Infof("socket-writer[%s]: write error: %v, reconnecting. line=%s", p.name, err2, output)
-						goto connect
-					}
-				}
-				glog.V(4).Infof("socket-writer[%s]: lineCh closed, forwarding done", p.name)
-				doneCh <- struct{}{}
-			}()
+			go p.runScanner(cmdReader, lineCh, pm, profileClockType)
+			go p.runSocketWriter(lineCh, doneCh)
 		}
-		// Don't restart after termination
+
 		if !p.Stopped() {
 			glog.Infof("starting %s...", p.name)
 			p.cmd = cmd
-			err = cmd.Start() // this is asynchronous call,
+			err = cmd.Start()
 			if err != nil {
 				glog.Errorf("CmdRun() error starting %s: %v", p.name, err)
 			}
 
-			<-doneCh // goroutine is done
+			<-doneCh
 			err = cmd.Wait()
 
 			glog.Infof("done waiting for %s...", p.name)
@@ -1760,8 +1753,7 @@ func (p *ptpProcess) cmdRun(stdoutToSocket bool, pm *plugin.PluginManager) {
 		if profileClockType == TBC && p.name == ptp4lProcessName {
 			pm.AfterRunPTPCommand(&p.nodeProfile, "reset-to-default")
 		}
-		time.Sleep(connectionRetryInterval) // Delay to prevent flooding restarts if startup fails
-		// Don't restart after termination
+		time.Sleep(connectionRetryInterval)
 		if p.Stopped() {
 			glog.Infof("Not recreating %s...", p.name)
 			break

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -367,7 +367,7 @@ func (l *liveGate) Reset() {
 	l.once = sync.OnceFunc(func() {
 		close(l.c)
 	})
-	glog.Info("liveGate: reset (blocked)")
+	glog.V(14).Info("liveGate: reset (blocked)")
 }
 
 // Open unblocks all ptp4l process connections waiting on the gate.
@@ -394,7 +394,7 @@ func (l *liveGate) Wait(timeout time.Duration) {
 	}
 	select {
 	case <-l.c:
-		glog.V(4).Info("waitForLiveGate: gate opened, proceeding")
+		glog.V(14).Info("waitForLiveGate: gate opened, proceeding")
 	case <-time.After(timeout):
 		glog.Warning("liveGate: timeout after 60s, proceeding without replay guarantee")
 	}
@@ -1383,11 +1383,11 @@ func processStatus(c net.Conn, processName, messageTag string, status int64) {
 	// ptp4l[5196819.100]: [ptp4l.0.config] PTP_PROCESS_STOPPED:0/1
 
 	if c == nil {
-		glog.V(4).Infof("processStatus: process=%s config=%s status=%d via=prometheus", processName, cfgName, status)
+		glog.V(14).Infof("processStatus: process=%s config=%s status=%d via=prometheus", processName, cfgName, status)
 		UpdateProcessStatusMetrics(processName, cfgName, status)
 		return
 	}
-	glog.V(4).Infof("processStatus: process=%s config=%s status=%d via=socket", processName, cfgName, status)
+	glog.V(14).Infof("processStatus: process=%s config=%s status=%d via=socket", processName, cfgName, status)
 	logProcessStatus(processName, cfgName, status, c)
 }
 
@@ -1613,27 +1613,27 @@ func (p *ptpProcess) runScanner(cmdReader io.Reader, lineCh chan<- string, pm *p
 func (p *ptpProcess) runSocketWriter(lineCh <-chan string, doneCh chan<- struct{}) {
 	var err error
 connect:
-	glog.V(4).Infof("socket-writer[%s]: attempting dial to event socket", p.name)
+	glog.V(14).Infof("socket-writer[%s]: attempting dial to event socket", p.name)
 	select {
 	case <-p.exitCh:
-		glog.V(4).Infof("socket-writer[%s]: exitCh during dial, returning", p.name)
+		glog.V(14).Infof("socket-writer[%s]: exitCh during dial, returning", p.name)
 		doneCh <- struct{}{}
 		return
 	default:
 		p.c, err = dialSocket()
 		if err != nil {
-			glog.V(4).Infof("socket-writer[%s]: dial failed: %v, retrying", p.name, err)
+			glog.V(14).Infof("socket-writer[%s]: dial failed: %v, retrying", p.name, err)
 			goto connect
 		}
 	}
-	glog.V(4).Infof("socket-writer[%s]: dial succeeded, waiting for liveGate", p.name)
+	glog.V(14).Infof("socket-writer[%s]: dial succeeded, waiting for liveGate", p.name)
 	p.dn.liveGate.Wait(liveGateTimeout)
-	glog.V(4).Infof("socket-writer[%s]: liveGate passed, sending LIVE_START", p.name)
+	glog.V(14).Infof("socket-writer[%s]: liveGate passed, sending LIVE_START", p.name)
 	if _, err2 := fmt.Fprintf(p.c, "%s\n", liveStartCommand); err2 != nil {
 		glog.Errorf("failed to write LIVE_START marker: %v", err2)
 		goto connect
 	}
-	glog.V(4).Infof("socket-writer[%s]: LIVE_START sent, draining stale buffer", p.name)
+	glog.V(14).Infof("socket-writer[%s]: LIVE_START sent, draining stale buffer", p.name)
 	{
 		drained := 0
 	drainLoop:
@@ -1641,7 +1641,7 @@ connect:
 			select {
 			case _, ok := <-lineCh:
 				if !ok {
-					glog.V(4).Infof("socket-writer[%s]: lineCh closed during drain", p.name)
+					glog.V(14).Infof("socket-writer[%s]: lineCh closed during drain", p.name)
 					doneCh <- struct{}{}
 					return
 				}
@@ -1650,7 +1650,7 @@ connect:
 				break drainLoop
 			}
 		}
-		glog.V(4).Infof("socket-writer[%s]: drained %d stale lines, sending processStatus UP", p.name, drained)
+		glog.V(14).Infof("socket-writer[%s]: drained %d stale lines, sending processStatus UP", p.name, drained)
 	}
 
 	processStatus(p.c, p.name, p.messageTag, PtpProcessUp)
@@ -1659,7 +1659,7 @@ connect:
 			d.ProcessStatus(p.c, PtpProcessUp)
 		}
 	}
-	glog.V(4).Infof("socket-writer[%s]: starting line forwarding loop", p.name)
+	glog.V(14).Infof("socket-writer[%s]: starting line forwarding loop", p.name)
 
 	for output := range lineCh {
 		if p.name == phc2sysProcessName && len(p.haProfile) > 0 {
@@ -1668,11 +1668,11 @@ connect:
 		line := removeMessageSuffix(output) + "\n"
 		_, err2 := p.c.Write([]byte(line))
 		if err2 != nil {
-			glog.V(4).Infof("socket-writer[%s]: write error: %v, reconnecting. line=%s", p.name, err2, output)
+			glog.Errorf("socket-writer[%s]: write error: %v, reconnecting. line=%s", p.name, err2, output)
 			goto connect
 		}
 	}
-	glog.V(4).Infof("socket-writer[%s]: lineCh closed, forwarding done", p.name)
+	glog.V(14).Infof("socket-writer[%s]: lineCh closed, forwarding done", p.name)
 	doneCh <- struct{}{}
 }
 
@@ -1740,10 +1740,10 @@ func (p *ptpProcess) cmdRun(stdoutToSocket bool, pm *plugin.PluginManager) {
 				glog.Errorf("CmdRun() error waiting for %s: %v", p.name, err)
 			}
 			if stdoutToSocket && p.c != nil {
-				glog.V(4).Infof("cmdRun[%s]: process ended, sending DOWN via socket", p.name)
+				glog.V(14).Infof("cmdRun[%s]: process ended, sending DOWN via socket", p.name)
 				processStatus(p.c, p.name, p.messageTag, PtpProcessDown)
 			} else {
-				glog.V(4).Infof("cmdRun[%s]: process ended, sending DOWN via prometheus", p.name)
+				glog.V(14).Infof("cmdRun[%s]: process ended, sending DOWN via prometheus", p.name)
 				processStatus(nil, p.name, p.messageTag, PtpProcessDown)
 			}
 			p.updateGMStatusOnProcessDown(p.name)
@@ -1762,7 +1762,7 @@ func (p *ptpProcess) cmdRun(stdoutToSocket bool, pm *plugin.PluginManager) {
 			cmd = newCmd
 		}
 		if stdoutToSocket && p.c != nil {
-			glog.V(4).Infof("cmdRun[%s]: closing old socket connection before restart", p.name)
+			glog.V(14).Infof("cmdRun[%s]: closing old socket connection before restart", p.name)
 			if err2 := p.c.Close(); err2 != nil {
 				glog.Errorf("closing connection returned error %s", err2)
 			}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -111,7 +111,12 @@ var ptpTmpFiles = []string{
 
 var vTbcHasHardwareConfig = false
 
-const socketDialTimeout = 5 * time.Second
+const (
+	socketDialTimeout = 5 * time.Second
+	// liveStartCommand is sent on each ptp4l process connection after the live
+	// gate opens. It tells CEP that all subsequent data is live (post-replay).
+	liveStartCommand = "CMD LIVE_START"
+)
 
 func dialSocket() (net.Conn, error) {
 	c, err := net.DialTimeout("unix", eventSocket, socketDialTimeout)
@@ -126,9 +131,12 @@ func dialSocket() (net.Conn, error) {
 // over a short-lived dedicated connection to the event socket. The sidecar will exec itself
 // for a clean restart, then re-read all configuration from disk (ConfigMap + ptp4l config files).
 //
-// This must be called after applyNodePTPProfiles() has written all config files and started
-// all PTP processes, so that the sidecar restarts into a consistent state.
-func sendSidecarRestart() error {
+// Before sending CMD RESTART, the live gate is reset so that ptp4l process connections
+// block until the next /emit-logs (replay) completes. This guarantees CEP sees replay
+// state before any live data.
+func (dn *Daemon) sendSidecarRestart() error {
+	dn.resetLiveGate()
+
 	c, err := net.Dial("unix", eventSocket)
 	if err != nil {
 		return err
@@ -150,6 +158,7 @@ type ProcessManager struct {
 	process         []*ptpProcess
 	eventChannel    chan event.EventChannel
 	ptpEventHandler *event.EventHandler
+	daemon          *Daemon
 }
 
 // NewProcessManager is used by unit tests
@@ -374,8 +383,71 @@ type Daemon struct {
 	pmcPollInterval int
 
 	// Allow vendors to include plugins
-	pluginManager plugin.PluginManager
-	saFileWatcher *fsnotify.Watcher
+	pluginManager  plugin.PluginManager
+	saFileWatcher  *fsnotify.Watcher
+	ptpClient      *ptpclient.Clientset
+	unknownPlugins []string
+
+	// liveGate blocks ptp4l process connections from writing to the event
+	// socket until the replay (/emit-logs) completes. This ensures CEP
+	// processes replay state before any live data arrives.
+	liveGateMu   sync.Mutex
+	liveGate     chan struct{}
+	liveGateOnce *sync.Once
+}
+
+// resetLiveGate creates a new blocking gate. All ptp4l process connections
+// will block on this gate until openLiveGate is called (by the /emit-logs handler).
+func (dn *Daemon) resetLiveGate() {
+	dn.liveGateMu.Lock()
+	dn.liveGate = make(chan struct{})
+	dn.liveGateOnce = &sync.Once{}
+	dn.liveGateMu.Unlock()
+	glog.Info("liveGate: reset (blocked)")
+}
+
+// openLiveGate unblocks all ptp4l process connections waiting on the gate.
+// Safe to call multiple times (uses sync.Once).
+func (dn *Daemon) openLiveGate() {
+	dn.liveGateMu.Lock()
+	once := dn.liveGateOnce
+	gate := dn.liveGate
+	dn.liveGateMu.Unlock()
+	if once != nil && gate != nil {
+		once.Do(func() {
+			close(gate)
+			glog.Info("liveGate: opened (replay complete, live data may flow)")
+		})
+	}
+}
+
+// liveGateTimeout is the safety timeout for waitForLiveGate. If the gate
+// is not opened within this duration, live data proceeds without the replay
+// guarantee. Exposed as a var so tests can shorten it.
+var liveGateTimeout = 60 * time.Second
+
+// waitForLiveGate blocks until the gate opens, exitCh fires, or a safety
+// timeout expires. Returns true if gate opened, false if exit/timeout.
+func (dn *Daemon) waitForLiveGate(exitCh chan bool) bool {
+	dn.liveGateMu.Lock()
+	gate := dn.liveGate
+	dn.liveGateMu.Unlock()
+	if gate == nil {
+		glog.V(4).Info("waitForLiveGate: gate is nil, returning immediately")
+		return true
+	}
+	glog.V(4).Info("waitForLiveGate: blocking until gate opens")
+	select {
+	case <-gate:
+		glog.V(4).Info("waitForLiveGate: gate opened, proceeding")
+		return true
+	case <-exitCh:
+		glog.V(4).Info("waitForLiveGate: exitCh fired, aborting")
+		return false
+	case <-time.After(liveGateTimeout):
+		glog.Warning("liveGate: timeout after 60s, proceeding without replay guarantee")
+		return true
+	}
 }
 
 // UpdateHardwareConfig implements controller.HardwareConfigUpdateHandler.
@@ -498,7 +570,7 @@ func New(
 		}
 	}
 
-	return &Daemon{
+	dn := &Daemon{
 		nodeName:              nodeName,
 		namespace:             namespace,
 		stdoutToSocket:        stdoutToSocket,
@@ -514,6 +586,8 @@ func New(
 		stopCh:                stopCh,
 		saFileWatcher:         saFileWatch,
 	}
+	pm.daemon = dn
+	return dn
 }
 
 // Run in a for loop to listen for any LinuxPTPConfUpdate changes
@@ -619,6 +693,7 @@ func printWhenNotEmpty(output string) {
 // SetProcessManager in tests
 func (dn *Daemon) SetProcessManager(p *ProcessManager) {
 	dn.processManager = p
+	p.daemon = dn
 	dn.readyTracker.processManager = p
 }
 
@@ -769,7 +844,7 @@ func (dn *Daemon) applyNodePTPProfiles() error {
 	dn.pluginManager.PopulateHwConfig(dn.hwconfigs)
 	*dn.refreshNodePtpDevice = true
 	dn.readyTracker.setConfig(true)
-	return sendSidecarRestart()
+	return dn.sendSidecarRestart()
 }
 
 func reconcileRelatedProfiles(profiles []ptpv1.PtpProfile) map[string]int {
@@ -1314,9 +1389,11 @@ func processStatus(c net.Conn, processName, messageTag string, status int64) {
 	// ptp4l[5196819.100]: [ptp4l.0.config] PTP_PROCESS_STOPPED:0/1
 
 	if c == nil {
+		glog.V(4).Infof("processStatus: process=%s config=%s status=%d via=prometheus", processName, cfgName, status)
 		UpdateProcessStatusMetrics(processName, cfgName, status)
 		return
 	}
+	glog.V(4).Infof("processStatus: process=%s config=%s status=%d via=socket", processName, cfgName, status)
 	logProcessStatus(processName, cfgName, status, c)
 }
 
@@ -1560,51 +1637,107 @@ func (p *ptpProcess) cmdRun(stdoutToSocket bool, pm *plugin.PluginManager) {
 				doneCh <- struct{}{}
 			}()
 		} else {
-			go func() {
-			connect:
-				select {
-				case <-p.exitCh:
-					doneCh <- struct{}{}
-				default:
-					p.c, err = dialSocket()
-					if err != nil {
-						goto connect
-					}
-				}
-				scanner := bufio.NewScanner(cmdReader)
-				processStatus(p.c, p.name, p.messageTag, PtpProcessUp)
-				for _, d := range p.depProcess {
-					if d != nil {
-						d.ProcessStatus(p.c, PtpProcessUp)
-					}
-				}
+			// lineCh bridges the scanner goroutine (which must start immediately
+			// to drain ptp4l's stdout pipe) with the socket-writer goroutine
+			// (which waits for the live gate before forwarding to CEP).
+			lineCh := make(chan string, 256)
 
+			// Scanner goroutine: reads ptp4l stdout without delay so the pipe
+			// never backs up, processes metrics and prints to pod logs.
+			go func() {
+				scanner := bufio.NewScanner(cmdReader)
 				for scanner.Scan() {
 					output := scanner.Text()
 					if p.name == chronydProcessName {
 						output = fmt.Sprintf("%s[%d]%s: %s", chronydProcessName, p.cmd.Process.Pid, p.messageTag, output)
 					}
 					output = pm.ProcessLog(p.name, output)
-					// for ts2phc from 4.2 onwards replace /dev/ptpX by actual interface
 					output = p.replaceClockID(output)
 					printWhenNotEmpty(logfilter.FilterOutput(p.logFilters, output))
 
-					// for ts2phc, we need to extract metrics to identify GM state
 					p.processPTPMetrics(output)
 					if p.name == ptp4lProcessName {
 						if profileClockType == TBC {
 							p.tBCTransitionCheck(output, pm)
 						}
 					} else if p.name == phc2sysProcessName && len(p.haProfile) > 0 {
-						p.announceHAFailOver(p.c, output) // do not use go routine since order of execution is important here
+						p.announceHAFailOver(nil, output)
+					}
+					select {
+					case lineCh <- output:
+					default:
+						glog.Warning("liveGate: lineCh full, dropping line for socket forwarding")
+					}
+				}
+				close(lineCh)
+			}()
+
+			// Socket-writer goroutine: connects to the event socket, waits for
+			// the live gate (replay) to complete, then forwards lines to CEP.
+			go func() {
+			connect:
+				glog.V(4).Infof("socket-writer[%s]: attempting dial to event socket", p.name)
+				select {
+				case <-p.exitCh:
+					glog.V(4).Infof("socket-writer[%s]: exitCh during dial, returning", p.name)
+					doneCh <- struct{}{}
+					return
+				default:
+					p.c, err = dialSocket()
+					if err != nil {
+						glog.V(4).Infof("socket-writer[%s]: dial failed: %v, retrying", p.name, err)
+						goto connect
+					}
+				}
+				glog.V(4).Infof("socket-writer[%s]: dial succeeded, waiting for liveGate", p.name)
+				if !p.dn.waitForLiveGate(p.exitCh) {
+					glog.V(4).Infof("socket-writer[%s]: liveGate returned false, returning", p.name)
+					doneCh <- struct{}{}
+					return
+				}
+				glog.V(4).Infof("socket-writer[%s]: liveGate passed, sending LIVE_START", p.name)
+				if _, err2 := fmt.Fprintf(p.c, "%s\n", liveStartCommand); err2 != nil {
+					glog.Errorf("failed to write LIVE_START marker: %v", err2)
+					goto connect
+				}
+				glog.V(4).Infof("socket-writer[%s]: LIVE_START sent, draining stale buffer", p.name)
+				drained := 0
+			drainLoop:
+				for {
+					select {
+					case _, ok := <-lineCh:
+						if !ok {
+							glog.V(4).Infof("socket-writer[%s]: lineCh closed during drain", p.name)
+							doneCh <- struct{}{}
+							return
+						}
+						drained++
+					default:
+						break drainLoop
+					}
+				}
+				glog.V(4).Infof("socket-writer[%s]: drained %d stale lines, sending processStatus UP", p.name, drained)
+
+				processStatus(p.c, p.name, p.messageTag, PtpProcessUp)
+				for _, d := range p.depProcess {
+					if d != nil {
+						d.ProcessStatus(p.c, PtpProcessUp)
+					}
+				}
+				glog.V(4).Infof("socket-writer[%s]: starting line forwarding loop", p.name)
+
+				for output := range lineCh {
+					if p.name == phc2sysProcessName && len(p.haProfile) > 0 {
+						p.announceHAFailOver(p.c, output)
 					}
 					line := removeMessageSuffix(output) + "\n"
 					_, err2 := p.c.Write([]byte(line))
 					if err2 != nil {
-						glog.Errorf("Write %s error %s:", output, err2)
+						glog.V(4).Infof("socket-writer[%s]: write error: %v, reconnecting. line=%s", p.name, err2, output)
 						goto connect
 					}
 				}
+				glog.V(4).Infof("socket-writer[%s]: lineCh closed, forwarding done", p.name)
 				doneCh <- struct{}{}
 			}()
 		}
@@ -1625,8 +1758,10 @@ func (p *ptpProcess) cmdRun(stdoutToSocket bool, pm *plugin.PluginManager) {
 				glog.Errorf("CmdRun() error waiting for %s: %v", p.name, err)
 			}
 			if stdoutToSocket && p.c != nil {
+				glog.V(4).Infof("cmdRun[%s]: process ended, sending DOWN via socket", p.name)
 				processStatus(p.c, p.name, p.messageTag, PtpProcessDown)
 			} else {
+				glog.V(4).Infof("cmdRun[%s]: process ended, sending DOWN via prometheus", p.name)
 				processStatus(nil, p.name, p.messageTag, PtpProcessDown)
 			}
 			p.updateGMStatusOnProcessDown(p.name)
@@ -1646,6 +1781,7 @@ func (p *ptpProcess) cmdRun(stdoutToSocket bool, pm *plugin.PluginManager) {
 			cmd = newCmd
 		}
 		if stdoutToSocket && p.c != nil {
+			glog.V(4).Infof("cmdRun[%s]: closing old socket connection before restart", p.name)
 			if err2 := p.c.Close(); err2 != nil {
 				glog.Errorf("closing connection returned error %s", err2)
 			}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -131,12 +131,9 @@ func dialSocket() (net.Conn, error) {
 // over a short-lived dedicated connection to the event socket. The sidecar will exec itself
 // for a clean restart, then re-read all configuration from disk (ConfigMap + ptp4l config files).
 //
-// Before sending CMD RESTART, the live gate is reset so that ptp4l process connections
-// block until the next /emit-logs (replay) completes. This guarantees CEP sees replay
-// state before any live data.
+// The live gate is reset earlier in applyNodePTPProfiles (before processes start)
+// so that socket-writers block until the next /emit-logs (replay) completes.
 func (dn *Daemon) sendSidecarRestart() error {
-	dn.resetLiveGate()
-
 	c, err := net.Dial("unix", eventSocket)
 	if err != nil {
 		return err
@@ -426,27 +423,21 @@ func (dn *Daemon) openLiveGate() {
 // guarantee. Exposed as a var so tests can shorten it.
 var liveGateTimeout = 60 * time.Second
 
-// waitForLiveGate blocks until the gate opens, exitCh fires, or a safety
-// timeout expires. Returns true if gate opened, false if exit/timeout.
-func (dn *Daemon) waitForLiveGate(exitCh chan bool) bool {
+// waitForLiveGate blocks until the gate opens or a safety timeout expires.
+func (dn *Daemon) waitForLiveGate() {
 	dn.liveGateMu.Lock()
 	gate := dn.liveGate
 	dn.liveGateMu.Unlock()
 	if gate == nil {
 		glog.V(4).Info("waitForLiveGate: gate is nil, returning immediately")
-		return true
+		return
 	}
 	glog.V(4).Info("waitForLiveGate: blocking until gate opens")
 	select {
 	case <-gate:
 		glog.V(4).Info("waitForLiveGate: gate opened, proceeding")
-		return true
-	case <-exitCh:
-		glog.V(4).Info("waitForLiveGate: exitCh fired, aborting")
-		return false
 	case <-time.After(liveGateTimeout):
 		glog.Warning("liveGate: timeout after 60s, proceeding without replay guarantee")
-		return true
 	}
 }
 
@@ -807,6 +798,9 @@ func (dn *Daemon) applyNodePTPProfiles() error {
 	}
 
 	glog.Infof("All profiles applied, starting %d processes", len(dn.processManager.process))
+	// Reset the live gate BEFORE starting processes so that socket-writers
+	// block until /emit-logs completes replay after the sidecar restart.
+	dn.resetLiveGate()
 	// Start all the process
 	for _, p := range dn.processManager.process {
 		if p != nil {
@@ -1690,11 +1684,7 @@ func (p *ptpProcess) cmdRun(stdoutToSocket bool, pm *plugin.PluginManager) {
 					}
 				}
 				glog.V(4).Infof("socket-writer[%s]: dial succeeded, waiting for liveGate", p.name)
-				if !p.dn.waitForLiveGate(p.exitCh) {
-					glog.V(4).Infof("socket-writer[%s]: liveGate returned false, returning", p.name)
-					doneCh <- struct{}{}
-					return
-				}
+				p.dn.waitForLiveGate()
 				glog.V(4).Infof("socket-writer[%s]: liveGate passed, sending LIVE_START", p.name)
 				if _, err2 := fmt.Fprintf(p.c, "%s\n", liveStartCommand); err2 != nil {
 					glog.Errorf("failed to write LIVE_START marker: %v", err2)

--- a/pkg/daemon/daemon_internal_test.go
+++ b/pkg/daemon/daemon_internal_test.go
@@ -1943,7 +1943,15 @@ func TestLiveGate_MultipleWaitersAllUnblock(t *testing.T) {
 
 func shortTestSocketPath(t *testing.T) string {
 	t.Helper()
-	return t.TempDir() + "/e.sock"
+	// Use os.MkdirTemp with a short prefix to stay within the 104-byte
+	// Unix socket path limit on macOS. t.TempDir() embeds the full test
+	// name, which can exceed this limit for long test names.
+	dir, err := os.MkdirTemp("", "s")
+	if err != nil {
+		t.Fatalf("shortTestSocketPath: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	return dir + "/e.sock"
 }
 
 // TestLiveGateIntegration_FullDaemonCEPFlow simulates the complete ptp4l →
@@ -2663,7 +2671,7 @@ func TestEmitLogsHandler_Ready_EmitsReplayThenOpensGate(t *testing.T) {
 	dn.resetLiveGate()
 
 	// Provide a real socket so EmitPortRoleLogs can connect without retry delays.
-	socketPath := t.TempDir() + "/e.sock"
+	socketPath := shortTestSocketPath(t)
 	ln, err := net.Listen("unix", socketPath)
 	assert.NoError(t, err)
 	defer ln.Close()
@@ -2742,5 +2750,374 @@ func TestLiveGate_TimeoutReturnsTrue(t *testing.T) {
 		assert.True(t, r, "timeout should return true (proceed without guarantee)")
 	case <-time.After(200 * time.Millisecond):
 		t.Fatal("waitForLiveGate did not return after timeout")
+	}
+}
+
+// TestSocketWriter_Drain verifies that lines buffered in lineCh while
+// the gate was closed are drained (discarded) by the socket-writer and
+// NOT forwarded to the socket. Only lines produced after the drain
+// should appear on the CEP side.
+func TestSocketWriter_Drain(t *testing.T) {
+	socketPath := shortTestSocketPath(t)
+	listener, err := net.Listen("unix", socketPath)
+	assert.NoError(t, err)
+	defer listener.Close()
+
+	dn := &Daemon{}
+	dn.resetLiveGate()
+
+	lineCh := make(chan string, 256)
+
+	staleLines := []string{
+		"ptp4l[0.001]: [ptp4l.0.config] master offset 999 s2 freq -5000 path delay 200",
+		"ptp4l[0.002]: [ptp4l.0.config] master offset 998 s2 freq -4999 path delay 201",
+		"ptp4l[0.003]: [ptp4l.0.config] master offset 997 s2 freq -4998 path delay 202",
+	}
+	liveLines := []string{
+		"ptp4l[10.000]: [ptp4l.0.config] master offset 3 s2 freq -998 path delay 99",
+		"ptp4l[11.000]: [ptp4l.0.config] master offset 2 s2 freq -997 path delay 100",
+	}
+
+	// Buffer stale lines BEFORE the gate opens.
+	for _, line := range staleLines {
+		lineCh <- line
+	}
+
+	// CEP side: accept one connection, read all messages.
+	cepMsgs := make(chan []string, 1)
+	go func() {
+		fd, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			cepMsgs <- nil
+			return
+		}
+		defer fd.Close()
+		var msgs []string
+		s := bufio.NewScanner(fd)
+		for s.Scan() {
+			msgs = append(msgs, s.Text())
+		}
+		cepMsgs <- msgs
+	}()
+
+	// Socket-writer goroutine: mirrors the real daemon code path.
+	writerDone := make(chan struct{})
+	go func() {
+		defer close(writerDone)
+		c, dialErr := net.DialTimeout("unix", socketPath, 5*time.Second)
+		if dialErr != nil {
+			t.Errorf("socket-writer dial: %v", dialErr)
+			return
+		}
+		defer c.Close()
+
+		dn.waitForLiveGate()
+		fmt.Fprintf(c, "%s\n", liveStartCommand)
+
+		// Drain stale lines (same logic as daemon.go drainLoop)
+		drained := 0
+	drainLoop:
+		for {
+			select {
+			case _, ok := <-lineCh:
+				if !ok {
+					return
+				}
+				drained++
+			default:
+				break drainLoop
+			}
+		}
+		t.Logf("drained %d stale lines", drained)
+
+		// Forward live lines
+		for line := range lineCh {
+			fmt.Fprintf(c, "%s\n", line)
+		}
+	}()
+
+	// Open the gate (stale lines are already buffered).
+	dn.openLiveGate()
+
+	// Feed live lines after a short delay to ensure drain has completed.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		for _, line := range liveLines {
+			lineCh <- line
+		}
+		close(lineCh)
+	}()
+
+	select {
+	case <-writerDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout: socket-writer did not finish")
+	}
+
+	select {
+	case msgs := <-cepMsgs:
+		if !assert.NotNil(t, msgs, "CEP should have received messages") {
+			return
+		}
+		t.Logf("CEP received %d messages: %v", len(msgs), msgs)
+
+		// LIVE_START should be first
+		assert.Equal(t, liveStartCommand, msgs[0], "first message should be CMD LIVE_START")
+
+		// Stale lines must NOT appear
+		for _, stale := range staleLines {
+			for _, m := range msgs {
+				assert.NotEqual(t, stale, m, "stale line should have been drained, not forwarded")
+			}
+		}
+
+		// Live lines must appear
+		for _, live := range liveLines {
+			found := false
+			for _, m := range msgs {
+				if m == live {
+					found = true
+					break
+				}
+			}
+			assert.True(t, found, "live line missing from CEP: %s", live)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout: CEP did not finish reading")
+	}
+}
+
+// TestSocketWriter_Reconnect verifies that when a socket write fails
+// mid-stream, the socket-writer reconnects and delivers subsequent
+// lines on the new connection.
+func TestSocketWriter_Reconnect(t *testing.T) {
+	socketPath := shortTestSocketPath(t)
+	listener, err := net.Listen("unix", socketPath)
+	assert.NoError(t, err)
+	defer listener.Close()
+
+	dn := &Daemon{}
+	dn.resetLiveGate()
+	dn.openLiveGate() // gate is already open for this test
+
+	lineCh := make(chan string, 256)
+	doneCh := make(chan struct{}, 1)
+
+	lines := []string{
+		"ptp4l[1.000]: [ptp4l.0.config] master offset 5 s2 freq -1000 path delay 100",
+		"ptp4l[2.000]: [ptp4l.0.config] master offset 3 s2 freq -998 path delay 99",
+		"ptp4l[3.000]: [ptp4l.0.config] master offset 1 s2 freq -996 path delay 98",
+	}
+
+	// Track messages across all connections
+	type connMsgs struct {
+		idx  int
+		msgs []string
+	}
+	allResults := make(chan connMsgs, 10)
+	var connCount int32
+
+	// CEP accept loop: first connection will be closed after accepting
+	// to simulate a write failure; second connection reads normally.
+	go func() {
+		for {
+			fd, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				return
+			}
+			ci := int(atomic.AddInt32(&connCount, 1))
+			if ci == 1 {
+				// First connection: close immediately to trigger write failure
+				time.Sleep(10 * time.Millisecond)
+				fd.Close()
+				allResults <- connMsgs{idx: ci, msgs: nil}
+				continue
+			}
+			go func(c net.Conn, idx int) {
+				defer c.Close()
+				var msgs []string
+				s := bufio.NewScanner(c)
+				for s.Scan() {
+					msgs = append(msgs, s.Text())
+				}
+				allResults <- connMsgs{idx: idx, msgs: msgs}
+			}(fd, ci)
+		}
+	}()
+
+	// Socket-writer with reconnect logic (mirrors daemon.go)
+	go func() {
+	connect:
+		select {
+		case <-doneCh:
+			return
+		default:
+		}
+		c, dialErr := net.DialTimeout("unix", socketPath, 5*time.Second)
+		if dialErr != nil {
+			time.Sleep(10 * time.Millisecond)
+			goto connect
+		}
+		dn.waitForLiveGate()
+		if _, err2 := fmt.Fprintf(c, "%s\n", liveStartCommand); err2 != nil {
+			c.Close()
+			goto connect
+		}
+		for line := range lineCh {
+			_, err2 := fmt.Fprintf(c, "%s\n", line)
+			if err2 != nil {
+				c.Close()
+				goto connect
+			}
+		}
+		c.Close()
+		doneCh <- struct{}{}
+	}()
+
+	// Feed lines with a delay so the first write hits the closed connection
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		for _, line := range lines {
+			lineCh <- line
+			time.Sleep(10 * time.Millisecond)
+		}
+		close(lineCh)
+	}()
+
+	select {
+	case <-doneCh:
+		t.Log("socket-writer completed with reconnect")
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout: socket-writer did not finish")
+	}
+	listener.Close()
+
+	// Collect results. The second connection should have received at least some lines.
+	var secondConn *connMsgs
+	timeout := time.After(2 * time.Second)
+	for secondConn == nil {
+		select {
+		case r := <-allResults:
+			if r.idx == 2 {
+				secondConn = &r
+			}
+		case <-timeout:
+			t.Fatal("timeout: did not receive second connection results")
+		}
+	}
+
+	assert.NotNil(t, secondConn, "second connection should exist after reconnect")
+	assert.Greater(t, len(secondConn.msgs), 0, "second connection should have received messages")
+	t.Logf("second connection received %d messages: %v", len(secondConn.msgs), secondConn.msgs)
+
+	// At least the LIVE_START marker should be present on reconnect
+	hasLiveStart := false
+	for _, m := range secondConn.msgs {
+		if m == liveStartCommand {
+			hasLiveStart = true
+			break
+		}
+	}
+	assert.True(t, hasLiveStart, "reconnected connection should have LIVE_START")
+}
+
+// TestSocketWriter_SuffixStrip verifies that removeMessageSuffix strips
+// severity tags and template braces from lines before they are forwarded
+// through the socket.
+func TestSocketWriter_SuffixStrip(t *testing.T) {
+	socketPath := shortTestSocketPath(t)
+	listener, err := net.Listen("unix", socketPath)
+	assert.NoError(t, err)
+	defer listener.Close()
+
+	dn := &Daemon{}
+	dn.resetLiveGate()
+	dn.openLiveGate()
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    "ptp4l[2464681.628]: [phc2sys.1.config:7] master offset -4 s2 freq -26835 path delay 525",
+			expected: "ptp4l[2464681.628]: [phc2sys.1.config] master offset -4 s2 freq -26835 path delay 525",
+		},
+		{
+			input:    "ptp4l[2464681.628]: [phc2sys.1.config:{level}] master offset -4 s2 freq -26835 path delay 525",
+			expected: "ptp4l[2464681.628]: [phc2sys.1.config] master offset -4 s2 freq -26835 path delay 525",
+		},
+		{
+			input:    "ptp4l[1.000]: [ptp4l.0.config] master offset 5 s2 freq -1000 path delay 100",
+			expected: "ptp4l[1.000]: [ptp4l.0.config] master offset 5 s2 freq -1000 path delay 100",
+		},
+	}
+
+	lineCh := make(chan string, 256)
+
+	// CEP side
+	cepMsgs := make(chan []string, 1)
+	go func() {
+		fd, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			cepMsgs <- nil
+			return
+		}
+		defer fd.Close()
+		var msgs []string
+		s := bufio.NewScanner(fd)
+		for s.Scan() {
+			msgs = append(msgs, s.Text())
+		}
+		cepMsgs <- msgs
+	}()
+
+	// Socket-writer that applies removeMessageSuffix (mirrors daemon.go line 1758)
+	writerDone := make(chan struct{})
+	go func() {
+		defer close(writerDone)
+		c, dialErr := net.DialTimeout("unix", socketPath, 5*time.Second)
+		if dialErr != nil {
+			t.Errorf("dial failed: %v", dialErr)
+			return
+		}
+		defer c.Close()
+
+		dn.waitForLiveGate()
+		fmt.Fprintf(c, "%s\n", liveStartCommand)
+		for output := range lineCh {
+			line := removeMessageSuffix(output) + "\n"
+			c.Write([]byte(line))
+		}
+	}()
+
+	// Feed test inputs
+	for _, tc := range tests {
+		lineCh <- tc.input
+	}
+	close(lineCh)
+
+	select {
+	case <-writerDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout: socket-writer did not finish")
+	}
+
+	select {
+	case msgs := <-cepMsgs:
+		if !assert.NotNil(t, msgs, "CEP should have received messages") {
+			return
+		}
+		// First message is LIVE_START
+		assert.Equal(t, liveStartCommand, msgs[0])
+		// Remaining messages should be the suffix-stripped versions
+		for i, tc := range tests {
+			msgIdx := i + 1 // skip LIVE_START
+			if assert.Greater(t, len(msgs), msgIdx, "should have enough messages") {
+				assert.Equal(t, tc.expected, msgs[msgIdx],
+					"line %d: removeMessageSuffix should strip suffix before forwarding", i)
+			}
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout: CEP did not finish reading")
 	}
 }

--- a/pkg/daemon/daemon_internal_test.go
+++ b/pkg/daemon/daemon_internal_test.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1797,27 +1798,27 @@ func TestPtp4lConf_PopulatePtp4lConf_ClockTypeWithCliArgs(t *testing.T) {
 
 func TestLiveGate_NilGateReturnsImmediately(t *testing.T) {
 	dn := &Daemon{} // liveGate is nil by default
-	exitCh := make(chan bool)
-	assert.True(t, dn.waitForLiveGate(exitCh), "nil gate should return true immediately")
+	assert.Nil(t, dn.liveGate, "nil gate means disabled")
+	dn.waitForLiveGate()
 }
 
 func TestLiveGate_OpenBeforeWait(t *testing.T) {
 	dn := &Daemon{}
 	dn.resetLiveGate()
+	assert.NotNil(t, dn.liveGate, "gate should exist after reset")
 	dn.openLiveGate()
 
-	exitCh := make(chan bool)
-	assert.True(t, dn.waitForLiveGate(exitCh), "already-open gate should return true immediately")
+	dn.waitForLiveGate()
 }
 
 func TestLiveGate_WaitThenOpen(t *testing.T) {
 	dn := &Daemon{}
 	dn.resetLiveGate()
 
-	exitCh := make(chan bool)
 	result := make(chan bool, 1)
 	go func() {
-		result <- dn.waitForLiveGate(exitCh)
+		dn.waitForLiveGate()
+		result <- true
 	}()
 
 	// Gate is closed — result should not be ready yet
@@ -1837,34 +1838,27 @@ func TestLiveGate_WaitThenOpen(t *testing.T) {
 	}
 }
 
-func TestLiveGate_ExitChUnblocks(t *testing.T) {
+func TestLiveGate_ClosedGateBlocksUntilTimeout(t *testing.T) {
+	origTimeout := liveGateTimeout
+	liveGateTimeout = 80 * time.Millisecond
+	defer func() { liveGateTimeout = origTimeout }()
+
 	dn := &Daemon{}
 	dn.resetLiveGate()
 
-	exitCh := make(chan bool, 1)
-	result := make(chan bool, 1)
-	go func() {
-		result <- dn.waitForLiveGate(exitCh)
-	}()
-
-	exitCh <- true
-
-	select {
-	case r := <-result:
-		assert.False(t, r, "exitCh should cause waitForLiveGate to return false")
-	case <-time.After(2 * time.Second):
-		t.Fatal("waitForLiveGate did not return after exitCh signal")
-	}
+	start := time.Now()
+	dn.waitForLiveGate()
+	assert.GreaterOrEqual(t, time.Since(start).Milliseconds(), int64(70),
+		"should block for approximately the timeout duration")
 }
 
 func TestLiveGate_DoubleOpenIsSafe(t *testing.T) {
 	dn := &Daemon{}
 	dn.resetLiveGate()
 	dn.openLiveGate()
-	dn.openLiveGate() // second call must not panic
+	assert.NotPanics(t, func() { dn.openLiveGate() }, "double open must not panic")
 
-	exitCh := make(chan bool)
-	assert.True(t, dn.waitForLiveGate(exitCh))
+	dn.waitForLiveGate()
 }
 
 func TestLiveGate_ResetReblocks(t *testing.T) {
@@ -1872,15 +1866,15 @@ func TestLiveGate_ResetReblocks(t *testing.T) {
 	dn.resetLiveGate()
 	dn.openLiveGate()
 
-	exitCh := make(chan bool)
-	assert.True(t, dn.waitForLiveGate(exitCh), "gate should be open")
+	dn.waitForLiveGate()
 
 	// Reset creates a new blocked gate
 	dn.resetLiveGate()
 
 	result := make(chan bool, 1)
 	go func() {
-		result <- dn.waitForLiveGate(exitCh)
+		dn.waitForLiveGate()
+		result <- true
 	}()
 
 	select {
@@ -1907,7 +1901,8 @@ func TestLiveGate_MultipleWaitersAllUnblock(t *testing.T) {
 	results := make(chan bool, n)
 	for i := 0; i < n; i++ {
 		go func() {
-			results <- dn.waitForLiveGate(make(chan bool))
+			dn.waitForLiveGate()
+			results <- true
 		}()
 	}
 
@@ -2008,7 +2003,6 @@ func TestLiveGateIntegration_FullDaemonCEPFlow(t *testing.T) {
 	// Daemon side: simulated ptp4l stdout → scanner goroutine → lineCh
 	ptp4lR, ptp4lW := io.Pipe()
 	lineCh := make(chan string, 256)
-	exitCh := make(chan bool)
 	scannerDone := make(chan struct{})
 	writerDone := make(chan struct{})
 
@@ -2043,9 +2037,7 @@ func TestLiveGateIntegration_FullDaemonCEPFlow(t *testing.T) {
 		}
 		defer c.Close()
 
-		if !dn.waitForLiveGate(exitCh) {
-			return
-		}
+		dn.waitForLiveGate()
 		if _, wErr := fmt.Fprintf(c, "%s\n", liveStartCommand); wErr != nil {
 			t.Errorf("LIVE_START write error: %v", wErr)
 			return
@@ -2257,9 +2249,7 @@ func TestLiveGateIntegration_ReplayThenLive(t *testing.T) {
 			return
 		}
 		defer c.Close()
-		if !dn.waitForLiveGate(make(chan bool)) {
-			return
-		}
+		dn.waitForLiveGate()
 		fmt.Fprintf(c, "%s\n", liveStartCommand)
 		for _, line := range liveLines {
 			fmt.Fprintf(c, "%s\n", line)
@@ -2342,24 +2332,22 @@ func TestLiveGateIntegration_OrderingPreventsCorruption(t *testing.T) {
 	dn := &Daemon{}
 	dn.resetLiveGate()
 
-	// Stale replay: port role that would poison metrics if it arrived after live data
 	replayLines := []string{
 		"ptp4l[0.000]: [ptp4l.0.config] port 1 (ens1f0): SLAVE to FAULTY on FAULT_DETECTED (FT_UNSPECIFIED)",
 	}
-	// Live data: offset showing LOCKED state
 	liveLines := []string{
 		"ptp4l[10.000]: [ptp4l.0.config] master offset 3 s2 freq -998 path delay 99",
 		"ptp4l[11.000]: [ptp4l.0.config] master offset 2 s2 freq -997 path delay 100",
 	}
 
-	// Collect messages in order from ALL accepted connections.
 	type taggedMsg struct {
 		connIdx int
 		msg     string
 	}
 	allMsgs := make(chan taggedMsg, 100)
+	replayReadDone := make(chan struct{})
+	var accepted int32
 	var cepWg sync.WaitGroup
-	connIdx := 0
 
 	go func() {
 		for {
@@ -2367,28 +2355,47 @@ func TestLiveGateIntegration_OrderingPreventsCorruption(t *testing.T) {
 			if acceptErr != nil {
 				return
 			}
-			idx := connIdx
-			connIdx++
+			ci := int(atomic.AddInt32(&accepted, 1) - 1)
 			cepWg.Add(1)
-			go func(c net.Conn, ci int) {
+			go func(c net.Conn, idx int) {
 				defer cepWg.Done()
 				defer c.Close()
 				s := bufio.NewScanner(c)
 				for s.Scan() {
-					allMsgs <- taggedMsg{connIdx: ci, msg: s.Text()}
+					allMsgs <- taggedMsg{connIdx: idx, msg: s.Text()}
 				}
-			}(fd, idx)
+				if idx == 1 {
+					close(replayReadDone)
+				}
+			}(fd, ci)
 		}
 	}()
 
-	// Simulate the /emit-logs handler behavior:
-	// 1. Write replay data through a separate connection (conn B)
-	// 2. Open the live gate
+	// Daemon socket-writer (conn-0): connects first, blocks on gate
+	writerDone := make(chan struct{})
+	go func() {
+		defer close(writerDone)
+		c, dialErr := net.DialTimeout("unix", socketPath, 5*time.Second)
+		if dialErr != nil {
+			t.Errorf("socket-writer dial: %v", dialErr)
+			return
+		}
+		defer c.Close()
+		dn.waitForLiveGate()
+		fmt.Fprintf(c, "%s\n", liveStartCommand)
+		for _, line := range liveLines {
+			fmt.Fprintf(c, "%s\n", line)
+		}
+	}()
+
+	// /emit-logs handler (conn-1): writes replay data, waits for receipt, opens gate
 	emitDone := make(chan struct{})
 	go func() {
 		defer close(emitDone)
-		// Small delay to ensure socket-writer has connected and is blocked on gate
-		time.Sleep(20 * time.Millisecond)
+		// Wait until live writer's connection is accepted (conn-0)
+		for atomic.LoadInt32(&accepted) < 1 {
+			time.Sleep(time.Millisecond)
+		}
 
 		replayConn, dialErr := net.DialTimeout("unix", socketPath, 2*time.Second)
 		if dialErr != nil {
@@ -2401,27 +2408,10 @@ func TestLiveGateIntegration_OrderingPreventsCorruption(t *testing.T) {
 		}
 		replayConn.Close()
 
-		// Gate opens AFTER replay is fully written — this is the fix
+		// Wait for the replay reader goroutine to fully consume the data.
+		// In production, kernel socket buffering makes this near-instantaneous.
+		<-replayReadDone
 		dn.openLiveGate()
-	}()
-
-	// Daemon socket-writer (conn A): blocks on gate, then sends LIVE_START + live data
-	writerDone := make(chan struct{})
-	go func() {
-		defer close(writerDone)
-		c, dialErr := net.DialTimeout("unix", socketPath, 5*time.Second)
-		if dialErr != nil {
-			t.Errorf("socket-writer dial: %v", dialErr)
-			return
-		}
-		defer c.Close()
-		if !dn.waitForLiveGate(make(chan bool)) {
-			return
-		}
-		fmt.Fprintf(c, "%s\n", liveStartCommand)
-		for _, line := range liveLines {
-			fmt.Fprintf(c, "%s\n", line)
-		}
 	}()
 
 	select {
@@ -2431,17 +2421,18 @@ func TestLiveGateIntegration_OrderingPreventsCorruption(t *testing.T) {
 	}
 	<-emitDone
 
+	for atomic.LoadInt32(&accepted) < 2 {
+		time.Sleep(time.Millisecond)
+	}
 	listener.Close()
 	cepWg.Wait()
 	close(allMsgs)
 
-	// Collect all messages in receipt order
 	var ordered []taggedMsg
 	for m := range allMsgs {
 		ordered = append(ordered, m)
 	}
 
-	// Find positions of key messages
 	replayIdx := -1
 	liveStartIdx := -1
 	firstLiveDataIdx := -1
@@ -2463,7 +2454,6 @@ func TestLiveGateIntegration_OrderingPreventsCorruption(t *testing.T) {
 		t.Logf("  [%d] conn-%d: %s", i, m.connIdx, m.msg)
 	}
 
-	// The gate guarantees: replay completes BEFORE LIVE_START BEFORE live data
 	assert.Greater(t, replayIdx, -1, "replay line should be present")
 	assert.Greater(t, liveStartIdx, -1, "LIVE_START should be present")
 	assert.Greater(t, firstLiveDataIdx, -1, "live data should be present")
@@ -2733,10 +2723,10 @@ func TestLiveGate_TimeoutReturnsTrue(t *testing.T) {
 	dn.resetLiveGate()
 	// Gate is never opened — should timeout and return true.
 
-	exitCh := make(chan bool)
 	result := make(chan bool, 1)
 	go func() {
-		result <- dn.waitForLiveGate(exitCh)
+		dn.waitForLiveGate()
+		result <- true
 	}()
 
 	// Should NOT return within 50ms (gate is still closed, timeout hasn't fired)

--- a/pkg/daemon/daemon_internal_test.go
+++ b/pkg/daemon/daemon_internal_test.go
@@ -31,6 +31,8 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+const testPtp4lOffsetLine = "ptp4l[1.000]: [ptp4l.0.config] master offset 5 s2 freq -1000 path delay 100"
+
 // vendor defaults are embedded; no filesystem setup needed
 
 // NewDaemonForTests creates a Daemon instance for testing
@@ -2015,7 +2017,7 @@ func TestLiveGateIntegration_FullDaemonCEPFlow(t *testing.T) {
 	writerDone := make(chan struct{})
 
 	livePtp4lLines := []string{
-		"ptp4l[1.000]: [ptp4l.0.config] master offset 5 s2 freq -1000 path delay 100",
+		testPtp4lOffsetLine,
 		"ptp4l[2.000]: [ptp4l.0.config] master offset 3 s2 freq -998 path delay 99",
 		"ptp4l[3.000]: [ptp4l.0.config] master offset -1 s2 freq -995 path delay 101",
 		"ptp4l[4.000]: [ptp4l.0.config] selected best master clock 001122.fffe.334455",
@@ -2179,7 +2181,7 @@ func TestLiveGateIntegration_ReplayThenLive(t *testing.T) {
 		"phc2sys[0.001]: [ptp4l.0.config] CLOCK_REALTIME phc offset 0 s2 freq -100 delay 500",
 	}
 	liveLines := []string{
-		"ptp4l[1.000]: [ptp4l.0.config] master offset 5 s2 freq -1000 path delay 100",
+		testPtp4lOffsetLine,
 		"ptp4l[2.000]: [ptp4l.0.config] selected best master clock 001122.fffe.334455",
 	}
 
@@ -2904,7 +2906,7 @@ func TestSocketWriter_Reconnect(t *testing.T) {
 	doneCh := make(chan struct{}, 1)
 
 	lines := []string{
-		"ptp4l[1.000]: [ptp4l.0.config] master offset 5 s2 freq -1000 path delay 100",
+		testPtp4lOffsetLine,
 		"ptp4l[2.000]: [ptp4l.0.config] master offset 3 s2 freq -998 path delay 99",
 		"ptp4l[3.000]: [ptp4l.0.config] master offset 1 s2 freq -996 path delay 98",
 	}
@@ -3047,8 +3049,8 @@ func TestSocketWriter_SuffixStrip(t *testing.T) {
 			expected: "ptp4l[2464681.628]: [phc2sys.1.config] master offset -4 s2 freq -26835 path delay 525",
 		},
 		{
-			input:    "ptp4l[1.000]: [ptp4l.0.config] master offset 5 s2 freq -1000 path delay 100",
-			expected: "ptp4l[1.000]: [ptp4l.0.config] master offset 5 s2 freq -1000 path delay 100",
+			input:    testPtp4lOffsetLine,
+			expected: testPtp4lOffsetLine,
 		},
 	}
 

--- a/pkg/daemon/daemon_internal_test.go
+++ b/pkg/daemon/daemon_internal_test.go
@@ -5,9 +5,15 @@ package daemon
 import (
 	"bufio"
 	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1787,6 +1793,817 @@ func TestPtp4lConf_PopulatePtp4lConf_ClockTypeWithCliArgs(t *testing.T) {
 	}
 }
 
+// --- liveGate unit tests ---
+
+func TestLiveGate_NilGateReturnsImmediately(t *testing.T) {
+	dn := &Daemon{} // liveGate is nil by default
+	exitCh := make(chan bool)
+	assert.True(t, dn.waitForLiveGate(exitCh), "nil gate should return true immediately")
+}
+
+func TestLiveGate_OpenBeforeWait(t *testing.T) {
+	dn := &Daemon{}
+	dn.resetLiveGate()
+	dn.openLiveGate()
+
+	exitCh := make(chan bool)
+	assert.True(t, dn.waitForLiveGate(exitCh), "already-open gate should return true immediately")
+}
+
+func TestLiveGate_WaitThenOpen(t *testing.T) {
+	dn := &Daemon{}
+	dn.resetLiveGate()
+
+	exitCh := make(chan bool)
+	result := make(chan bool, 1)
+	go func() {
+		result <- dn.waitForLiveGate(exitCh)
+	}()
+
+	// Gate is closed — result should not be ready yet
+	select {
+	case <-result:
+		t.Fatal("waitForLiveGate returned before gate was opened")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	dn.openLiveGate()
+
+	select {
+	case r := <-result:
+		assert.True(t, r, "gate opened, should return true")
+	case <-time.After(2 * time.Second):
+		t.Fatal("waitForLiveGate did not return after openLiveGate")
+	}
+}
+
+func TestLiveGate_ExitChUnblocks(t *testing.T) {
+	dn := &Daemon{}
+	dn.resetLiveGate()
+
+	exitCh := make(chan bool, 1)
+	result := make(chan bool, 1)
+	go func() {
+		result <- dn.waitForLiveGate(exitCh)
+	}()
+
+	exitCh <- true
+
+	select {
+	case r := <-result:
+		assert.False(t, r, "exitCh should cause waitForLiveGate to return false")
+	case <-time.After(2 * time.Second):
+		t.Fatal("waitForLiveGate did not return after exitCh signal")
+	}
+}
+
+func TestLiveGate_DoubleOpenIsSafe(t *testing.T) {
+	dn := &Daemon{}
+	dn.resetLiveGate()
+	dn.openLiveGate()
+	dn.openLiveGate() // second call must not panic
+
+	exitCh := make(chan bool)
+	assert.True(t, dn.waitForLiveGate(exitCh))
+}
+
+func TestLiveGate_ResetReblocks(t *testing.T) {
+	dn := &Daemon{}
+	dn.resetLiveGate()
+	dn.openLiveGate()
+
+	exitCh := make(chan bool)
+	assert.True(t, dn.waitForLiveGate(exitCh), "gate should be open")
+
+	// Reset creates a new blocked gate
+	dn.resetLiveGate()
+
+	result := make(chan bool, 1)
+	go func() {
+		result <- dn.waitForLiveGate(exitCh)
+	}()
+
+	select {
+	case <-result:
+		t.Fatal("waitForLiveGate returned before re-opened gate")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	dn.openLiveGate()
+
+	select {
+	case r := <-result:
+		assert.True(t, r)
+	case <-time.After(2 * time.Second):
+		t.Fatal("waitForLiveGate did not return after second openLiveGate")
+	}
+}
+
+func TestLiveGate_MultipleWaitersAllUnblock(t *testing.T) {
+	dn := &Daemon{}
+	dn.resetLiveGate()
+
+	const n = 5
+	results := make(chan bool, n)
+	for i := 0; i < n; i++ {
+		go func() {
+			results <- dn.waitForLiveGate(make(chan bool))
+		}()
+	}
+
+	// None should have returned yet
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, 0, len(results), "no waiter should return before gate opens")
+
+	dn.openLiveGate()
+
+	for i := 0; i < n; i++ {
+		select {
+		case r := <-results:
+			assert.True(t, r)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("waiter %d did not return after openLiveGate", i)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests: full daemon ↔ CEP communication over the event socket
+// ---------------------------------------------------------------------------
+//
+// These tests simulate both sides of the live-gate protocol to verify the
+// complete flow works without deadlock:
+//
+//  Daemon side:
+//    - Scanner goroutine: drains "ptp4l stdout" (io.Pipe) immediately
+//    - Socket-writer goroutine: connects to CEP socket, waits for liveGate,
+//      sends CMD LIVE_START, then forwards lines from lineCh
+//    - /emit-logs HTTP handler: opens the liveGate (and optionally writes
+//      replay data through a separate EventHandler connection)
+//
+//  CEP side (simulated from cloud-event-proxy processMessages logic):
+//    - Unix socket listener accepts connections
+//    - For each connection: calls TriggerLogs (HTTP GET to /emit-logs),
+//      then scans messages from the socket
+
+func shortTestSocketPath(t *testing.T) string {
+	t.Helper()
+	return t.TempDir() + "/e.sock"
+}
+
+// TestLiveGateIntegration_FullDaemonCEPFlow simulates the complete ptp4l →
+// linuxptp-daemon → CEP flow: scanner goroutine drains stdout, socket-writer
+// waits for the live gate, CEP triggers /emit-logs (which opens the gate),
+// then CEP receives CMD LIVE_START followed by all live ptp4l lines.
+func TestLiveGateIntegration_FullDaemonCEPFlow(t *testing.T) {
+	socketPath := shortTestSocketPath(t)
+	listener, err := net.Listen("unix", socketPath)
+	assert.NoError(t, err)
+	defer listener.Close()
+
+	dn := &Daemon{}
+	dn.resetLiveGate()
+
+	// Daemon HTTP server (/emit-logs opens the gate)
+	httpLn, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.NoError(t, err)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/emit-logs", func(w http.ResponseWriter, _ *http.Request) {
+		dn.openLiveGate()
+		w.WriteHeader(http.StatusOK)
+	})
+	httpSrv := &http.Server{Handler: mux}
+	go func() { _ = httpSrv.Serve(httpLn) }()
+	defer httpSrv.Close()
+	triggerURL := "http://" + httpLn.Addr().String() + "/emit-logs"
+
+	// CEP side: accept ONE connection, call TriggerLogs, read messages.
+	cepMsgs := make(chan []string, 1)
+	go func() {
+		fd, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			cepMsgs <- nil
+			return
+		}
+		defer fd.Close()
+
+		// Simulate processMessages: TriggerLogs then scan.
+		client := &http.Client{Timeout: 5 * time.Second}
+		resp, trigErr := client.Get(triggerURL)
+		if trigErr != nil {
+			t.Logf("CEP TriggerLogs failed: %v", trigErr)
+			cepMsgs <- nil
+			return
+		}
+		_ = resp.Body.Close()
+
+		var msgs []string
+		scanner := bufio.NewScanner(fd)
+		for scanner.Scan() {
+			msgs = append(msgs, scanner.Text())
+		}
+		cepMsgs <- msgs
+	}()
+
+	// Daemon side: simulated ptp4l stdout → scanner goroutine → lineCh
+	ptp4lR, ptp4lW := io.Pipe()
+	lineCh := make(chan string, 256)
+	exitCh := make(chan bool)
+	scannerDone := make(chan struct{})
+	writerDone := make(chan struct{})
+
+	livePtp4lLines := []string{
+		"ptp4l[1.000]: [ptp4l.0.config] master offset 5 s2 freq -1000 path delay 100",
+		"ptp4l[2.000]: [ptp4l.0.config] master offset 3 s2 freq -998 path delay 99",
+		"ptp4l[3.000]: [ptp4l.0.config] master offset -1 s2 freq -995 path delay 101",
+		"ptp4l[4.000]: [ptp4l.0.config] selected best master clock 001122.fffe.334455",
+		"ptp4l[5.000]: [ptp4l.0.config] master offset 2 s2 freq -997 path delay 100",
+	}
+
+	// Scanner goroutine (daemon)
+	go func() {
+		defer close(scannerDone)
+		s := bufio.NewScanner(ptp4lR)
+		for s.Scan() {
+			select {
+			case lineCh <- s.Text():
+			default:
+			}
+		}
+		close(lineCh)
+	}()
+
+	// Socket-writer goroutine (daemon)
+	go func() {
+		defer close(writerDone)
+		c, dialErr := net.DialTimeout("unix", socketPath, 5*time.Second)
+		if dialErr != nil {
+			t.Errorf("socket-writer dial failed: %v", dialErr)
+			return
+		}
+		defer c.Close()
+
+		if !dn.waitForLiveGate(exitCh) {
+			return
+		}
+		if _, wErr := fmt.Fprintf(c, "%s\n", liveStartCommand); wErr != nil {
+			t.Errorf("LIVE_START write error: %v", wErr)
+			return
+		}
+		for line := range lineCh {
+			if _, wErr := fmt.Fprintf(c, "%s\n", line); wErr != nil {
+				t.Errorf("live data write error: %v", wErr)
+				return
+			}
+		}
+	}()
+
+	// Feed simulated ptp4l output
+	go func() {
+		for _, line := range livePtp4lLines {
+			fmt.Fprintln(ptp4lW, line)
+			time.Sleep(5 * time.Millisecond)
+		}
+		ptp4lW.Close()
+	}()
+
+	// Wait for daemon goroutines
+	select {
+	case <-scannerDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout: scanner goroutine did not finish")
+	}
+	select {
+	case <-writerDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout: socket-writer goroutine did not finish — possible deadlock")
+	}
+
+	// Verify CEP received everything
+	select {
+	case msgs := <-cepMsgs:
+		if !assert.NotNil(t, msgs, "CEP should have received messages") {
+			return
+		}
+		t.Logf("CEP received %d messages", len(msgs))
+		assert.GreaterOrEqual(t, len(msgs), 1+len(livePtp4lLines),
+			"should receive LIVE_START + all ptp4l lines")
+		assert.Equal(t, liveStartCommand, msgs[0], "first message should be CMD LIVE_START")
+
+		foundBMC := false
+		for _, m := range msgs {
+			if strings.Contains(m, "selected best master clock") {
+				foundBMC = true
+			}
+		}
+		assert.True(t, foundBMC, "live data must contain 'selected best master clock'")
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout: CEP did not finish reading messages")
+	}
+}
+
+// TestLiveGateIntegration_ScannerDrainsWhileGateBlocked verifies that the
+// scanner goroutine keeps draining ptp4l stdout even while the socket-writer
+// is blocked waiting for the live gate. This was the original bug: a single
+// goroutine both waited for the gate AND read stdout, causing ptp4l to freeze.
+func TestLiveGateIntegration_ScannerDrainsWhileGateBlocked(t *testing.T) {
+	dn := &Daemon{}
+	dn.resetLiveGate() // gate is CLOSED
+
+	ptp4lR, ptp4lW := io.Pipe()
+	lineCh := make(chan string, 256)
+	scannerDone := make(chan struct{})
+
+	// Scanner goroutine: must drain immediately regardless of gate state.
+	go func() {
+		defer close(scannerDone)
+		s := bufio.NewScanner(ptp4lR)
+		for s.Scan() {
+			select {
+			case lineCh <- s.Text():
+			default:
+			}
+		}
+		close(lineCh)
+	}()
+
+	// Write lines while gate is CLOSED. If scanner were gated, ptp4lW.Write
+	// would block (pipe full) and this goroutine would hang.
+	writeCount := 100
+	writeDone := make(chan struct{})
+	go func() {
+		defer close(writeDone)
+		for i := 0; i < writeCount; i++ {
+			fmt.Fprintf(ptp4lW, "ptp4l[%d.000]: [ptp4l.0.config] master offset %d s2 freq 0 path delay 100\n", i, i)
+		}
+		ptp4lW.Close()
+	}()
+
+	// Writer must complete quickly even though gate is closed
+	select {
+	case <-writeDone:
+		t.Log("all lines written while gate was closed — no stdout blocking")
+	case <-time.After(5 * time.Second):
+		t.Fatal("DEADLOCK: ptp4l stdout write blocked because scanner is gated")
+	}
+
+	// Scanner should finish and lineCh should have all lines
+	select {
+	case <-scannerDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout: scanner goroutine did not finish")
+	}
+
+	received := 0
+	for range lineCh {
+		received++
+	}
+	assert.Equal(t, writeCount, received, "scanner should have drained all lines into lineCh")
+}
+
+// TestLiveGateIntegration_ReplayThenLive simulates the full two-connection
+// scenario: the EventHandler writes replay data through its own connection
+// (conn B) while the daemon's socket-writer sends live data through conn A.
+// CEP accepts both connections and processes them independently.
+func TestLiveGateIntegration_ReplayThenLive(t *testing.T) {
+	socketPath := shortTestSocketPath(t)
+	listener, err := net.Listen("unix", socketPath)
+	assert.NoError(t, err)
+	defer listener.Close()
+
+	dn := &Daemon{}
+	dn.resetLiveGate()
+
+	replayLines := []string{
+		"ptp4l[0.000]: [ptp4l.0.config] port 1 (ens1f0): UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED",
+		"phc2sys[0.001]: [ptp4l.0.config] CLOCK_REALTIME phc offset 0 s2 freq -100 delay 500",
+	}
+	liveLines := []string{
+		"ptp4l[1.000]: [ptp4l.0.config] master offset 5 s2 freq -1000 path delay 100",
+		"ptp4l[2.000]: [ptp4l.0.config] selected best master clock 001122.fffe.334455",
+	}
+
+	// Daemon HTTP server. The handler:
+	// 1. Writes replay data through a NEW socket connection (EventHandler path)
+	// 2. Opens the live gate
+	httpLn, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.NoError(t, err)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/emit-logs", func(w http.ResponseWriter, _ *http.Request) {
+		// Write replay data through a separate connection (simulates EventHandler)
+		replayConn, dialErr := net.DialTimeout("unix", socketPath, 2*time.Second)
+		if dialErr != nil {
+			t.Logf("replay dial failed (non-fatal): %v", dialErr)
+		} else {
+			for _, line := range replayLines {
+				fmt.Fprintf(replayConn, "%s\n", line)
+			}
+			replayConn.Close()
+		}
+		dn.openLiveGate()
+		w.WriteHeader(http.StatusOK)
+	})
+	httpSrv := &http.Server{Handler: mux}
+	go func() { _ = httpSrv.Serve(httpLn) }()
+	defer httpSrv.Close()
+	triggerURL := "http://" + httpLn.Addr().String() + "/emit-logs"
+
+	// CEP side: accept ALL connections, each runs processMessages.
+	type connResult struct {
+		label string
+		msgs  []string
+	}
+	results := make(chan connResult, 5)
+	var cepWg sync.WaitGroup
+	go func() {
+		idx := 0
+		for {
+			fd, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				return
+			}
+			label := fmt.Sprintf("conn-%d", idx)
+			idx++
+			cepWg.Add(1)
+			go func(c net.Conn, lbl string) {
+				defer cepWg.Done()
+				defer c.Close()
+
+				client := &http.Client{Timeout: 5 * time.Second}
+				resp, trigErr := client.Get(triggerURL)
+				if trigErr != nil {
+					t.Logf("CEP %s TriggerLogs failed: %v (non-fatal)", lbl, trigErr)
+					return
+				}
+				resp.Body.Close()
+
+				var msgs []string
+				s := bufio.NewScanner(c)
+				for s.Scan() {
+					msgs = append(msgs, s.Text())
+				}
+				results <- connResult{label: lbl, msgs: msgs}
+			}(fd, label)
+		}
+	}()
+
+	// Daemon socket-writer: connects, waits for gate, sends LIVE_START + data
+	writerDone := make(chan struct{})
+	go func() {
+		defer close(writerDone)
+		c, dialErr := net.DialTimeout("unix", socketPath, 5*time.Second)
+		if dialErr != nil {
+			t.Errorf("socket-writer dial: %v", dialErr)
+			return
+		}
+		defer c.Close()
+		if !dn.waitForLiveGate(make(chan bool)) {
+			return
+		}
+		fmt.Fprintf(c, "%s\n", liveStartCommand)
+		for _, line := range liveLines {
+			fmt.Fprintf(c, "%s\n", line)
+		}
+	}()
+
+	select {
+	case <-writerDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout: socket-writer blocked — possible deadlock")
+	}
+
+	// Shut down listener and wait for CEP goroutines to drain.
+	listener.Close()
+	cepWg.Wait()
+	close(results)
+
+	var liveResult, replayResult *connResult
+	for r := range results {
+		r := r
+		hasLiveStart := false
+		for _, m := range r.msgs {
+			if m == liveStartCommand {
+				hasLiveStart = true
+				break
+			}
+		}
+		if hasLiveStart {
+			liveResult = &r
+		} else if len(r.msgs) > 0 {
+			replayResult = &r
+		}
+	}
+
+	if assert.NotNil(t, liveResult, "should have connection with LIVE_START") {
+		t.Logf("live %s: %d msgs", liveResult.label, len(liveResult.msgs))
+		assert.Equal(t, liveStartCommand, liveResult.msgs[0])
+		for _, expected := range liveLines {
+			found := false
+			for _, m := range liveResult.msgs {
+				if m == expected {
+					found = true
+					break
+				}
+			}
+			assert.True(t, found, "live connection missing: %s", expected)
+		}
+	}
+
+	if replayResult != nil {
+		t.Logf("replay %s: %d msgs", replayResult.label, len(replayResult.msgs))
+		for _, expected := range replayLines {
+			found := false
+			for _, m := range replayResult.msgs {
+				if m == expected {
+					found = true
+					break
+				}
+			}
+			assert.True(t, found, "replay connection missing: %s", expected)
+		}
+	}
+}
+
+// TestLiveGateIntegration_OrderingPreventsCorruption verifies the core
+// OCPBUGS-85092 fix: the live gate ensures stale replay data (SLAVE→FAULTY)
+// is fully delivered BEFORE CMD LIVE_START and live data. CEP processes replay
+// first on a separate connection, then receives LIVE_START + live LOCKED offsets
+// on the daemon connection — so the live state is always the final state.
+//
+// Without the gate, the socket-writer would send live data immediately, and
+// the /emit-logs handler would write stale replay AFTER — permanently poisoning
+// the metrics.
+func TestLiveGateIntegration_OrderingPreventsCorruption(t *testing.T) {
+	socketPath := shortTestSocketPath(t)
+	listener, err := net.Listen("unix", socketPath)
+	assert.NoError(t, err)
+	defer listener.Close()
+
+	dn := &Daemon{}
+	dn.resetLiveGate()
+
+	// Stale replay: port role that would poison metrics if it arrived after live data
+	replayLines := []string{
+		"ptp4l[0.000]: [ptp4l.0.config] port 1 (ens1f0): SLAVE to FAULTY on FAULT_DETECTED (FT_UNSPECIFIED)",
+	}
+	// Live data: offset showing LOCKED state
+	liveLines := []string{
+		"ptp4l[10.000]: [ptp4l.0.config] master offset 3 s2 freq -998 path delay 99",
+		"ptp4l[11.000]: [ptp4l.0.config] master offset 2 s2 freq -997 path delay 100",
+	}
+
+	// Collect messages in order from ALL accepted connections.
+	type taggedMsg struct {
+		connIdx int
+		msg     string
+	}
+	allMsgs := make(chan taggedMsg, 100)
+	var cepWg sync.WaitGroup
+	connIdx := 0
+
+	go func() {
+		for {
+			fd, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				return
+			}
+			idx := connIdx
+			connIdx++
+			cepWg.Add(1)
+			go func(c net.Conn, ci int) {
+				defer cepWg.Done()
+				defer c.Close()
+				s := bufio.NewScanner(c)
+				for s.Scan() {
+					allMsgs <- taggedMsg{connIdx: ci, msg: s.Text()}
+				}
+			}(fd, idx)
+		}
+	}()
+
+	// Simulate the /emit-logs handler behavior:
+	// 1. Write replay data through a separate connection (conn B)
+	// 2. Open the live gate
+	emitDone := make(chan struct{})
+	go func() {
+		defer close(emitDone)
+		// Small delay to ensure socket-writer has connected and is blocked on gate
+		time.Sleep(20 * time.Millisecond)
+
+		replayConn, dialErr := net.DialTimeout("unix", socketPath, 2*time.Second)
+		if dialErr != nil {
+			t.Errorf("replay dial failed: %v", dialErr)
+			dn.openLiveGate()
+			return
+		}
+		for _, line := range replayLines {
+			fmt.Fprintf(replayConn, "%s\n", line)
+		}
+		replayConn.Close()
+
+		// Gate opens AFTER replay is fully written — this is the fix
+		dn.openLiveGate()
+	}()
+
+	// Daemon socket-writer (conn A): blocks on gate, then sends LIVE_START + live data
+	writerDone := make(chan struct{})
+	go func() {
+		defer close(writerDone)
+		c, dialErr := net.DialTimeout("unix", socketPath, 5*time.Second)
+		if dialErr != nil {
+			t.Errorf("socket-writer dial: %v", dialErr)
+			return
+		}
+		defer c.Close()
+		if !dn.waitForLiveGate(make(chan bool)) {
+			return
+		}
+		fmt.Fprintf(c, "%s\n", liveStartCommand)
+		for _, line := range liveLines {
+			fmt.Fprintf(c, "%s\n", line)
+		}
+	}()
+
+	select {
+	case <-writerDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout: socket-writer blocked")
+	}
+	<-emitDone
+
+	listener.Close()
+	cepWg.Wait()
+	close(allMsgs)
+
+	// Collect all messages in receipt order
+	var ordered []taggedMsg
+	for m := range allMsgs {
+		ordered = append(ordered, m)
+	}
+
+	// Find positions of key messages
+	replayIdx := -1
+	liveStartIdx := -1
+	firstLiveDataIdx := -1
+	for i, m := range ordered {
+		if strings.Contains(m.msg, "SLAVE to FAULTY") && replayIdx == -1 {
+			replayIdx = i
+		}
+		if m.msg == liveStartCommand && liveStartIdx == -1 {
+			liveStartIdx = i
+		}
+		if strings.Contains(m.msg, "master offset") && firstLiveDataIdx == -1 {
+			firstLiveDataIdx = i
+		}
+	}
+
+	t.Logf("message order: replay@%d, LIVE_START@%d, first_live@%d (total %d msgs)",
+		replayIdx, liveStartIdx, firstLiveDataIdx, len(ordered))
+	for i, m := range ordered {
+		t.Logf("  [%d] conn-%d: %s", i, m.connIdx, m.msg)
+	}
+
+	// The gate guarantees: replay completes BEFORE LIVE_START BEFORE live data
+	assert.Greater(t, replayIdx, -1, "replay line should be present")
+	assert.Greater(t, liveStartIdx, -1, "LIVE_START should be present")
+	assert.Greater(t, firstLiveDataIdx, -1, "live data should be present")
+
+	if replayIdx >= 0 && liveStartIdx >= 0 {
+		assert.Less(t, replayIdx, liveStartIdx,
+			"CRITICAL: stale replay must arrive BEFORE CMD LIVE_START (gate guarantee)")
+	}
+	if liveStartIdx >= 0 && firstLiveDataIdx >= 0 {
+		assert.Less(t, liveStartIdx, firstLiveDataIdx,
+			"live data must arrive AFTER CMD LIVE_START")
+	}
+}
+
+// TestLiveGateIntegration_TriggerLogsFailureRecovery verifies that when
+// TriggerLogs fails (daemon HTTP not ready), CEP closes the connection,
+// and the daemon's socket-writer can recover once the server comes up.
+func TestLiveGateIntegration_TriggerLogsFailureRecovery(t *testing.T) {
+	socketPath := shortTestSocketPath(t)
+	listener, err := net.Listen("unix", socketPath)
+	assert.NoError(t, err)
+	defer listener.Close()
+
+	dn := &Daemon{}
+	dn.resetLiveGate()
+
+	// Reserve an address but DON'T serve yet — TriggerLogs will fail.
+	httpLn, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.NoError(t, err)
+	httpAddr := httpLn.Addr().String()
+	httpLn.Close() // intentionally closed
+
+	triggerURL := "http://" + httpAddr + "/emit-logs"
+	firstFail := make(chan struct{}, 1)
+	success := make(chan []string, 1)
+
+	// CEP accept loop
+	go func() {
+		for {
+			fd, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				client := &http.Client{Timeout: 1 * time.Second}
+				resp, trigErr := client.Get(triggerURL)
+				if trigErr != nil {
+					select {
+					case firstFail <- struct{}{}:
+					default:
+					}
+					return // CEP closes conn on failure (matches real behavior)
+				}
+				resp.Body.Close()
+				var msgs []string
+				s := bufio.NewScanner(c)
+				for s.Scan() {
+					msgs = append(msgs, s.Text())
+				}
+				success <- msgs
+			}(fd)
+		}
+	}()
+
+	// Daemon socket-writer with retry loop (mirrors real code's goto connect).
+	// Uses a short gate timeout so the test doesn't block for 60s.
+	writerDone := make(chan struct{})
+	go func() {
+		defer close(writerDone)
+		for attempt := 0; attempt < 30; attempt++ {
+			c, dialErr := net.DialTimeout("unix", socketPath, 2*time.Second)
+			if dialErr != nil {
+				time.Sleep(100 * time.Millisecond)
+				continue
+			}
+			// Short gate timeout: if CEP closed the connection (TriggerLogs
+			// failed), the gate won't open for this attempt. Rather than
+			// blocking for 60s, use a short select.
+			gateOpen := false
+			func() {
+				dn.liveGateMu.Lock()
+				gate := dn.liveGate
+				dn.liveGateMu.Unlock()
+				if gate == nil {
+					gateOpen = true
+					return
+				}
+				select {
+				case <-gate:
+					gateOpen = true
+				case <-time.After(2 * time.Second):
+				}
+			}()
+			if !gateOpen {
+				c.Close()
+				continue
+			}
+			_, wErr := fmt.Fprintf(c, "%s\nlive data\n", liveStartCommand)
+			c.Close()
+			if wErr == nil {
+				return
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		t.Error("socket-writer exhausted retries")
+	}()
+
+	// Wait for first failure
+	select {
+	case <-firstFail:
+		t.Log("first TriggerLogs failed as expected")
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for first TriggerLogs failure")
+	}
+
+	// Start the HTTP server
+	newLn, err := net.Listen("tcp", httpAddr)
+	if err != nil {
+		t.Skipf("cannot rebind %s: %v", httpAddr, err)
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/emit-logs", func(w http.ResponseWriter, _ *http.Request) {
+		dn.openLiveGate()
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := &http.Server{Handler: mux}
+	go func() { _ = srv.Serve(newLn) }()
+	defer srv.Close()
+
+	select {
+	case <-writerDone:
+		t.Log("socket-writer recovered after HTTP server started")
+	case <-time.After(15 * time.Second):
+		t.Fatal("timeout: socket-writer did not recover")
+	}
+
+	listener.Close()
+}
+
 func TestEmitClockClassLogs_EmitsWithNilParentDS(t *testing.T) {
 	// Create a minimal event handler (no socket needed — the event package
 	// tests already cover the socket write path via EmitClockClass).
@@ -1816,4 +2633,124 @@ func TestEmitClockClassLogs_EmitsWithNilParentDS(t *testing.T) {
 	assert.NotPanics(t, func() {
 		pm.EmitClockClassLogs()
 	}, "EmitClockClassLogs should not panic with nil parentDS")
+}
+
+// --- /emit-logs handler unit tests ---
+
+func TestEmitLogsHandler_NotReady_OpensGateAndReturns204(t *testing.T) {
+	dn := &Daemon{}
+	dn.resetLiveGate()
+
+	tracker := &ReadyTracker{
+		config: false, // not ready
+		processManager: &ProcessManager{
+			daemon: dn,
+		},
+	}
+
+	handler := metricHandler{tracker: tracker}
+	req := httptest.NewRequest("GET", "/emit-logs", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNoContent, rec.Code, "not-ready should return 204")
+
+	// liveGate must be open (channel closed)
+	dn.liveGateMu.Lock()
+	gate := dn.liveGate
+	dn.liveGateMu.Unlock()
+	select {
+	case <-gate:
+		// expected: gate is closed (open)
+	default:
+		t.Fatal("liveGate should be open after not-ready /emit-logs")
+	}
+}
+
+func TestEmitLogsHandler_Ready_EmitsReplayThenOpensGate(t *testing.T) {
+	dn := &Daemon{}
+	dn.resetLiveGate()
+
+	// Provide a real socket so EmitPortRoleLogs can connect without retry delays.
+	socketPath := t.TempDir() + "/e.sock"
+	ln, err := net.Listen("unix", socketPath)
+	assert.NoError(t, err)
+	defer ln.Close()
+	go func() {
+		for {
+			c, acceptErr := ln.Accept()
+			if acceptErr != nil {
+				return
+			}
+			c.Close()
+		}
+	}()
+
+	// A "ready" tracker requires config=true and at least one process
+	// that is not stopped and has collected metrics.
+	tracker := &ReadyTracker{
+		config: true,
+		processManager: &ProcessManager{
+			process: []*ptpProcess{
+				{
+					name:                ptp4lProcessName,
+					hasCollectedMetrics: true,
+					stopped:             false,
+				},
+			},
+			ptpEventHandler: event.Init("test-node", false, socketPath, nil, nil, nil, nil, nil),
+			daemon:          dn,
+		},
+	}
+
+	handler := metricHandler{tracker: tracker}
+	req := httptest.NewRequest("GET", "/emit-logs", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code, "ready should return 200")
+
+	// liveGate must be open after synchronous replay completes
+	dn.liveGateMu.Lock()
+	gate := dn.liveGate
+	dn.liveGateMu.Unlock()
+	select {
+	case <-gate:
+		// expected: gate is open
+	default:
+		t.Fatal("liveGate should be open after ready /emit-logs completes synchronous replay")
+	}
+}
+
+func TestLiveGate_TimeoutReturnsTrue(t *testing.T) {
+	origTimeout := liveGateTimeout
+	liveGateTimeout = 100 * time.Millisecond
+	defer func() { liveGateTimeout = origTimeout }()
+
+	dn := &Daemon{}
+	dn.resetLiveGate()
+	// Gate is never opened — should timeout and return true.
+
+	exitCh := make(chan bool)
+	result := make(chan bool, 1)
+	go func() {
+		result <- dn.waitForLiveGate(exitCh)
+	}()
+
+	// Should NOT return within 50ms (gate is still closed, timeout hasn't fired)
+	select {
+	case <-result:
+		t.Fatal("waitForLiveGate returned before timeout")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Should return true after the 100ms timeout
+	select {
+	case r := <-result:
+		assert.True(t, r, "timeout should return true (proceed without guarantee)")
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("waitForLiveGate did not return after timeout")
+	}
 }

--- a/pkg/daemon/daemon_internal_test.go
+++ b/pkg/daemon/daemon_internal_test.go
@@ -43,6 +43,7 @@ func NewDaemonForTests(tracker *ReadyTracker, processManager *ProcessManager) *D
 		readyTracker:          tracker,
 		processManager:        processManager,
 		hardwareConfigManager: hardwareconfig.NewHardwareConfigManager(fakeClient, "default"),
+		liveGate:              &liveGate{},
 	}
 }
 
@@ -1799,27 +1800,33 @@ func TestPtp4lConf_PopulatePtp4lConf_ClockTypeWithCliArgs(t *testing.T) {
 // --- liveGate unit tests ---
 
 func TestLiveGate_NilGateReturnsImmediately(t *testing.T) {
-	dn := &Daemon{} // liveGate is nil by default
-	assert.Nil(t, dn.liveGate, "nil gate means disabled")
-	dn.waitForLiveGate()
+	dn := &Daemon{
+		liveGate: &liveGate{},
+	}
+	assert.Nil(t, dn.liveGate.c, "nil gate means disabled")
+	dn.liveGate.Wait(liveGateTimeout)
 }
 
 func TestLiveGate_OpenBeforeWait(t *testing.T) {
-	dn := &Daemon{}
-	dn.resetLiveGate()
-	assert.NotNil(t, dn.liveGate, "gate should exist after reset")
-	dn.openLiveGate()
+	dn := &Daemon{
+		liveGate: &liveGate{},
+	}
+	dn.liveGate.Reset()
+	assert.NotNil(t, dn.liveGate.c, "gate should exist after reset")
+	dn.liveGate.Open()
 
-	dn.waitForLiveGate()
+	dn.liveGate.Wait(liveGateTimeout)
 }
 
 func TestLiveGate_WaitThenOpen(t *testing.T) {
-	dn := &Daemon{}
-	dn.resetLiveGate()
+	dn := &Daemon{
+		liveGate: &liveGate{},
+	}
+	dn.liveGate.Reset()
 
 	result := make(chan bool, 1)
 	go func() {
-		dn.waitForLiveGate()
+		dn.liveGate.Wait(liveGateTimeout)
 		result <- true
 	}()
 
@@ -1830,7 +1837,7 @@ func TestLiveGate_WaitThenOpen(t *testing.T) {
 	case <-time.After(50 * time.Millisecond):
 	}
 
-	dn.openLiveGate()
+	dn.liveGate.Open()
 
 	select {
 	case r := <-result:
@@ -1845,37 +1852,43 @@ func TestLiveGate_ClosedGateBlocksUntilTimeout(t *testing.T) {
 	liveGateTimeout = 80 * time.Millisecond
 	defer func() { liveGateTimeout = origTimeout }()
 
-	dn := &Daemon{}
-	dn.resetLiveGate()
+	dn := &Daemon{
+		liveGate: &liveGate{},
+	}
+	dn.liveGate.Reset()
 
 	start := time.Now()
-	dn.waitForLiveGate()
+	dn.liveGate.Wait(liveGateTimeout)
 	assert.GreaterOrEqual(t, time.Since(start).Milliseconds(), int64(70),
 		"should block for approximately the timeout duration")
 }
 
 func TestLiveGate_DoubleOpenIsSafe(t *testing.T) {
-	dn := &Daemon{}
-	dn.resetLiveGate()
-	dn.openLiveGate()
-	assert.NotPanics(t, func() { dn.openLiveGate() }, "double open must not panic")
+	dn := &Daemon{
+		liveGate: &liveGate{},
+	}
+	dn.liveGate.Reset()
+	dn.liveGate.Open()
+	assert.NotPanics(t, func() { dn.liveGate.Open() }, "double open must not panic")
 
-	dn.waitForLiveGate()
+	dn.liveGate.Wait(liveGateTimeout)
 }
 
 func TestLiveGate_ResetReblocks(t *testing.T) {
-	dn := &Daemon{}
-	dn.resetLiveGate()
-	dn.openLiveGate()
+	dn := &Daemon{
+		liveGate: &liveGate{},
+	}
+	dn.liveGate.Reset()
+	dn.liveGate.Open()
 
-	dn.waitForLiveGate()
+	dn.liveGate.Wait(liveGateTimeout)
 
 	// Reset creates a new blocked gate
-	dn.resetLiveGate()
+	dn.liveGate.Reset()
 
 	result := make(chan bool, 1)
 	go func() {
-		dn.waitForLiveGate()
+		dn.liveGate.Wait(liveGateTimeout)
 		result <- true
 	}()
 
@@ -1885,7 +1898,7 @@ func TestLiveGate_ResetReblocks(t *testing.T) {
 	case <-time.After(50 * time.Millisecond):
 	}
 
-	dn.openLiveGate()
+	dn.liveGate.Open()
 
 	select {
 	case r := <-result:
@@ -1896,14 +1909,16 @@ func TestLiveGate_ResetReblocks(t *testing.T) {
 }
 
 func TestLiveGate_MultipleWaitersAllUnblock(t *testing.T) {
-	dn := &Daemon{}
-	dn.resetLiveGate()
+	dn := &Daemon{
+		liveGate: &liveGate{},
+	}
+	dn.liveGate.Reset()
 
 	const n = 5
 	results := make(chan bool, n)
 	for i := 0; i < n; i++ {
 		go func() {
-			dn.waitForLiveGate()
+			dn.liveGate.Wait(liveGateTimeout)
 			results <- true
 		}()
 	}
@@ -1912,7 +1927,7 @@ func TestLiveGate_MultipleWaitersAllUnblock(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 	assert.Equal(t, 0, len(results), "no waiter should return before gate opens")
 
-	dn.openLiveGate()
+	dn.liveGate.Open()
 
 	for i := 0; i < n; i++ {
 		select {
@@ -1966,15 +1981,17 @@ func TestLiveGateIntegration_FullDaemonCEPFlow(t *testing.T) {
 	assert.NoError(t, err)
 	defer listener.Close()
 
-	dn := &Daemon{}
-	dn.resetLiveGate()
+	dn := &Daemon{
+		liveGate: &liveGate{},
+	}
+	dn.liveGate.Reset()
 
 	// Daemon HTTP server (/emit-logs opens the gate)
 	httpLn, err := net.Listen("tcp", "127.0.0.1:0")
 	assert.NoError(t, err)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/emit-logs", func(w http.ResponseWriter, _ *http.Request) {
-		dn.openLiveGate()
+		dn.liveGate.Open()
 		w.WriteHeader(http.StatusOK)
 	})
 	httpSrv := &http.Server{Handler: mux}
@@ -2047,7 +2064,7 @@ func TestLiveGateIntegration_FullDaemonCEPFlow(t *testing.T) {
 		}
 		defer c.Close()
 
-		dn.waitForLiveGate()
+		dn.liveGate.Wait(liveGateTimeout)
 		if _, wErr := fmt.Fprintf(c, "%s\n", liveStartCommand); wErr != nil {
 			t.Errorf("LIVE_START write error: %v", wErr)
 			return
@@ -2109,8 +2126,10 @@ func TestLiveGateIntegration_FullDaemonCEPFlow(t *testing.T) {
 // is blocked waiting for the live gate. This was the original bug: a single
 // goroutine both waited for the gate AND read stdout, causing ptp4l to freeze.
 func TestLiveGateIntegration_ScannerDrainsWhileGateBlocked(t *testing.T) {
-	dn := &Daemon{}
-	dn.resetLiveGate() // gate is CLOSED
+	dn := &Daemon{
+		liveGate: &liveGate{},
+	}
+	dn.liveGate.Reset() // gate is CLOSED
 
 	ptp4lR, ptp4lW := io.Pipe()
 	lineCh := make(chan string, 256)
@@ -2173,8 +2192,10 @@ func TestLiveGateIntegration_ReplayThenLive(t *testing.T) {
 	assert.NoError(t, err)
 	defer listener.Close()
 
-	dn := &Daemon{}
-	dn.resetLiveGate()
+	dn := &Daemon{
+		liveGate: &liveGate{},
+	}
+	dn.liveGate.Reset()
 
 	replayLines := []string{
 		"ptp4l[0.000]: [ptp4l.0.config] port 1 (ens1f0): UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED",
@@ -2202,7 +2223,7 @@ func TestLiveGateIntegration_ReplayThenLive(t *testing.T) {
 			}
 			replayConn.Close()
 		}
-		dn.openLiveGate()
+		dn.liveGate.Open()
 		w.WriteHeader(http.StatusOK)
 	})
 	httpSrv := &http.Server{Handler: mux}
@@ -2259,7 +2280,7 @@ func TestLiveGateIntegration_ReplayThenLive(t *testing.T) {
 			return
 		}
 		defer c.Close()
-		dn.waitForLiveGate()
+		dn.liveGate.Wait(liveGateTimeout)
 		fmt.Fprintf(c, "%s\n", liveStartCommand)
 		for _, line := range liveLines {
 			fmt.Fprintf(c, "%s\n", line)
@@ -2339,8 +2360,10 @@ func TestLiveGateIntegration_OrderingPreventsCorruption(t *testing.T) {
 	assert.NoError(t, err)
 	defer listener.Close()
 
-	dn := &Daemon{}
-	dn.resetLiveGate()
+	dn := &Daemon{
+		liveGate: &liveGate{},
+	}
+	dn.liveGate.Reset()
 
 	replayLines := []string{
 		"ptp4l[0.000]: [ptp4l.0.config] port 1 (ens1f0): SLAVE to FAULTY on FAULT_DETECTED (FT_UNSPECIFIED)",
@@ -2391,7 +2414,7 @@ func TestLiveGateIntegration_OrderingPreventsCorruption(t *testing.T) {
 			return
 		}
 		defer c.Close()
-		dn.waitForLiveGate()
+		dn.liveGate.Wait(liveGateTimeout)
 		fmt.Fprintf(c, "%s\n", liveStartCommand)
 		for _, line := range liveLines {
 			fmt.Fprintf(c, "%s\n", line)
@@ -2410,7 +2433,7 @@ func TestLiveGateIntegration_OrderingPreventsCorruption(t *testing.T) {
 		replayConn, dialErr := net.DialTimeout("unix", socketPath, 2*time.Second)
 		if dialErr != nil {
 			t.Errorf("replay dial failed: %v", dialErr)
-			dn.openLiveGate()
+			dn.liveGate.Open()
 			return
 		}
 		for _, line := range replayLines {
@@ -2421,7 +2444,7 @@ func TestLiveGateIntegration_OrderingPreventsCorruption(t *testing.T) {
 		// Wait for the replay reader goroutine to fully consume the data.
 		// In production, kernel socket buffering makes this near-instantaneous.
 		<-replayReadDone
-		dn.openLiveGate()
+		dn.liveGate.Open()
 	}()
 
 	select {
@@ -2487,8 +2510,10 @@ func TestLiveGateIntegration_TriggerLogsFailureRecovery(t *testing.T) {
 	assert.NoError(t, err)
 	defer listener.Close()
 
-	dn := &Daemon{}
-	dn.resetLiveGate()
+	dn := &Daemon{
+		liveGate: &liveGate{},
+	}
+	dn.liveGate.Reset()
 
 	// Reserve an address but DON'T serve yet — TriggerLogs will fail.
 	httpLn, err := net.Listen("tcp", "127.0.0.1:0")
@@ -2543,25 +2568,7 @@ func TestLiveGateIntegration_TriggerLogsFailureRecovery(t *testing.T) {
 			// Short gate timeout: if CEP closed the connection (TriggerLogs
 			// failed), the gate won't open for this attempt. Rather than
 			// blocking for 60s, use a short select.
-			gateOpen := false
-			func() {
-				dn.liveGateMu.Lock()
-				gate := dn.liveGate
-				dn.liveGateMu.Unlock()
-				if gate == nil {
-					gateOpen = true
-					return
-				}
-				select {
-				case <-gate:
-					gateOpen = true
-				case <-time.After(2 * time.Second):
-				}
-			}()
-			if !gateOpen {
-				c.Close()
-				continue
-			}
+			dn.liveGate.Wait(2 * time.Second)
 			_, wErr := fmt.Fprintf(c, "%s\nlive data\n", liveStartCommand)
 			c.Close()
 			if wErr == nil {
@@ -2587,7 +2594,7 @@ func TestLiveGateIntegration_TriggerLogsFailureRecovery(t *testing.T) {
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/emit-logs", func(w http.ResponseWriter, _ *http.Request) {
-		dn.openLiveGate()
+		dn.liveGate.Open()
 		w.WriteHeader(http.StatusOK)
 	})
 	srv := &http.Server{Handler: mux}
@@ -2638,8 +2645,10 @@ func TestEmitClockClassLogs_EmitsWithNilParentDS(t *testing.T) {
 // --- /emit-logs handler unit tests ---
 
 func TestEmitLogsHandler_NotReady_OpensGateAndReturns204(t *testing.T) {
-	dn := &Daemon{}
-	dn.resetLiveGate()
+	dn := &Daemon{
+		liveGate: &liveGate{},
+	}
+	dn.liveGate.Reset()
 
 	tracker := &ReadyTracker{
 		config: false, // not ready
@@ -2656,12 +2665,10 @@ func TestEmitLogsHandler_NotReady_OpensGateAndReturns204(t *testing.T) {
 
 	assert.Equal(t, http.StatusNoContent, rec.Code, "not-ready should return 204")
 
-	// liveGate must be open (channel closed)
-	dn.liveGateMu.Lock()
-	gate := dn.liveGate
-	dn.liveGateMu.Unlock()
+	dn.liveGate.lock.RLock()
+	defer dn.liveGate.lock.RUnlock()
 	select {
-	case <-gate:
+	case <-dn.liveGate.c:
 		// expected: gate is closed (open)
 	default:
 		t.Fatal("liveGate should be open after not-ready /emit-logs")
@@ -2669,8 +2676,10 @@ func TestEmitLogsHandler_NotReady_OpensGateAndReturns204(t *testing.T) {
 }
 
 func TestEmitLogsHandler_Ready_EmitsReplayThenOpensGate(t *testing.T) {
-	dn := &Daemon{}
-	dn.resetLiveGate()
+	dn := &Daemon{
+		liveGate: &liveGate{},
+	}
+	dn.liveGate.Reset()
 
 	// Provide a real socket so EmitPortRoleLogs can connect without retry delays.
 	socketPath := shortTestSocketPath(t)
@@ -2713,11 +2722,10 @@ func TestEmitLogsHandler_Ready_EmitsReplayThenOpensGate(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code, "ready should return 200")
 
 	// liveGate must be open after synchronous replay completes
-	dn.liveGateMu.Lock()
-	gate := dn.liveGate
-	dn.liveGateMu.Unlock()
+	dn.liveGate.lock.RLock()
+	defer dn.liveGate.lock.RUnlock()
 	select {
-	case <-gate:
+	case <-dn.liveGate.c:
 		// expected: gate is open
 	default:
 		t.Fatal("liveGate should be open after ready /emit-logs completes synchronous replay")
@@ -2725,17 +2733,15 @@ func TestEmitLogsHandler_Ready_EmitsReplayThenOpensGate(t *testing.T) {
 }
 
 func TestLiveGate_TimeoutReturnsTrue(t *testing.T) {
-	origTimeout := liveGateTimeout
-	liveGateTimeout = 100 * time.Millisecond
-	defer func() { liveGateTimeout = origTimeout }()
-
-	dn := &Daemon{}
-	dn.resetLiveGate()
+	dn := &Daemon{
+		liveGate: &liveGate{},
+	}
+	dn.liveGate.Reset()
 	// Gate is never opened — should timeout and return true.
 
 	result := make(chan bool, 1)
 	go func() {
-		dn.waitForLiveGate()
+		dn.liveGate.Wait(50 * time.Millisecond)
 		result <- true
 	}()
 
@@ -2765,8 +2771,10 @@ func TestSocketWriter_Drain(t *testing.T) {
 	assert.NoError(t, err)
 	defer listener.Close()
 
-	dn := &Daemon{}
-	dn.resetLiveGate()
+	dn := &Daemon{
+		liveGate: &liveGate{},
+	}
+	dn.liveGate.Reset()
 
 	lineCh := make(chan string, 256)
 
@@ -2813,7 +2821,7 @@ func TestSocketWriter_Drain(t *testing.T) {
 		}
 		defer c.Close()
 
-		dn.waitForLiveGate()
+		dn.liveGate.Wait(liveGateTimeout)
 		fmt.Fprintf(c, "%s\n", liveStartCommand)
 
 		// Drain stale lines (same logic as daemon.go drainLoop)
@@ -2839,7 +2847,7 @@ func TestSocketWriter_Drain(t *testing.T) {
 	}()
 
 	// Open the gate (stale lines are already buffered).
-	dn.openLiveGate()
+	dn.liveGate.Open()
 
 	// Feed live lines after a short delay to ensure drain has completed.
 	go func() {
@@ -2898,9 +2906,11 @@ func TestSocketWriter_Reconnect(t *testing.T) {
 	assert.NoError(t, err)
 	defer listener.Close()
 
-	dn := &Daemon{}
-	dn.resetLiveGate()
-	dn.openLiveGate() // gate is already open for this test
+	dn := &Daemon{
+		liveGate: &liveGate{},
+	}
+	dn.liveGate.Reset()
+	dn.liveGate.Open() // gate is already open for this test
 
 	lineCh := make(chan string, 256)
 	doneCh := make(chan struct{}, 1)
@@ -2960,7 +2970,7 @@ func TestSocketWriter_Reconnect(t *testing.T) {
 			time.Sleep(10 * time.Millisecond)
 			goto connect
 		}
-		dn.waitForLiveGate()
+		dn.liveGate.Wait(liveGateTimeout)
 		if _, err2 := fmt.Fprintf(c, "%s\n", liveStartCommand); err2 != nil {
 			c.Close()
 			goto connect
@@ -3032,9 +3042,11 @@ func TestSocketWriter_SuffixStrip(t *testing.T) {
 	assert.NoError(t, err)
 	defer listener.Close()
 
-	dn := &Daemon{}
-	dn.resetLiveGate()
-	dn.openLiveGate()
+	dn := &Daemon{
+		liveGate: &liveGate{},
+	}
+	dn.liveGate.Reset()
+	dn.liveGate.Open()
 
 	tests := []struct {
 		input    string
@@ -3084,7 +3096,7 @@ func TestSocketWriter_SuffixStrip(t *testing.T) {
 		}
 		defer c.Close()
 
-		dn.waitForLiveGate()
+		dn.liveGate.Wait(liveGateTimeout)
 		fmt.Fprintf(c, "%s\n", liveStartCommand)
 		for output := range lineCh {
 			line := removeMessageSuffix(output) + "\n"

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -263,7 +263,7 @@ func updatePTPMetrics(from, process, iface string, ptpOffset, maxPtpOffset, freq
 
 // extractMetrics ...
 func extractMetrics(messageTag string, processName string, ifaces config.IFaces, output string, updateMetrics bool) (configName, source string, offset float64, state string, iface string) {
-	glog.V(4).Infof("DEBUG extractMetrics: process=%s updateMetrics=%v tag=%s", processName, updateMetrics, messageTag)
+	glog.V(14).Infof("DEBUG extractMetrics: process=%s updateMetrics=%v tag=%s", processName, updateMetrics, messageTag)
 	configName = strings.Replace(strings.Replace(messageTag, "]", "", 1), "[", "", 1)
 	if configName != "" {
 		configName = strings.Split(configName, MessageTagSuffixSeperator)[0] // remove any suffix added to the configName
@@ -528,7 +528,7 @@ func updateClockStateMetrics(process, iface string, state string) {
 	if !utils.CheckMetricSanity("ClockState", process, iface) {
 		return
 	}
-	glog.V(4).Infof("updateClockStateMetrics: process=%s iface=%s state=%s", process, iface, state)
+	glog.V(14).Infof("updateClockStateMetrics: process=%s iface=%s state=%s", process, iface, state)
 	if state == LOCKED {
 		ClockState.With(prometheus.Labels{
 			"process": process, "node": NodeName, "iface": iface}).Set(1)

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -263,6 +263,7 @@ func updatePTPMetrics(from, process, iface string, ptpOffset, maxPtpOffset, freq
 
 // extractMetrics ...
 func extractMetrics(messageTag string, processName string, ifaces config.IFaces, output string, updateMetrics bool) (configName, source string, offset float64, state string, iface string) {
+	glog.V(4).Infof("DEBUG extractMetrics: process=%s updateMetrics=%v tag=%s", processName, updateMetrics, messageTag)
 	configName = strings.Replace(strings.Replace(messageTag, "]", "", 1), "[", "", 1)
 	if configName != "" {
 		configName = strings.Split(configName, MessageTagSuffixSeperator)[0] // remove any suffix added to the configName
@@ -527,6 +528,7 @@ func updateClockStateMetrics(process, iface string, state string) {
 	if !utils.CheckMetricSanity("ClockState", process, iface) {
 		return
 	}
+	glog.V(4).Infof("updateClockStateMetrics: process=%s iface=%s state=%s", process, iface, state)
 	if state == LOCKED {
 		ClockState.With(prometheus.Labels{
 			"process": process, "node": NodeName, "iface": iface}).Set(1)

--- a/pkg/daemon/ready.go
+++ b/pkg/daemon/ready.go
@@ -83,9 +83,9 @@ type metricHandler struct {
 }
 
 func (h metricHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
-	glog.V(4).Info("/emit-logs: handler invoked")
+	glog.V(14).Info("/emit-logs: handler invoked")
 	if isReady, _ := h.tracker.Ready(); !isReady {
-		glog.V(4).Info("/emit-logs: not ready, opening gate early and returning 204")
+		glog.V(14).Info("/emit-logs: not ready, opening gate early and returning 204")
 		w.WriteHeader(http.StatusNoContent)
 		// Open the gate even when not ready: processes need to start writing
 		// to collect metrics and become ready. No stale state exists yet, so
@@ -99,11 +99,11 @@ func (h metricHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 
 	// Emit replay data synchronously so the live gate is only opened after
 	// all replay state has been written to the socket.
-	glog.V(4).Info("/emit-logs: starting synchronous replay (EmitClockSyncLogs + EmitPortRoleLogs)")
+	glog.V(14).Info("/emit-logs: starting synchronous replay (EmitClockSyncLogs + EmitPortRoleLogs)")
 	eventHandler := h.tracker.processManager.ptpEventHandler
 	eventHandler.EmitClockSyncLogs()
 	eventHandler.EmitPortRoleLogs()
-	glog.V(4).Info("/emit-logs: synchronous replay complete, opening liveGate")
+	glog.V(14).Info("/emit-logs: synchronous replay complete, opening liveGate")
 
 	// Open the live gate: ptp4l processes may now write to the socket.
 	if dn := h.tracker.processManager.daemon; dn != nil {
@@ -111,7 +111,7 @@ func (h metricHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	// Non-critical emits can remain async.
-	glog.V(4).Info("/emit-logs: firing async emits (ProcessStatusLogs, ClockClassLogs)")
+	glog.V(14).Info("/emit-logs: firing async emits (ProcessStatusLogs, ClockClassLogs)")
 	processManager := h.tracker.processManager
 	go processManager.EmitProcessStatusLogs()
 	go processManager.EmitClockClassLogs()

--- a/pkg/daemon/ready.go
+++ b/pkg/daemon/ready.go
@@ -91,7 +91,7 @@ func (h metricHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 		// to collect metrics and become ready. No stale state exists yet, so
 		// there is nothing harmful to replay.
 		if dn := h.tracker.processManager.daemon; dn != nil {
-			dn.openLiveGate()
+			dn.liveGate.Open()
 		}
 		return
 	}
@@ -107,7 +107,7 @@ func (h metricHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 
 	// Open the live gate: ptp4l processes may now write to the socket.
 	if dn := h.tracker.processManager.daemon; dn != nil {
-		dn.openLiveGate()
+		dn.liveGate.Open()
 	}
 
 	// Non-critical emits can remain async.

--- a/pkg/daemon/ready.go
+++ b/pkg/daemon/ready.go
@@ -83,21 +83,38 @@ type metricHandler struct {
 }
 
 func (h metricHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	glog.V(4).Info("/emit-logs: handler invoked")
 	if isReady, _ := h.tracker.Ready(); !isReady {
+		glog.V(4).Info("/emit-logs: not ready, opening gate early and returning 204")
 		w.WriteHeader(http.StatusNoContent)
+		// Open the gate even when not ready: processes need to start writing
+		// to collect metrics and become ready. No stale state exists yet, so
+		// there is nothing harmful to replay.
+		if dn := h.tracker.processManager.daemon; dn != nil {
+			dn.openLiveGate()
+		}
 		return
 	}
 	w.WriteHeader(http.StatusOK)
 
-	go func() {
-		eventHandler := h.tracker.processManager.ptpEventHandler
-		eventHandler.EmitClockSyncLogs()
-		eventHandler.EmitPortRoleLogs()
+	// Emit replay data synchronously so the live gate is only opened after
+	// all replay state has been written to the socket.
+	glog.V(4).Info("/emit-logs: starting synchronous replay (EmitClockSyncLogs + EmitPortRoleLogs)")
+	eventHandler := h.tracker.processManager.ptpEventHandler
+	eventHandler.EmitClockSyncLogs()
+	eventHandler.EmitPortRoleLogs()
+	glog.V(4).Info("/emit-logs: synchronous replay complete, opening liveGate")
 
-		processManager := h.tracker.processManager
-		go processManager.EmitProcessStatusLogs()
-		go processManager.EmitClockClassLogs()
-	}()
+	// Open the live gate: ptp4l processes may now write to the socket.
+	if dn := h.tracker.processManager.daemon; dn != nil {
+		dn.openLiveGate()
+	}
+
+	// Non-critical emits can remain async.
+	glog.V(4).Info("/emit-logs: firing async emits (ProcessStatusLogs, ClockClassLogs)")
+	processManager := h.tracker.processManager
+	go processManager.EmitProcessStatusLogs()
+	go processManager.EmitClockClassLogs()
 }
 
 type portAliasesHandler struct{}

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -1309,6 +1309,8 @@ func getMetricName(valueType ValueType) string {
 
 // SetPortRole saves the port role change event
 func (e *EventHandler) SetPortRole(cfgName, portNane string, event *parser.PTPEvent) {
+	e.Lock()
+	defer e.Unlock()
 	if e.portRole == nil {
 		e.portRole = make(map[string]map[string]*parser.PTPEvent)
 	}


### PR DESCRIPTION
Cherry-pick of upstream PR https://github.com/k8snetworkplumbingwg/linuxptp-daemon/pull/216 to release-4.22.

Backport of OCPBUGS-85092 for 4.22 (clone: OCPBUGS-87839).