### PR TITLE
OCPBUGS-88741: [4.22] Fix gnr-d initialization

### DIFF
--- a/addons/intel/e825.go
+++ b/addons/intel/e825.go
@@ -61,6 +61,27 @@ func tbcConfigured(nodeProfile *ptpv1.PtpProfile) bool {
 	return nodeProfile.PtpSettings["clockType"] == "T-BC"
 }
 
+func leadingInterfaceForPinReset(nodeProfile *ptpv1.PtpProfile, devices []string) string {
+	if nodeProfile.PtpSettings != nil {
+		if device := nodeProfile.PtpSettings["leadingInterface"]; device != "" {
+			return device
+		}
+	}
+	if len(devices) > 0 {
+		return devices[0]
+	}
+	return ""
+}
+
+func applyNicPinReset(device string) {
+	if device == "" {
+		return
+	}
+	if err := pinConfig.applyPinSet(device, bcDpllPinReset); err != nil {
+		glog.Errorf("Could not apply BC pin reset to %s: %s", device, err)
+	}
+}
+
 // OnPTPConfigChangeE825 performs actions on PTP config change for e825 plugin
 func OnPTPConfigChangeE825(data *interface{}, nodeProfile *ptpv1.PtpProfile) error {
 	pluginData := (*data).(*E825PluginData)
@@ -146,6 +167,10 @@ func OnPTPConfigChangeE825(data *interface{}, nodeProfile *ptpv1.PtpProfile) err
 
 			updateLeapManagerSources(e825Opts.Gnss.LeapSources)
 
+			if !e825Opts.Gnss.Disabled {
+				applyNicPinReset(leadingInterfaceForPinReset(nodeProfile, allDevices))
+			}
+
 			// BC sanity check and pin setup
 			if tbcConfigured(nodeProfile) {
 				if _, ok := nodeProfile.PtpSettings["upstreamPort"]; !ok {
@@ -155,11 +180,7 @@ func OnPTPConfigChangeE825(data *interface{}, nodeProfile *ptpv1.PtpProfile) err
 					// TODO: We could actually figure this out based on upstreamPort... And the fact that there's only one NAC per GNR-D
 					return errors.New("GNR-D T-BC must set leadingInterface")
 				}
-				device := nodeProfile.PtpSettings["leadingInterface"]
-				err = pinConfig.applyPinSet(device, bcDpllPinReset)
-				if err != nil {
-					glog.Errorf("Could not apply BC pin reset to %s: %s", device, err)
-				}
+				applyNicPinReset(nodeProfile.PtpSettings["leadingInterface"])
 				if inputPinErr := pluginData.setupDpllInputPins(); inputPinErr != nil {
 					glog.Errorf("Could not enable DPLL input pins for T-BC: %s", inputPinErr)
 				}

--- a/addons/intel/e825_test.go
+++ b/addons/intel/e825_test.go
@@ -445,6 +445,7 @@ func Test_OnPTPConfigChangeE825(t *testing.T) {
 		{
 			name:             "TGM Profile",
 			profile:          "./testdata/e825-tgm.yaml",
+			expectedPinSets:  2,
 			expectedDpllCmds: 1,
 		},
 		{

--- a/pkg/hardwareconfig/hardware-vendor/dell/XR8720t/behavior-profiles.yaml
+++ b/pkg/hardwareconfig/hardware-vendor/dell/XR8720t/behavior-profiles.yaml
@@ -32,6 +32,27 @@ behaviorProfiles:
                 state: disconnected
               pps:
                 state: disconnected
+          - dpll:
+              subsystem: "{subsystem}"
+              boardLabel: "{ptpInputPin}"
+              eec:
+                state: disconnected
+              pps:
+                state: selectable
+          - dpll:
+              subsystem: "{subsystem}"
+              boardLabel: GNSS_10M_IN
+              eec:
+                state: disconnected
+              pps:
+                state: disconnected
+          - dpll:
+              subsystem: "{subsystem}"
+              boardLabel: ETH01_SDP_TIMESYNC_2
+              eec:
+                state: disconnected
+              pps:
+                state: selectable
           - ptpPin:
               name: SDP2
               func: Disabled

--- a/pkg/hardwareconfig/hardware-vendor/hpe/EL140-Gen12/behavior-profiles.yaml
+++ b/pkg/hardwareconfig/hardware-vendor/hpe/EL140-Gen12/behavior-profiles.yaml
@@ -9,7 +9,7 @@ behaviorProfiles:
     pinRoles:
       gnssInputPin: GNSS_1PPS_IN  # DPLL pin used for GNSS input (that should be disabled for T-BC)
       ptpInputPin: 1PPS_IN0 # DPLL pin used for PTP input
-    
+
     # Source template - will be instantiated with resolved variables
     sources:
       - name: PTP
@@ -32,6 +32,27 @@ behaviorProfiles:
                 state: disconnected
               pps:
                 state: disconnected
+          - dpll:
+              subsystem: "{subsystem}"
+              boardLabel: "{ptpInputPin}"
+              eec:
+                state: disconnected
+              pps:
+                state: selectable
+          - dpll:
+              subsystem: "{subsystem}"
+              boardLabel: GNSS_10M_IN
+              eec:
+                state: disconnected
+              pps:
+                state: disconnected
+          - dpll:
+              subsystem: "{subsystem}"
+              boardLabel: 1PPS_IN1
+              eec:
+                state: disconnected
+              pps:
+                state: selectable
           - ptpPin:
               name: SDP2
               func: Disabled


### PR DESCRIPTION
Cherry-pick from main to 4.22
Before the fix, both T-GM and T-BC left hardware configurations that could interfere with the other profile.
- T-GM e825 plugin initialized all pins (including both PTP input pins) as selectable for both eec and pps parent devices.
- TBC enabled 1PPS and 1kHz outputs to DPLL

These configurations impacted the clock operation in the following ways:
- T-BC had EEC input enabled and locking, creating a parasitic feedback loop resulted in `ptp4l` offset oscillations and the servo failing to converge
- T-GM was working with PHC sync outputs available for DPLL to consider as a source. As a result, the eec could lock on GNSS and the pps - pn the PHC

The fix:
- T-GM will disable e825 outputs to DPLL on init
- T-BC eill disable both GNSS inputs and the eec input

Assisted by Cursor