### PR TITLE
OCPBUGS-87869: Allow phase offsets from Active state pins

### DIFF
--- a/pkg/dpll-netlink/dpll-uapi.go
+++ b/pkg/dpll-netlink/dpll-uapi.go
@@ -265,22 +265,26 @@ func GetClockQualityLevels(cqs []uint32) string {
 
 // GetClockQualityLevel returns clock quality level as a string
 func GetClockQualityLevel(cq uint32) string {
-	clockQualityLevelMap := map[uint32]string{
-		ClockQualityLevel:             "itu-opt1-prc",
-		ClockQualityLevelITUOpt1PRC:   "itu-opt1-prc",
-		ClockQualityLevelITUOpt1SSUA:  "itu-opt1-ssua",
-		ClockQualityLevelITUOpt1SSUB:  "itu-opt1-ssub",
-		ClockQualityLevelITUOpt1EEC1:  "itu-opt1-eec1",
-		ClockQualityLevelITUOpt1PRTC:  "itu-opt1-prtc",
-		ClockQualityLevelITUOpt1EPRTC: "itu-opt1-eprtc",
-		ClockQualityLevelITUOpt1EEEC:  "itu-opt1-eeec",
-		ClockQualityLevelItuOpt1EPRC:  "itu-opt1-eprc",
+	switch cq {
+	case ClockQualityLevel, ClockQualityLevelITUOpt1PRC:
+		return "itu-opt1-prc"
+	case ClockQualityLevelITUOpt1SSUA:
+		return "itu-opt1-ssua"
+	case ClockQualityLevelITUOpt1SSUB:
+		return "itu-opt1-ssub"
+	case ClockQualityLevelITUOpt1EEC1:
+		return "itu-opt1-eec1"
+	case ClockQualityLevelITUOpt1PRTC:
+		return "itu-opt1-prtc"
+	case ClockQualityLevelITUOpt1EPRTC:
+		return "itu-opt1-eprtc"
+	case ClockQualityLevelITUOpt1EEEC:
+		return "itu-opt1-eeec"
+	case ClockQualityLevelItuOpt1EPRC:
+		return "itu-opt1-eprc"
+	default:
+		return unknownStr
 	}
-	cqStr, found := clockQualityLevelMap[cq]
-	if found {
-		return cqStr
-	}
-	return unknownStr
 }
 
 // DpllTypeAttribute defines DPLL types

--- a/pkg/dpll/dpll.go
+++ b/pkg/dpll/dpll.go
@@ -429,7 +429,12 @@ func (d *DpllConfig) ActivePhaseOffsetPin(pin *nl.PinInfo) (int, bool) {
 		return -1, false
 	}
 	for i, p := range pin.ParentDevice {
-		if p.State != nl.PinStateConnected || p.Direction != nl.PinDirectionInput {
+		// Legacy behavior: An input pin was considered "connected" if it acted as a source.
+		// New behavior: An input pin is the device synchronization source when its OperState is "active".
+		// Note: In this scenario, the administrative state never exceeds "selectable".
+		if (p.State != nl.PinStateConnected && p.Operstate != nl.PinOperstateActive) || p.Direction != nl.PinDirectionInput {
+			glog.Infof("pin id %d parentID=%d skipped: direction=%s adminState=%s operstate=%s",
+				pin.ID, p.ParentID, nl.GetPinDirection(p.Direction), nl.GetPinState(p.State), nl.GetPinOperstate(p.Operstate))
 			continue
 		}
 		for _, dev := range d.devices {


### PR DESCRIPTION
Newer DPLL drivers differentiate between an input pin's administrative and operational states. When the operational state is supported, the legacy state maps to the administrative state. Because the administrative state is capped at "selectable", it fails the legacy pin state filter.

Add pin-operstate, measured-frequency, frequency-monitor to dpll-netlink Accommodate dpll kernel spec additions: new pin-operstate enum (active/standby/no-signal/qual-failed), measured-frequency pin attr in millihertz, frequency-monitor device feature flag, and operstate/ffo/ffo-ppt fields inside pin-parent-device nest. Extends ParseDeviceReplies, ParsePinReplies, all HR structs, and adds table-driven unit tests for every new decode path. Modify the filter to accept phase offsets from either:
- "connected" input pins (legacy drivers)
- Input pins with an "active" operational state (new drivers)

Assisted by Cursor