### PR TITLE
OCPBUGS-91642: Fix chronyd NTP failover: stop/start process instead of chronyc offli…

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1862,11 +1862,14 @@ func (p *ptpProcess) cmdSetEnabled(enabled bool) {
 	switch p.name {
 	case "chronyd":
 		if enabled {
-			_, _ = exec.Command("chronyc", "-h", ChronydSocketPath, "online").Output()
-			processStatus(p.c, p.name, p.messageTag, PtpProcessUp)
+			if p.Stopped() && p.cmd != nil {
+				cmd := p.cmd
+				newCmd := exec.Command(cmd.Args[0], cmd.Args[1:]...)
+				p.cmd = newCmd
+				go p.cmdRun(p.dn.stdoutToSocket, &(p.dn.pluginManager))
+			}
 		} else {
-			_, _ = exec.Command("chronyc", "-h", ChronydSocketPath, "offline").Output()
-			processStatus(p.c, p.name, p.messageTag, PtpProcessDown)
+			go p.cmdStop()
 		}
 	case "phc2sys":
 		if enabled {


### PR DESCRIPTION
Fix chronyd NTP failover:

The chronyc offline command was unreliable — chronyd could re-acquire NTP sources despite being told to go offline, causing clock frequency interference with phc2sys (clockcheck events). Replace with process stop/start, using the same pattern as phc2sys.

The disable path uses `go p.cmdStop()` (non-blocking) to avoid a deadlock: cmdStop blocks on exitCh, but the ntpfailover FSM callback runs inside the process scanner goroutine which must finish before cmdRun can send to exitCh.