### PR TITLE
OCPBUGS-87866: Allow phase offsets from Active state pins

### DIFF
--- a/pkg/dpll-netlink/dpll-uapi.go
+++ b/pkg/dpll-netlink/dpll-uapi.go
@@ -30,6 +30,29 @@ const DpllPhaseOffsetDivider = 1000
 // temperature value.
 const DpllTemperatureDivider = 1000
 
+// DpllPinMeasuredFrequencyDivider allows userspace to calculate a value of
+// measured input frequency as a fractional value with three digit decimal
+// precision (millihertz).
+// Value of (DPLL_A_PIN_MEASURED_FREQUENCY / DpllPinMeasuredFrequencyDivider)
+// is an integer part of a measured frequency value.
+// Value of (DPLL_A_PIN_MEASURED_FREQUENCY % DpllPinMeasuredFrequencyDivider)
+// is a fractional part of a measured frequency value.
+const DpllPinMeasuredFrequencyDivider = 1000
+
+// Defines possible operational states of a pin with respect to its parent DPLL device.
+// Unlike pin state (administrative intent), operstate reflects actual hardware status.
+const (
+	// PinOperstateActive indicates the pin is qualified and actively used by the DPLL.
+	PinOperstateActive = 1
+	// PinOperstateStandby indicates the pin is qualified but not actively used by the DPLL.
+	PinOperstateStandby = 2
+	// PinOperstateNoSignal indicates the pin does not have a valid signal.
+	PinOperstateNoSignal = 3
+	// PinOperstateQualFailed indicates the pin signal failed qualification
+	// (e.g. frequency or phase monitor).
+	PinOperstateQualFailed = 4
+)
+
 // DpllAttributes provides the dpll_a attribute-set
 const (
 	DpllAttributes = iota
@@ -46,6 +69,9 @@ const (
 	DpllClockQualityLevel
 	DpllPhaseOffsetMonitor
 	DpllPhaseOffsetAverageFactor
+	// DpllFrequencyMonitor is the netlink attribute ID for the frequency-monitor
+	// feature flag on a DPLL device (uses the feature-state enum).
+	DpllFrequencyMonitor
 )
 
 // DpllPinTypes defines the attribute-set for dpll_a_pin
@@ -75,13 +101,34 @@ const (
 	DpllPinPhaseAdjustMax
 	DpllPinPhaseAdjust
 	DpllPinPhaseOffset
+	// DpllPinFractionalFrequencyOffset is the netlink attribute ID for the FFO
+	// (Fractional Frequency Offset) of a pin in PPM (parts per million).
+	// At the top-level pin scope this represents the RX vs TX symbol rate offset
+	// on the media associated with the pin.
+	// Inside the pin-parent-device nest it represents the frequency offset between
+	// the pin and its parent DPLL device.
+	// This is a lower-precision version of DpllPinFractionalFrequencyOffsetPPT.
 	DpllPinFractionalFrequencyOffset
 	DpllPinEsyncFrequency
 	DpllPinEsyncFrequencySupported
 	DpllPinEsyncPulse
 	DpllPinReferenceSync
 	DpllPinPhaseAdjustGran
+	// DpllPinFractionalFrequencyOffsetPPT is the netlink attribute ID for the FFO
+	// (Fractional Frequency Offset) of a pin in PPT (parts per trillion, 10^-12).
+	// At the top-level pin scope this represents the RX vs TX symbol rate offset
+	// on the media associated with the pin.
+	// Inside the pin-parent-device nest it represents the frequency offset between
+	// the pin and its parent DPLL device.
+	// This is a higher-precision version of DpllPinFractionalFrequencyOffset.
 	DpllPinFractionalFrequencyOffsetPPT
+	// DpllPinMeasuredFrequency is the netlink attribute ID for the measured
+	// frequency of an input pin in millihertz. Divide by
+	// DpllPinMeasuredFrequencyDivider to obtain Hz with mHz fractional precision.
+	DpllPinMeasuredFrequency
+	// DpllPinOperstate is the netlink attribute ID for the operational state of a
+	// pin with respect to its parent DPLL device (pin-operstate enum).
+	DpllPinOperstate
 )
 
 // DpllCmds defines DPLL subsystem commands encoding
@@ -145,13 +192,53 @@ const (
 	PhaseOffsetMonitorDisabled
 )
 
+// unknownStr is the fallback human-readable value returned by Get* helpers
+// when an enum value has no known mapping.
+const unknownStr = "unknown"
+
+// Feature-state string constants shared by phase-offset-monitor and frequency-monitor.
+const (
+	featureStateEnabled  = "enabled"
+	featureStateDisabled = "disabled"
+)
+
+// Pin operstate string constants.
+const (
+	pinOperstateActive     = "active"
+	pinOperstateStandby    = "standby"
+	pinOperstateNoSignal   = "no-signal"
+	pinOperstateQualFailed = "qual-failed"
+)
+
 // GetPhaseOffsetMonitor returns phase offset monitor as a string
 func GetPhaseOffsetMonitor(po uint32) string {
 	phaseOffsetMonitorMap := map[uint32]string{
-		PhaseOffsetMonitorEnabled:  "enabled",
-		PhaseOffsetMonitorDisabled: "disabled",
+		PhaseOffsetMonitorEnabled:  featureStateEnabled,
+		PhaseOffsetMonitorDisabled: featureStateDisabled,
 	}
 	return phaseOffsetMonitorMap[po]
+}
+
+// GetFrequencyMonitor returns the frequency-monitor feature state as a human-readable string.
+// Uses the feature-state enum (same as phase-offset-monitor): "enabled", "disabled", or "unknown".
+func GetFrequencyMonitor(s uint32) string {
+	return GetPhaseOffsetMonitor(s)
+}
+
+// GetPinOperstate returns the pin operational state as a human-readable string.
+// Returns "active", "standby", "no-signal", "qual-failed", or "" for unknown values.
+func GetPinOperstate(s uint32) string {
+	operstateMap := map[uint32]string{
+		PinOperstateActive:     pinOperstateActive,
+		PinOperstateStandby:    pinOperstateStandby,
+		PinOperstateNoSignal:   pinOperstateNoSignal,
+		PinOperstateQualFailed: pinOperstateQualFailed,
+	}
+	r, found := operstateMap[s]
+	if found {
+		return r
+	}
+	return unknownStr
 }
 
 // ClockQualityLevel defines possible clock quality levels when on holdover
@@ -193,7 +280,7 @@ func GetClockQualityLevel(cq uint32) string {
 	if found {
 		return cqStr
 	}
-	return ""
+	return unknownStr
 }
 
 // DpllTypeAttribute defines DPLL types
@@ -217,7 +304,7 @@ func GetLockStatus(ls uint32) string {
 	if found {
 		return status
 	}
-	return ""
+	return unknownStr
 }
 
 // GetDpllType returns DPLL type as a string
@@ -230,7 +317,7 @@ func GetDpllType(tp uint32) string {
 	if found {
 		return typ
 	}
-	return ""
+	return unknownStr
 }
 
 // GetMode returns DPLL mode as a string
@@ -243,7 +330,7 @@ func GetMode(md uint32) string {
 	if found {
 		return mode
 	}
-	return ""
+	return unknownStr
 }
 
 // DpllStatusHR represents human-readable DPLL status
@@ -261,6 +348,7 @@ type DpllStatusHR struct {
 	ClockQualityLevel        string    `json:"clockQualityLevel,omitempty"`
 	PhaseOffsetMonitor       string    `json:"phaseOffsetMonitor,omitempty"`
 	PhaseOffsetAverageFactor uint32    `json:"phaseOffsetAverageFactor,omitempty"`
+	FrequencyMonitor         string    `json:"frequencyMonitor,omitempty"`
 }
 
 // GetDpllStatusHR returns human-readable DPLL status
@@ -283,6 +371,7 @@ func GetDpllStatusHR(reply *DoDeviceGetReply, timestamp time.Time) ([]byte, erro
 		ClockQualityLevel:        GetClockQualityLevels(reply.ClockQualityLevel),
 		PhaseOffsetMonitor:       GetPhaseOffsetMonitor(reply.PhaseOffsetMonitor),
 		PhaseOffsetAverageFactor: reply.PhaseOffsetAverageFactor,
+		FrequencyMonitor:         GetFrequencyMonitor(reply.FrequencyMonitor),
 	}
 	return json.Marshal(hr)
 }
@@ -312,15 +401,20 @@ type PinInfoHR struct {
 	ReferenceSync                []ReferenceSync     `json:"referenceSync,omitempty"`
 	PhaseAdjustGran              uint32              `json:"phaseAdjustGran,omitempty"`
 	FractionalFrequencyOffsetPPT int                 `json:"fractionalFrequencyOffsetPPT,omitempty"`
+	MeasuredFrequencyHz          float64             `json:"measuredFrequencyHz,omitempty"`
+	Operstate                    string              `json:"operstate,omitempty"`
 }
 
 // PinParentDeviceHR contains nested netlink attributes.
 type PinParentDeviceHR struct {
-	ParentID      uint32  `json:"parentID"`
-	Direction     string  `json:"direction"`
-	Prio          *uint32 `json:"prio,omitempty"`
-	State         string  `json:"state"`
-	PhaseOffsetPs float64 `json:"phaseOffsetPs"`
+	ParentID                     uint32  `json:"parentID"`
+	Direction                    string  `json:"direction"`
+	Prio                         *uint32 `json:"prio,omitempty"`
+	State                        string  `json:"state"`
+	PhaseOffsetPs                float64 `json:"phaseOffsetPs"`
+	Operstate                    string  `json:"operstate,omitempty"`
+	FractionalFrequencyOffset    int     `json:"fractionalFrequencyOffset,omitempty"`
+	FractionalFrequencyOffsetPPT int     `json:"fractionalFrequencyOffsetPPT,omitempty"`
 }
 
 // PinParentPin contains nested netlink attributes.
@@ -347,7 +441,7 @@ func GetPinState(s uint32) string {
 	if found {
 		return r
 	}
-	return ""
+	return unknownStr
 }
 
 // Defines possible pin types
@@ -372,7 +466,7 @@ func GetPinType(tp uint32) string {
 	if found {
 		return typ
 	}
-	return ""
+	return unknownStr
 }
 
 // Defines pin directions
@@ -391,7 +485,7 @@ func GetPinDirection(d uint32) string {
 	if found {
 		return dir
 	}
-	return ""
+	return unknownStr
 }
 
 // String returns a concise debug representation aligned with PinParentDeviceHR
@@ -543,14 +637,19 @@ func GetPinInfoHR(reply *PinInfo, timestamp time.Time) ([]byte, error) {
 		ReferenceSync:                make([]ReferenceSync, 0),
 		PhaseAdjustGran:              reply.PhaseAdjustGran,
 		FractionalFrequencyOffsetPPT: reply.FractionalFrequencyOffsetPPT,
+		MeasuredFrequencyHz:          float64(reply.MeasuredFrequency) / DpllPinMeasuredFrequencyDivider,
+		Operstate:                    GetPinOperstate(reply.Operstate),
 	}
 	for i := 0; i < len(reply.ParentDevice); i++ {
 		hr.ParentDevice = append(hr.ParentDevice, PinParentDeviceHR{
-			ParentID:      reply.ParentDevice[i].ParentID,
-			Direction:     GetPinDirection(reply.ParentDevice[i].Direction),
-			Prio:          reply.ParentDevice[i].Prio,
-			State:         GetPinState(reply.ParentDevice[i].State),
-			PhaseOffsetPs: float64(reply.ParentDevice[i].PhaseOffset) / DpllPhaseOffsetDivider,
+			ParentID:                     reply.ParentDevice[i].ParentID,
+			Direction:                    GetPinDirection(reply.ParentDevice[i].Direction),
+			Prio:                         reply.ParentDevice[i].Prio,
+			State:                        GetPinState(reply.ParentDevice[i].State),
+			PhaseOffsetPs:                float64(reply.ParentDevice[i].PhaseOffset) / DpllPhaseOffsetDivider,
+			Operstate:                    GetPinOperstate(reply.ParentDevice[i].Operstate),
+			FractionalFrequencyOffset:    reply.ParentDevice[i].FractionalFrequencyOffset,
+			FractionalFrequencyOffsetPPT: reply.ParentDevice[i].FractionalFrequencyOffsetPPT,
 		})
 	}
 	for i := 0; i < len(reply.ParentPin); i++ {

--- a/pkg/dpll-netlink/dpll.go
+++ b/pkg/dpll-netlink/dpll.go
@@ -161,8 +161,10 @@ func ParseDeviceReplies(msgs []genetlink.Message) ([]*DoDeviceGetReply, error) {
 				reply.PhaseOffsetMonitor = ad.Uint32()
 			case DpllPhaseOffsetAverageFactor:
 				reply.PhaseOffsetAverageFactor = ad.Uint32()
+			case DpllFrequencyMonitor:
+				reply.FrequencyMonitor = ad.Uint32()
 			default:
-				log.Println("default", ad.Type(), len(ad.Bytes()), ad.Bytes())
+				log.Println("default", ad.Type(), len(ad.Bytes()), string(ad.Bytes()))
 			}
 		}
 		if err := ad.Err(); err != nil {
@@ -259,6 +261,7 @@ type DoDeviceGetReply struct {
 	ClockQualityLevel        []uint32
 	PhaseOffsetMonitor       uint32
 	PhaseOffsetAverageFactor uint32
+	FrequencyMonitor         uint32
 }
 
 func ParsePinReplies(msgs []genetlink.Message) ([]*PinInfo, error) {
@@ -325,6 +328,12 @@ func ParsePinReplies(msgs []genetlink.Message) ([]*PinInfo, error) {
 							temp.State = ad.Uint32()
 						case DpllPinPhaseOffset:
 							temp.PhaseOffset = ad.Int64()
+						case DpllPinOperstate:
+							temp.Operstate = ad.Uint32()
+						case DpllPinFractionalFrequencyOffset:
+							temp.FractionalFrequencyOffset = int(ad.Int32())
+						case DpllPinFractionalFrequencyOffsetPPT:
+							temp.FractionalFrequencyOffsetPPT = int(ad.Int32())
 						}
 
 					}
@@ -389,6 +398,10 @@ func ParsePinReplies(msgs []genetlink.Message) ([]*PinInfo, error) {
 				reply.PhaseAdjustGran = ad.Uint32()
 			case DpllPinFractionalFrequencyOffsetPPT:
 				reply.FractionalFrequencyOffsetPPT = int(ad.Int32())
+			case DpllPinMeasuredFrequency:
+				reply.MeasuredFrequency = ad.Uint64()
+			case DpllPinOperstate:
+				reply.Operstate = ad.Uint32()
 			default:
 				log.Printf("unrecognized type: %d\n", ad.Type())
 			}
@@ -491,6 +504,8 @@ type PinInfo struct {
 	EsyncPulse                   uint32
 	ReferenceSync                []ReferenceSync
 	PhaseAdjustGran              uint32
+	MeasuredFrequency            uint64
+	Operstate                    uint32
 }
 
 // FrequencyRange contains nested netlink attributes.
@@ -507,11 +522,14 @@ type ReferenceSync struct {
 
 // PinParentDevice contains nested netlink attributes.
 type PinParentDevice struct {
-	ParentID    uint32
-	Direction   uint32
-	Prio        *uint32
-	State       uint32
-	PhaseOffset int64
+	ParentID                     uint32
+	Direction                    uint32
+	Prio                         *uint32
+	State                        uint32
+	PhaseOffset                  int64
+	Operstate                    uint32
+	FractionalFrequencyOffset    int
+	FractionalFrequencyOffsetPPT int
 }
 
 // PinParentPin contains nested netlink attributes.

--- a/pkg/dpll-netlink/dpll_test.go
+++ b/pkg/dpll-netlink/dpll_test.go
@@ -118,3 +118,159 @@ func TestParsePinReplies_DpllPinFractionalFrequencyOffsetPPT(t *testing.T) {
 		})
 	}
 }
+
+// TestGetFrequencyMonitor verifies that GetFrequencyMonitor maps kernel feature-state values
+// to their canonical string representations.
+func TestGetFrequencyMonitor(t *testing.T) {
+	tests := []struct {
+		name  string
+		input uint32
+		want  string
+	}{
+		{"enabled", PhaseOffsetMonitorEnabled, featureStateEnabled},
+		{"disabled", PhaseOffsetMonitorDisabled, featureStateDisabled},
+		{unknownStr, 99, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, GetFrequencyMonitor(tt.input))
+		})
+	}
+}
+
+// TestGetPinOperstate verifies that GetPinOperstate maps kernel pin-operstate values
+// to their canonical string representations.
+func TestGetPinOperstate(t *testing.T) {
+	tests := []struct {
+		name  string
+		input uint32
+		want  string
+	}{
+		{"active", PinOperstateActive, pinOperstateActive},
+		{"standby", PinOperstateStandby, pinOperstateStandby},
+		{"no-signal", PinOperstateNoSignal, pinOperstateNoSignal},
+		{"qual-failed", PinOperstateQualFailed, pinOperstateQualFailed},
+		{unknownStr, 99, unknownStr},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, GetPinOperstate(tt.input))
+		})
+	}
+}
+
+// TestParseDeviceReplies_FrequencyMonitor verifies that ParseDeviceReplies
+// correctly decodes the DpllFrequencyMonitor attribute into DoDeviceGetReply.FrequencyMonitor.
+func TestParseDeviceReplies_FrequencyMonitor(t *testing.T) {
+	tests := []struct {
+		name    string
+		encoded uint32
+		want    uint32
+	}{
+		{"enabled", PhaseOffsetMonitorEnabled, PhaseOffsetMonitorEnabled},
+		{"disabled", PhaseOffsetMonitorDisabled, PhaseOffsetMonitorDisabled},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ae := netlink.NewAttributeEncoder()
+			ae.Uint32(DpllID, 1)
+			ae.Uint32(DpllFrequencyMonitor, tt.encoded)
+			payload, err := ae.Encode()
+			assert.NoError(t, err)
+
+			msgs := []genetlink.Message{{Data: payload}}
+			replies, err := ParseDeviceReplies(msgs)
+			assert.NoError(t, err)
+			assert.Len(t, replies, 1)
+			assert.Equal(t, tt.want, replies[0].FrequencyMonitor)
+		})
+	}
+}
+
+// TestParsePinReplies_MeasuredFrequency verifies that ParsePinReplies correctly
+// decodes the DpllPinMeasuredFrequency attribute into PinInfo.MeasuredFrequency.
+func TestParsePinReplies_MeasuredFrequency(t *testing.T) {
+	tests := []struct {
+		name  string
+		mfreq uint64
+	}{
+		{"10 MHz expressed as millihertz", 10_000_000_000},
+		{"zero", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ae := netlink.NewAttributeEncoder()
+			ae.Uint32(DpllPinID, 1)
+			ae.Uint64(DpllPinMeasuredFrequency, tt.mfreq)
+			payload, err := ae.Encode()
+			assert.NoError(t, err)
+
+			msgs := []genetlink.Message{{Data: payload}}
+			replies, err := ParsePinReplies(msgs)
+			assert.NoError(t, err)
+			assert.Len(t, replies, 1)
+			assert.Equal(t, tt.mfreq, replies[0].MeasuredFrequency)
+		})
+	}
+}
+
+// TestParsePinReplies_Operstate verifies that ParsePinReplies correctly
+// decodes the top-level DpllPinOperstate attribute into PinInfo.Operstate.
+func TestParsePinReplies_Operstate(t *testing.T) {
+	tests := []struct {
+		name      string
+		operstate uint32
+	}{
+		{"active", PinOperstateActive},
+		{"standby", PinOperstateStandby},
+		{"no-signal", PinOperstateNoSignal},
+		{"qual-failed", PinOperstateQualFailed},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ae := netlink.NewAttributeEncoder()
+			ae.Uint32(DpllPinID, 1)
+			ae.Uint32(DpllPinOperstate, tt.operstate)
+			payload, err := ae.Encode()
+			assert.NoError(t, err)
+
+			msgs := []genetlink.Message{{Data: payload}}
+			replies, err := ParsePinReplies(msgs)
+			assert.NoError(t, err)
+			assert.Len(t, replies, 1)
+			assert.Equal(t, tt.operstate, replies[0].Operstate)
+		})
+	}
+}
+
+// TestParsePinReplies_ParentDeviceNewFields verifies that ParsePinReplies correctly
+// decodes operstate, FFO, and FFO-PPT from the pin-parent-device nest.
+func TestParsePinReplies_ParentDeviceNewFields(t *testing.T) {
+	const parentID = uint32(7)
+	const operstate = uint32(PinOperstateActive)
+	const ffo = int32(-42)
+	const ffoPPT = int32(12345)
+
+	ae := netlink.NewAttributeEncoder()
+	ae.Uint32(DpllPinID, 1)
+	ae.Nested(DpllPinParentDevice, func(nae *netlink.AttributeEncoder) error {
+		nae.Uint32(DpllPinParentID, parentID)
+		nae.Uint32(DpllPinOperstate, operstate)
+		nae.Int32(DpllPinFractionalFrequencyOffset, ffo)
+		nae.Int32(DpllPinFractionalFrequencyOffsetPPT, ffoPPT)
+		return nil
+	})
+	payload, err := ae.Encode()
+	assert.NoError(t, err)
+
+	msgs := []genetlink.Message{{Data: payload}}
+	replies, err := ParsePinReplies(msgs)
+	assert.NoError(t, err)
+	assert.Len(t, replies, 1)
+	assert.Len(t, replies[0].ParentDevice, 1)
+	pd := replies[0].ParentDevice[0]
+	assert.Equal(t, parentID, pd.ParentID)
+	assert.Equal(t, operstate, pd.Operstate)
+	assert.Equal(t, int(ffo), pd.FractionalFrequencyOffset)
+	assert.Equal(t, int(ffoPPT), pd.FractionalFrequencyOffsetPPT)
+}

--- a/pkg/dpll/dpll.go
+++ b/pkg/dpll/dpll.go
@@ -431,7 +431,12 @@ func (d *DpllConfig) ActivePhaseOffsetPin(pin *nl.PinInfo) (int, bool) {
 		return -1, false
 	}
 	for i, p := range pin.ParentDevice {
-		if p.State != nl.PinStateConnected || p.Direction != nl.PinDirectionInput {
+		// Legacy behavior: An input pin was considered "connected" if it acted as a source.
+		// New behavior: An input pin is the device synchronization source when its OperState is "active".
+		// Note: In this scenario, the administrative state never exceeds "selectable".
+		if (p.State != nl.PinStateConnected && p.Operstate != nl.PinOperstateActive) || p.Direction != nl.PinDirectionInput {
+			glog.Infof("pin id %d parentID=%d skipped: direction=%s adminState=%s operstate=%s",
+				pin.ID, p.ParentID, nl.GetPinDirection(p.Direction), nl.GetPinState(p.State), nl.GetPinOperstate(p.Operstate))
 			continue
 		}
 		for _, dev := range d.devices {


### PR DESCRIPTION
Newer DPLL drivers differentiate between an input pin's administrative and operational states. When the operational state is supported, the legacy state maps to the administrative state. Because the administrative state is capped at "selectable", it fails the legacy pin state filter.

Add pin-operstate, measured-frequency, frequency-monitor to dpll-netlink Accommodate dpll kernel spec additions: new pin-operstate enum (active/standby/no-signal/qual-failed), measured-frequency pin attr in millihertz, frequency-monitor device feature flag, and operstate/ffo/ffo-ppt fields inside pin-parent-device nest. Extends ParseDeviceReplies, ParsePinReplies, all HR structs, and adds table-driven unit tests for every new decode path. Modify the filter to accept phase offsets from either:
- "connected" input pins (legacy drivers)
- Input pins with an "active" operational state (new drivers)

Assisted by Cursor