### PR TITLE
CNF-22056, CNF-22693, CNF-25167, OCPBUGS-85586, OCPBUGS-93744: Sync from upstream (30-Jun-2026)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ COPY deploy deploy
 COPY hack hack
 COPY Makefile Makefile
 COPY pkg pkg
-COPY .git .git
-
+ARG GIT_COMMIT=unknown
+ENV GIT_COMMIT=${GIT_COMMIT}
 RUN --mount=type=cache,target=/root/.cache/go-build make
 
 FROM quay.io/centos/centos:stream9

--- a/hack/build-image.sh
+++ b/hack/build-image.sh
@@ -6,4 +6,5 @@ IMAGE_TAG_BASE="${IMAGE_TAG_BASE:-ghcr.io/k8snetworkplumbingwg/${IMAGE_NAME}}"
 VERSION="${VERSION:-latest}"
 IMG="${IMAGE_TAG_BASE}:${VERSION}"
 
-$CONTAINER_TOOL build -t "${IMG}"  -f ./Dockerfile .
+GIT_COMMIT="${GIT_COMMIT:-$(git rev-list -1 HEAD 2>/dev/null || echo unknown)}"
+$CONTAINER_TOOL build --build-arg GIT_COMMIT="${GIT_COMMIT}" -t "${IMG}" -f ./Dockerfile .

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -3,6 +3,10 @@
 ORG_PATH="github.com/k8snetworkplumbingwg"
 REPO_PATH="${ORG_PATH}/linuxptp-daemon"
 
-GIT_COMMIT=$(git rev-list -1 HEAD)
+# GIT_COMMIT can be set via:
+#   1. Environment variable (e.g. Dockerfile ARG/ENV)
+#   2. Git repository (local builds)
+#   3. Falls back to "unknown"
+GIT_COMMIT="${GIT_COMMIT:-$(git rev-list -1 HEAD 2>/dev/null || echo unknown)}"
 LINKER_RELEASE_FLAGS="-X main.GitCommit=${GIT_COMMIT}"
 go build -ldflags "${LINKER_RELEASE_FLAGS}" --mod=vendor "$@" -o bin/ptp ${REPO_PATH}/cmd

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -451,6 +451,12 @@ func (conf *Ptp4lConf) RenderPtp4lConf() (configOut string, ifaces config.IFaces
 
 			if source, ok := conf.getPtp4lConfOptionOrEmptyString(section.sectionName, "ts2phc.master"); ok {
 				iface.Source = getSource(source)
+				// when a [nmea] section with `ts2phc.master 1` exists, each interface with `ts2phc.master 0`
+				// marks a time sink whose PHC is disciplined by the [nmea] GNSS master, and should be labeled as GNSS.
+				// This requires that the [nmea] section precedes the interface section in the config
+				if iface.Source == event.PPS && nmea_source == event.GNSS {
+					iface.Source = event.GNSS
+				}
 			} else {
 				// if not defined here, use source defined at nmea section
 				iface.Source = nmea_source

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -174,7 +174,8 @@ func NewProcessManager() *ProcessManager {
 
 // SetTestProfileProcess ...
 func (p *ProcessManager) SetTestProfileProcess(name string, ifaces config.IFaces, socketPath,
-	processConfigPath string, nodeProfile ptpv1.PtpProfile) {
+	processConfigPath string, nodeProfile ptpv1.PtpProfile,
+) {
 	p.process = append(p.process, &ptpProcess{
 		name:              name,
 		ifaces:            ifaces,
@@ -235,7 +236,6 @@ func (p *ProcessManager) UpdateSynceConfig(config *synce.Relations) {
 		return
 	}
 	p.process[0].syncERelations = config
-
 }
 
 // EmitProcessStatusLogs emits process status logs using the EventHandler's
@@ -565,7 +565,7 @@ func New(
 		// Watch the known security mount folder from startup
 		if watchErr := saFileWatch.Add(PtpSecretMountDir); watchErr != nil {
 			glog.Warningf("Failed to watch %s (may not exist yet): %v", PtpSecretMountDir, watchErr)
-			//destroy and release the watcher
+			// destroy and release the watcher
 			saFileWatch.Close()
 			saFileWatch = nil
 		} else {
@@ -748,7 +748,7 @@ func (dn *Daemon) applyNodePTPProfiles() error {
 	// compare nodeProfile with previous config,
 	// only apply when nodeProfile changes
 
-	//clear hwconfig before updating
+	// clear hwconfig before updating
 	*dn.hwconfigs = []ptpv1.HwConfig{}
 
 	glog.Infof("updating NodePTPProfiles to:")
@@ -756,7 +756,7 @@ func (dn *Daemon) applyNodePTPProfiles() error {
 	slices.SortFunc(dn.ptpUpdate.NodeProfiles, func(a, b ptpv1.PtpProfile) int {
 		aHasPhc2sysOpts := a.Phc2sysOpts != nil && *a.Phc2sysOpts != ""
 		bHasPhc2sysOpts := b.Phc2sysOpts != nil && *b.Phc2sysOpts != ""
-		//sorted in ascending order
+		// sorted in ascending order
 		// here having phc2sysOptions is considered a high number
 		if !aHasPhc2sysOpts && bHasPhc2sysOpts {
 			return -1 //  a<b return -1
@@ -826,33 +826,28 @@ func (dn *Daemon) applyNodePTPProfiles() error {
 	for _, p := range dn.processManager.process {
 		if p != nil {
 			p.eventCh = dn.processManager.eventChannel
-			// start ptp4l process early , it doesn't have
-			if p.depProcess == nil {
-				go p.cmdRun(dn.stdoutToSocket, &dn.pluginManager)
-			} else {
-				for _, d := range p.depProcess {
-					if d != nil {
-						time.Sleep(3 * time.Second)
-						glog.Infof("Starting %s", d.Name())
-						go d.CmdRun(false)
-						time.Sleep(3 * time.Second)
-						dn.pluginManager.AfterRunPTPCommand(&p.nodeProfile, d.Name())
-						d.MonitorProcess(config.ProcessConfig{
-							ClockType:    p.clockType,
-							ConfigName:   p.configName,
-							EventChannel: dn.processManager.eventChannel,
-							GMThreshold: config.Threshold{
-								Max:             p.ptpClockThreshold.MaxOffsetThreshold,
-								Min:             p.ptpClockThreshold.MinOffsetThreshold,
-								HoldOverTimeout: p.ptpClockThreshold.HoldOverTimeout,
-							},
-							InitialPTPState: event.PTP_FREERUN,
-						})
-						glog.Infof("enabling dep process %s with Max %d Min %d Holdover %d", d.Name(), p.ptpClockThreshold.MaxOffsetThreshold, p.ptpClockThreshold.MinOffsetThreshold, p.ptpClockThreshold.HoldOverTimeout)
-					}
+			for _, d := range p.depProcess {
+				if d != nil {
+					time.Sleep(3 * time.Second)
+					glog.Infof("Starting %s", d.Name())
+					go d.CmdRun(false)
+					time.Sleep(3 * time.Second)
+					dn.pluginManager.AfterRunPTPCommand(&p.nodeProfile, d.Name())
+					d.MonitorProcess(config.ProcessConfig{
+						ClockType:    p.clockType,
+						ConfigName:   p.configName,
+						EventChannel: dn.processManager.eventChannel,
+						GMThreshold: config.Threshold{
+							Max:             p.ptpClockThreshold.MaxOffsetThreshold,
+							Min:             p.ptpClockThreshold.MinOffsetThreshold,
+							HoldOverTimeout: p.ptpClockThreshold.HoldOverTimeout,
+						},
+						InitialPTPState: event.PTP_FREERUN,
+					})
+					glog.Infof("enabling dep process %s with Max %d Min %d Holdover %d", d.Name(), p.ptpClockThreshold.MaxOffsetThreshold, p.ptpClockThreshold.MinOffsetThreshold, p.ptpClockThreshold.HoldOverTimeout)
 				}
-				go p.cmdRun(dn.stdoutToSocket, &dn.pluginManager)
 			}
+			go p.cmdRun(dn.stdoutToSocket, &dn.pluginManager)
 			dn.pluginManager.AfterRunPTPCommand(&p.nodeProfile, p.name)
 		}
 	}
@@ -922,7 +917,8 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 			if _, registered := dn.pluginManager.Plugins[pluginName]; !registered {
 				pluginErrors = append(pluginErrors, fmt.Errorf(
 					"unknown plugin '%s' in profile '%s' (possible typo in hardware plugin configuration)",
-					pluginName, *nodeProfile.Name))
+					pluginName, *nodeProfile.Name,
+				))
 			}
 		}
 	}
@@ -1049,7 +1045,7 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 							*configOpts += " --servo_offset_threshold " + strconv.FormatInt(min(maxInSpecOffset, maxHoldoverOffSet), 10)
 						}
 					}
-					if !strings.Contains(*configOpts, "--servo_num_offset_values") { //if consecutive smaller offsets (less than the threshold) are not observed, the system stays in S2
+					if !strings.Contains(*configOpts, "--servo_num_offset_values") { // if consecutive smaller offsets (less than the threshold) are not observed, the system stays in S2
 						*configOpts += " --servo_num_offset_values 10"
 					}
 				}
@@ -1097,7 +1093,7 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 			output.profile_name = *nodeProfile.Name
 		}
 
-		//output, messageTag, socketPath, GPSPIPE_SERIALPORT, update_leapfile, os.Getenv("NODE_NAME")
+		// output, messageTag, socketPath, GPSPIPE_SERIALPORT, update_leapfile, os.Getenv("NODE_NAME")
 
 		// This adds the flags needed for monitor
 		addFlagsForMonitor(pProcess, configOpts, output, dn.stdoutToSocket)
@@ -1145,8 +1141,10 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 			haProfile:         haProfile,
 			syncERelations:    relations,
 			logParser:         getParser(pProcess),
-			tBCAttributes: tBCProcessAttributes{ttPortsConfigFile: controlledConfigFile, trPortsConfigFile: configFile,
-				lastReportedState: event.PTP_NOTSET, lastAppliedState: event.PTP_NOTSET, offsetFilter: nil},
+			tBCAttributes: tBCProcessAttributes{
+				ttPortsConfigFile: controlledConfigFile, trPortsConfigFile: configFile,
+				lastReportedState: event.PTP_NOTSET, lastAppliedState: event.PTP_NOTSET, offsetFilter: nil,
+			},
 			handler: dn.processManager.ptpEventHandler,
 			dn:      dn,
 		}
@@ -1360,7 +1358,7 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 				}
 			}
 		}
-		err = os.WriteFile(configPath, []byte(configOutput), 0644)
+		err = os.WriteFile(configPath, []byte(configOutput), 0o644)
 		if err != nil {
 			printNodeProfile(nodeProfile)
 			return fmt.Errorf("failed to write the configuration file named %s: %v", configPath, err)
@@ -1835,7 +1833,7 @@ func (p *ptpProcess) processPTPMetrics(output string) {
 				}
 			}
 			// ts2phc has to be handled differently since it announce holdover state when gnss is lost
-			//TODO: verify how 1pps is handled when lost
+			// TODO: verify how 1pps is handled when lost
 			switch clockState {
 			case FREERUN:
 				state = event.PTP_FREERUN
@@ -1894,17 +1892,19 @@ func (p *ptpProcess) cmdSetEnabled(enabled bool) {
 		} else {
 			go p.cmdStop()
 		}
-	case "phc2sys":
+	case phc2sysProcessName:
 		if enabled {
 			if p.Stopped() && p.cmd != nil {
 				cmd := p.cmd
 				newCmd := exec.Command(cmd.Args[0], cmd.Args[1:]...)
 				p.cmd = newCmd
-				go p.cmdRun(p.dn.stdoutToSocket, &(p.dn.pluginManager))
+				go p.cmdRun(p.dn.stdoutToSocket, &p.dn.pluginManager)
 			}
 		} else {
 			p.cmdStop()
 		}
+	default:
+		glog.Warningf("cmdSetEnabled called for unhandled process %s", p.name)
 	}
 }
 
@@ -1939,7 +1939,7 @@ func (p *ptpProcess) ProcessTs2PhcEvents(ptpOffset float64, source string, iface
 	}
 
 	if source == ts2phcProcessName { // for ts2phc send it to event to create metrics and events
-		var values = make(map[event.ValueType]interface{})
+		values := make(map[event.ValueType]interface{})
 
 		values[event.OFFSET] = ptpOffsetInt64
 		for k, v := range extraValue {
@@ -2265,7 +2265,7 @@ func (p *ptpProcess) ProcessSynceEvents(logEntry synce.LogEntry) {
 					}
 
 					state = sDeviceConfig.LastClockState
-				} else if logEntry.QL != synce.QL_DEFAULT_SSM { //else we have only QL
+				} else if logEntry.QL != synce.QL_DEFAULT_SSM { // else we have only QL
 					lastQLState.SSM = logEntry.QL // wait for extTlv
 				}
 			}
@@ -2297,8 +2297,8 @@ func (p *ptpProcess) ProcessSynceEvents(logEntry synce.LogEntry) {
 		default:
 		}
 	}
-
 }
+
 func (p *ptpProcess) SyncEDeviceByInterface(iface string) *synce.Config {
 	if p.syncERelations != nil {
 		for _, sConfig := range p.syncERelations.Devices {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -45,8 +45,18 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+// PtpNamespace is the namespace where PTP resources are managed.
+// It defaults to "openshift-ptp" and can be overridden via the
+// NAME_SPACE env var for OLMv1 AllNamespaces install mode.
+var PtpNamespace = "openshift-ptp"
+
+func init() {
+	if ns := os.Getenv("NAME_SPACE"); ns != "" {
+		PtpNamespace = ns
+	}
+}
+
 const (
-	PtpNamespace                    = "openshift-ptp"
 	PTP4L_CONF_FILE_PATH            = "/etc/ptp4l.conf"
 	PTP4L_CONF_DIR                  = "/ptp4l-conf"
 	connectionRetryInterval         = 1 * time.Second

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1589,6 +1589,11 @@ func (p *ptpProcess) processTBCTransitionLegacy(output string, pm *plugin.Plugin
 	}
 	if portMatched {
 		if strings.Contains(output, "to SLAVE on MASTER_CLOCK_SELECTED") {
+			portName := parser.ExtractPortName(output)
+			if portName != "" {
+				p.tBCAttributes.activePort = portName
+				glog.Infof("T-BC active upstream port: %s", portName)
+			}
 			p.tBCAttributes.lastReportedState = event.PTP_LOCKED
 			p.tBCAttributes.offsetFilter = utils.NewWindow(offsetFilterSize)
 		} else if strings.Contains(output, "to MASTER on ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES") ||

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -159,6 +159,17 @@ type ProcessManager struct {
 	daemon          *Daemon
 }
 
+// findProcessesByName returns a list of processes with the given name
+func (p *ProcessManager) findProcessesByName(name string) []*ptpProcess {
+	var procs []*ptpProcess
+	for _, proc := range p.process {
+		if proc != nil && proc.name == name {
+			procs = append(procs, proc)
+		}
+	}
+	return procs
+}
+
 // NewProcessManager is used by unit tests
 func NewProcessManager() *ProcessManager {
 	processPTP := &ptpProcess{}
@@ -327,6 +338,7 @@ type ptpProcess struct {
 	cmdSetEnabledMutex    sync.Mutex
 	tbcStateDetector      *hardwareconfig.PTPStateDetector // Cached PTP state detector instance
 	offset                float64
+	skipInitialStartup    string
 }
 
 func (p *ptpProcess) Stopped() bool {
@@ -440,6 +452,9 @@ type Daemon struct {
 	// socket until the replay (/emit-logs) completes. This ensures CEP
 	// processes replay state before any live data arrives.
 	liveGate *liveGate
+
+	delayedPhc2sys   atomic.Bool
+	delayedPhc2sysMu sync.Mutex // protects skipInitialStartup on phc2sys processes
 }
 
 // UpdateHardwareConfig implements controller.HardwareConfigUpdateHandler.
@@ -847,8 +862,21 @@ func (dn *Daemon) applyNodePTPProfiles() error {
 					glog.Infof("enabling dep process %s with Max %d Min %d Holdover %d", d.Name(), p.ptpClockThreshold.MaxOffsetThreshold, p.ptpClockThreshold.MinOffsetThreshold, p.ptpClockThreshold.HoldOverTimeout)
 				}
 			}
+			if p.skipInitialStartup != "" {
+				glog.Infof("Delaying %s startup: %s", p.name, p.skipInitialStartup)
+				continue
+			}
 			go p.cmdRun(dn.stdoutToSocket, &dn.pluginManager)
 			dn.pluginManager.AfterRunPTPCommand(&p.nodeProfile, p.name)
+		}
+	}
+	// Arm the delayed-phc2sys flag now that the startup loop is complete.
+	// Keeping it false during the loop ensures HandleDelayedPhc2sysStartup
+	// cannot clear skipInitialStartup and race with the loop's skip check.
+	for _, p := range dn.processManager.process {
+		if p != nil && p.skipInitialStartup != "" {
+			dn.delayedPhc2sys.Store(true)
+			break
 		}
 	}
 	dn.pluginManager.PopulateHwConfig(dn.hwconfigs)
@@ -1196,6 +1224,13 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 				// TODO addScheduling
 				dprocess.depProcess = append(dprocess.depProcess, pmcProcess)
 			}
+		} else if pProcess == phc2sysProcessName {
+			glog.Infof("Setting up phc2sys (%s)", clockType)
+			// Delay phc2sys startup until the clock source has synchronized.
+			dn.delayedPhc2sysMu.Lock()
+			dprocess.skipInitialStartup = "waiting for PHC synchronization before adjusting system time"
+			dn.delayedPhc2sysMu.Unlock()
+			glog.Infof("Delaying phc2sys startup: %s", dprocess.skipInitialStartup)
 		} else if pProcess == ts2phcProcessName { //& if the x plugin is enabled
 			if clockType == event.GM {
 				if output.gnss_serial_port == "" {
@@ -1928,6 +1963,46 @@ func (p *ptpProcess) MonitorEvent(offset float64, clockState string) {
 	// not implemented
 }
 
+// HandleDelayedPhc2sysStartup checks if phc2sys was delayed and if the current offset is within the 1s threshold, starts it.
+func (dn *Daemon) HandleDelayedPhc2sysStartup(source string, offset float64, profileName *string) {
+	if profileName == nil {
+		return
+	}
+	if !dn.delayedPhc2sys.Load() {
+		return
+	}
+	if math.Abs(offset) < 1000000000 {
+		dn.delayedPhc2sysMu.Lock()
+		defer dn.delayedPhc2sysMu.Unlock()
+		if !dn.delayedPhc2sys.Load() { // re-check under lock
+			return
+		}
+		for _, proc := range dn.processManager.findProcessesByName(phc2sysProcessName) {
+			if proc.skipInitialStartup == "" || proc.nodeProfile.Name == nil {
+				continue
+			}
+			// Match if the reporting process is in the same profile as phc2sys,
+			// or in one of phc2sys's HA-linked profiles. The latter handles the
+			// case where phc2sys is in a dedicated profile with no ptp4l of its
+			// own (e.g. test-dual-nic-bc-ha with haProfiles=master1,master2).
+			_, linkedByHA := proc.haProfile[*profileName]
+			if *proc.nodeProfile.Name == *profileName || linkedByHA {
+				glog.Infof("%s offset is %f (sub-second); enabling %s", source, offset, proc.name)
+				proc.skipInitialStartup = ""
+				proc.cmdSetEnabled(true)
+				dn.pluginManager.AfterRunPTPCommand(&proc.nodeProfile, proc.name)
+			}
+		}
+		// Only clear the daemon-wide flag once no phc2sys processes remain delayed.
+		for _, proc := range dn.processManager.findProcessesByName(phc2sysProcessName) {
+			if proc.skipInitialStartup != "" {
+				return
+			}
+		}
+		dn.delayedPhc2sys.Store(false)
+	}
+}
+
 func (p *ptpProcess) ProcessTs2PhcEvents(ptpOffset float64, source string, iface string, state event.PTPState, extraValue map[event.ValueType]interface{}) {
 	var ptpState event.PTPState
 	ptpState = state
@@ -1939,6 +2014,9 @@ func (p *ptpProcess) ProcessTs2PhcEvents(ptpOffset float64, source string, iface
 	}
 
 	if source == ts2phcProcessName { // for ts2phc send it to event to create metrics and events
+		if p.dn != nil {
+			p.dn.HandleDelayedPhc2sysStartup(source, ptpOffset, p.nodeProfile.Name)
+		}
 		values := make(map[event.ValueType]interface{})
 
 		values[event.OFFSET] = ptpOffsetInt64

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1591,8 +1591,12 @@ func (p *ptpProcess) processTBCTransitionLegacy(output string, pm *plugin.Plugin
 		if strings.Contains(output, "to SLAVE on MASTER_CLOCK_SELECTED") {
 			portName := parser.ExtractPortName(output)
 			if portName != "" {
-				p.tBCAttributes.activePort = portName
-				glog.Infof("T-BC active upstream port: %s", portName)
+				if len(p.tBCAttributes.trIfaceNames) > 1 && !slices.Contains(p.tBCAttributes.trIfaceNames, portName) {
+					glog.Warningf("Ignoring non-TR port in legacy MASTER_CLOCK_SELECTED event: %s", portName)
+				} else {
+					p.tBCAttributes.activePort = portName
+					glog.Infof("T-BC active upstream port: %s", portName)
+				}
 			}
 			p.tBCAttributes.lastReportedState = event.PTP_LOCKED
 			p.tBCAttributes.offsetFilter = utils.NewWindow(offsetFilterSize)

--- a/pkg/daemon/daemon_internal_test.go
+++ b/pkg/daemon/daemon_internal_test.go
@@ -1819,6 +1819,41 @@ func TestTBCLegacy_ActiveTRPort_ReportsCorrectInterface(t *testing.T) {
 		"activeTRPort should reflect the newly selected backup port")
 }
 
+func TestTBCLegacy_ActivePort_IgnoresNonTRPort(t *testing.T) {
+	pmStruct, _ := registerPlugins([]string{})
+	pm := &pmStruct
+
+	oldValue := vTbcHasHardwareConfig
+	vTbcHasHardwareConfig = false
+	defer func() { vTbcHasHardwareConfig = oldValue }()
+
+	process := &ptpProcess{
+		tBCAttributes: tBCProcessAttributes{
+			trIfaceNames:      []string{testDUTUpstream1, testDUTUpstream2},
+			perPortState:      map[string]event.PTPState{testDUTUpstream1: event.PTP_LOCKED, testDUTUpstream2: event.PTP_NOTSET},
+			activePort:        testDUTUpstream1,
+			trPortsConfigFile: "test-config",
+			lastReportedState: event.PTP_LOCKED,
+			lastAppliedState:  event.PTP_LOCKED,
+			offsetThreshold:   10.0,
+		},
+		nodeProfile: ptpv1.PtpProfile{
+			Name:        stringPointer("test-profile"),
+			PtpSettings: map[string]string{"leadingInterface": testDUTLeadingIface, testDUTClockIDKey: "123456789"},
+		},
+		eventCh:    make(chan event.Event, 10),
+		configName: "test-config",
+		clockType:  event.BC,
+	}
+
+	// A port with a prefix-colliding name (ens2f10 vs tracked ens2f1) fires MASTER_CLOCK_SELECTED.
+	// The log line contains "ens2f1" as a substring so portMatched is true, but
+	// ExtractPortName returns "ens2f10" which is NOT in trIfaceNames.
+	process.tBCTransitionCheck("ptp4l[300]: [test-config.0.config] port 3 (ens2f10): UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED", pm)
+	assert.Equal(t, testDUTUpstream1, process.tBCAttributes.activePort,
+		"activePort must not change to a non-TR port with a prefix-colliding name")
+}
+
 // TestPtp4lConf_PopulatePtp4lConf_ClockTypeWithCliArgs tests clock_type detection with cliArgs parameter
 func TestPtp4lConf_PopulatePtp4lConf_ClockTypeWithCliArgs(t *testing.T) {
 	tests := []struct {

--- a/pkg/daemon/daemon_internal_test.go
+++ b/pkg/daemon/daemon_internal_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/event"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/hardwareconfig"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/leap"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/utils"
 	ptpv1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v1"
 	ptpv2alpha1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v2alpha1"
 	"github.com/stretchr/testify/assert"
@@ -32,6 +33,13 @@ import (
 )
 
 const testPtp4lOffsetLine = "ptp4l[1.000]: [ptp4l.0.config] master offset 5 s2 freq -1000 path delay 100"
+
+const (
+	testDUTLeadingIface = "ens2f0"
+	testDUTUpstream1    = "ens2f1"
+	testDUTUpstream2    = "ens2f3"
+	testDUTClockIDKey   = "clockId[ens2f0]"
+)
 
 // vendor defaults are embedded; no filesystem setup needed
 
@@ -1651,6 +1659,164 @@ func TestTBCDualUpstream_ActiveTRPort_Helper(t *testing.T) {
 		attrs := &tBCProcessAttributes{}
 		assert.Equal(t, "", attrs.activeTRPort())
 	})
+}
+
+func TestTBCLegacy_Switchover_ActivePortUpdated(t *testing.T) {
+	pmStruct, _ := registerPlugins([]string{})
+	pm := &pmStruct
+
+	oldValue := vTbcHasHardwareConfig
+	vTbcHasHardwareConfig = false
+	defer func() { vTbcHasHardwareConfig = oldValue }()
+
+	process := &ptpProcess{
+		tBCAttributes: tBCProcessAttributes{
+			trIfaceNames:      []string{testDUTUpstream1, testDUTUpstream2},
+			perPortState:      map[string]event.PTPState{testDUTUpstream1: event.PTP_LOCKED, testDUTUpstream2: event.PTP_NOTSET},
+			activePort:        testDUTUpstream1,
+			trPortsConfigFile: "test-config",
+			lastReportedState: event.PTP_LOCKED,
+			lastAppliedState:  event.PTP_LOCKED,
+			offsetThreshold:   10.0,
+		},
+		nodeProfile: ptpv1.PtpProfile{
+			Name:        stringPointer("test-profile"),
+			PtpSettings: map[string]string{"leadingInterface": testDUTLeadingIface, testDUTClockIDKey: "123456789"},
+		},
+		eventCh:    make(chan event.Event, 10),
+		configName: "test-config",
+		clockType:  event.BC,
+		offset:     5.0,
+	}
+
+	// ens2f1 goes down — enters holdover
+	process.tBCTransitionCheck("ptp4l[100]: [test-config.0.config] port 1 ("+testDUTUpstream1+"): SLAVE to FAULTY on FAULT_DETECTED (FT_UNSPECIFIED)", pm)
+	assert.Equal(t, event.PTP_FREERUN, process.tBCAttributes.lastReportedState)
+	assert.Equal(t, event.PTP_HOLDOVER, process.tBCAttributes.lastAppliedState)
+
+	// ens2f3 takes over as SLAVE — activePort should update
+	process.tBCTransitionCheck("ptp4l[200]: [test-config.0.config] port 2 ("+testDUTUpstream2+"): UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED", pm)
+	assert.Equal(t, event.PTP_LOCKED, process.tBCAttributes.lastReportedState)
+	assert.Equal(t, testDUTUpstream2, process.tBCAttributes.activePort,
+		"activePort should update to backup port after switchover")
+	assert.NotNil(t, process.tBCAttributes.offsetFilter)
+}
+
+func TestTBCLegacy_AllPortsLost_EntersHoldover(t *testing.T) {
+	pmStruct, _ := registerPlugins([]string{})
+	pm := &pmStruct
+
+	oldValue := vTbcHasHardwareConfig
+	vTbcHasHardwareConfig = false
+	defer func() { vTbcHasHardwareConfig = oldValue }()
+
+	process := &ptpProcess{
+		tBCAttributes: tBCProcessAttributes{
+			trIfaceNames:      []string{testDUTUpstream1, testDUTUpstream2},
+			perPortState:      map[string]event.PTPState{testDUTUpstream1: event.PTP_LOCKED, testDUTUpstream2: event.PTP_NOTSET},
+			activePort:        testDUTUpstream1,
+			trPortsConfigFile: "test-config",
+			lastReportedState: event.PTP_LOCKED,
+			lastAppliedState:  event.PTP_LOCKED,
+			offsetThreshold:   10.0,
+		},
+		nodeProfile: ptpv1.PtpProfile{
+			Name:        stringPointer("test-profile"),
+			PtpSettings: map[string]string{"leadingInterface": testDUTLeadingIface, testDUTClockIDKey: "123456789"},
+		},
+		eventCh:    make(chan event.Event, 10),
+		configName: "test-config",
+		clockType:  event.BC,
+	}
+
+	// Active port loses SLAVE via ANNOUNCE timeout — enters holdover
+	process.tBCTransitionCheck("ptp4l[100]: [test-config.0.config] port 1 ("+testDUTUpstream1+"): SLAVE to MASTER on ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES", pm)
+	assert.Equal(t, event.PTP_FREERUN, process.tBCAttributes.lastReportedState)
+	assert.Equal(t, event.PTP_HOLDOVER, process.tBCAttributes.lastAppliedState)
+	assert.Nil(t, process.tBCAttributes.offsetFilter)
+}
+
+func TestTBCLegacy_RecoveryFromHoldover(t *testing.T) {
+	pmStruct, _ := registerPlugins([]string{})
+	pm := &pmStruct
+
+	oldValue := vTbcHasHardwareConfig
+	vTbcHasHardwareConfig = false
+	defer func() { vTbcHasHardwareConfig = oldValue }()
+
+	process := &ptpProcess{
+		tBCAttributes: tBCProcessAttributes{
+			trIfaceNames:      []string{testDUTUpstream1, testDUTUpstream2},
+			perPortState:      map[string]event.PTPState{testDUTUpstream1: event.PTP_FREERUN, testDUTUpstream2: event.PTP_NOTSET},
+			trPortsConfigFile: "test-config",
+			lastReportedState: event.PTP_FREERUN,
+			lastAppliedState:  event.PTP_HOLDOVER,
+			offsetThreshold:   10.0,
+		},
+		nodeProfile: ptpv1.PtpProfile{
+			Name:        stringPointer("test-profile"),
+			PtpSettings: map[string]string{"leadingInterface": testDUTLeadingIface, testDUTClockIDKey: "123456789"},
+		},
+		eventCh:    make(chan event.Event, 10),
+		configName: "test-config",
+		clockType:  event.BC,
+		offset:     5.0,
+	}
+
+	// Backup port becomes SLAVE — starts recovery
+	process.tBCTransitionCheck("ptp4l[200]: [test-config.0.config] port 2 ("+testDUTUpstream2+"): UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED", pm)
+	assert.Equal(t, event.PTP_LOCKED, process.tBCAttributes.lastReportedState)
+	assert.Equal(t, testDUTUpstream2, process.tBCAttributes.activePort)
+	assert.NotNil(t, process.tBCAttributes.offsetFilter)
+	assert.Equal(t, event.PTP_HOLDOVER, process.tBCAttributes.lastAppliedState,
+		"should remain in holdover until offset filter converges")
+
+	// Fill offset filter (64 samples) to complete recovery
+	for i := 0; i < 64; i++ {
+		process.tBCTransitionCheck("ptp4l[300]: [test-config.0.config] master offset 5 s2 freq 0 path delay 100", pm)
+	}
+	assert.Equal(t, event.PTP_LOCKED, process.tBCAttributes.lastAppliedState,
+		"should exit holdover after offset filter converges")
+}
+
+func TestTBCLegacy_ActiveTRPort_ReportsCorrectInterface(t *testing.T) {
+	pmStruct, _ := registerPlugins([]string{})
+	pm := &pmStruct
+
+	oldValue := vTbcHasHardwareConfig
+	vTbcHasHardwareConfig = false
+	defer func() { vTbcHasHardwareConfig = oldValue }()
+
+	process := &ptpProcess{
+		tBCAttributes: tBCProcessAttributes{
+			trIfaceNames:      []string{testDUTUpstream1, testDUTUpstream2},
+			perPortState:      map[string]event.PTPState{testDUTUpstream1: event.PTP_NOTSET, testDUTUpstream2: event.PTP_NOTSET},
+			trPortsConfigFile: "test-config",
+			lastAppliedState:  event.PTP_NOTSET,
+			offsetThreshold:   10.0,
+			offsetEventWindow: utils.NewWindow(16),
+		},
+		nodeProfile: ptpv1.PtpProfile{
+			Name:        stringPointer("test-profile"),
+			PtpSettings: map[string]string{"leadingInterface": testDUTLeadingIface, testDUTClockIDKey: "123456789"},
+		},
+		eventCh:    make(chan event.Event, 10),
+		configName: "test-config",
+		clockType:  event.BC,
+		offset:     3.0,
+	}
+
+	// Initially activePort is empty — activeTRPort() returns trIfaceNames[0]
+	assert.Equal(t, testDUTUpstream1, process.tBCAttributes.activeTRPort())
+
+	// testDUTUpstream1 becomes SLAVE
+	process.tBCTransitionCheck("ptp4l[100]: [test-config.0.config] port 1 ("+testDUTUpstream1+"): UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED", pm)
+	assert.Equal(t, testDUTUpstream1, process.tBCAttributes.activeTRPort())
+
+	// Switchover: testDUTUpstream2 becomes SLAVE
+	process.tBCTransitionCheck("ptp4l[200]: [test-config.0.config] port 2 ("+testDUTUpstream2+"): UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED", pm)
+	assert.Equal(t, testDUTUpstream2, process.tBCAttributes.activeTRPort(),
+		"activeTRPort should reflect the newly selected backup port")
 }
 
 // TestPtp4lConf_PopulatePtp4lConf_ClockTypeWithCliArgs tests clock_type detection with cliArgs parameter

--- a/pkg/daemon/daemon_internal_test.go
+++ b/pkg/daemon/daemon_internal_test.go
@@ -90,7 +90,7 @@ func parseClockIDHex(s string) uint64 {
 	return v
 }
 
-func createMockDpllPinsGetterFromFile(path string) (hardwareconfig.DpllPinsGetter, error) {
+func createMockDpllPinsGetterFromFile(path string) (hardwareconfig.DpllPinsGetter, error) { //nolint:unparam
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err

--- a/pkg/daemon/daemon_internal_test.go
+++ b/pkg/daemon/daemon_internal_test.go
@@ -321,6 +321,13 @@ func Test_applyProfile_TGM(t *testing.T) {
 		}
 		assert.Contains(t, depNames, GPSD_PROCESSNAME, "gpsd must be a dependent process of ts2phc for T-GM")
 		assert.Contains(t, depNames, GPSPIPE_PROCESSNAME, "gpspipe must be a dependent process of ts2phc for T-GM")
+
+		for _, d := range ts2phcProc.depProcess {
+			if gpsd, ok := d.(*GPSD); ok {
+				assert.Equal(t, "ens7f0", gpsd.gmInterface,
+					"GPSD gmInterface should match the first interface in ts2phcConf (leading GNSS-sourced interface)")
+			}
+		}
 	}
 
 	// 2. ptp4l should NOT have a PMC dependent process for GM profiles.

--- a/pkg/daemon/daemon_internal_test.go
+++ b/pkg/daemon/daemon_internal_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 const testPtp4lOffsetLine = "ptp4l[1.000]: [ptp4l.0.config] master offset 5 s2 freq -1000 path delay 100"
+const testSkipStartupReason = "delayed"
 
 // vendor defaults are embedded; no filesystem setup needed
 
@@ -127,6 +128,7 @@ func clean(t *testing.T) {
 	err := os.RemoveAll("/tmp/test")
 	assert.NoError(t, err)
 }
+
 func applyTestProfile(t *testing.T, profile *ptpv1.PtpProfile) {
 	stopCh := make(<-chan struct{})
 	assert.NoError(t, leap.MockLeapFile())
@@ -162,7 +164,6 @@ func applyTestProfile(t *testing.T, profile *ptpv1.PtpProfile) {
 }
 
 func testRequirements(t *testing.T, profile *ptpv1.PtpProfile) {
-
 	cfg, err := configparser.NewConfigParserFromFile("/tmp/test/synce4l.0.config")
 	assert.NoError(t, err)
 	for _, sec := range cfg.Sections() {
@@ -179,6 +180,7 @@ func testRequirements(t *testing.T, profile *ptpv1.PtpProfile) {
 		}
 	}
 }
+
 func Test_applyProfile_synce(t *testing.T) {
 	defer clean(t)
 	testDataFiles := []string{
@@ -211,9 +213,18 @@ func Test_applyProfile_TBC(t *testing.T) {
 	}
 	defer hardwareconfig.TeardownMockDpllPinsForTests()
 
-	testDataFiles := []string{
-		"testdata/profile-tbc-tt.yaml",
-		"testdata/profile-tbc-tr.yaml",
+	tests := []struct {
+		dataFile          string
+		expectedProcesses []string
+	}{
+		{
+			dataFile:          "testdata/profile-tbc-tt.yaml",
+			expectedProcesses: []string{ptp4lProcessName},
+		},
+		{
+			dataFile:          "testdata/profile-tbc-tr.yaml",
+			expectedProcesses: []string{ptp4lProcessName, ptp4lProcessName, ts2phcProcessName, phc2sysProcessName},
+		},
 	}
 	stopCh := make(<-chan struct{})
 	assert.NoError(t, leap.MockLeapFile())
@@ -245,13 +256,23 @@ func Test_applyProfile_TBC(t *testing.T) {
 	// Signal that no hardware configs are expected for this test
 	_ = dn.hardwareConfigManager.UpdateHardwareConfig([]ptpv2alpha1.HardwareConfig{})
 
-	for i := range len(testDataFiles) {
+	for _, test := range tests {
 		mkPath(t)
-		profile, err := loadProfile(testDataFiles[i])
+		profile, err := loadProfile(test.dataFile)
 		assert.NoError(t, err)
 		// Will assert inside in case of error:
 		err = dn.applyNodePtpProfile(0, profile)
 		assert.NoError(t, err)
+
+		// Ensure for T-BC that phc2sys is selected for delayed-start
+		actualProcesses := []string{}
+		for _, p := range dn.processManager.process {
+			actualProcesses = append(actualProcesses, p.name)
+			if p.name == phc2sysProcessName {
+				assert.NotEmpty(t, p.skipInitialStartup, "Ensure phc2sys is startup-delayed for T-BC")
+			}
+		}
+		assert.ElementsMatch(t, test.expectedProcesses, actualProcesses, "Ensure T-BC has the required processes prepared (%s)", test.dataFile)
 		clean(t)
 	}
 }
@@ -302,6 +323,8 @@ func Test_applyProfile_TGM(t *testing.T) {
 			ts2phcProc = p
 		case ptp4lProcessName:
 			ptp4lProc = p
+		case phc2sysProcessName:
+			assert.NotEmpty(t, p.skipInitialStartup, "Ensure phc2sys is startup-delayed for T-GM")
 		}
 	}
 
@@ -2718,6 +2741,76 @@ func TestEmitClockClassLogs_EmitsWithNilParentDS(t *testing.T) {
 	}, "EmitClockClassLogs should not panic with nil parentDS")
 }
 
+// --- ReadyTracker.Ready() unit tests ---
+
+func makeReadyTracker(processes []*ptpProcess) *ReadyTracker {
+	return &ReadyTracker{
+		config: true,
+		processManager: &ProcessManager{
+			process: processes,
+		},
+	}
+}
+
+func TestReady_NoProcesses(t *testing.T) {
+	rt := makeReadyTracker(nil)
+	ok, msg := rt.Ready()
+	assert.False(t, ok)
+	assert.Contains(t, msg, "No processes")
+}
+
+func TestReady_AllRunningWithMetrics(t *testing.T) {
+	rt := makeReadyTracker([]*ptpProcess{
+		{name: ptp4lProcessName, stopped: false, hasCollectedMetrics: true},
+		{name: phc2sysProcessName, stopped: false, hasCollectedMetrics: true},
+	})
+	ok, msg := rt.Ready()
+	assert.True(t, ok, msg)
+}
+
+func TestReady_StoppedProcessReportsNotReady(t *testing.T) {
+	rt := makeReadyTracker([]*ptpProcess{
+		{name: ptp4lProcessName, stopped: false, hasCollectedMetrics: true},
+		{name: phc2sysProcessName, stopped: true},
+	})
+	ok, msg := rt.Ready()
+	assert.False(t, ok)
+	assert.Contains(t, msg, "Stopped")
+	assert.Contains(t, msg, phc2sysProcessName)
+}
+
+func TestReady_DelayedPhc2sysNotReportedAsStopped(t *testing.T) {
+	// phc2sys is intentionally delayed (skipInitialStartup set): the pod
+	// should be considered ready without it.
+	rt := makeReadyTracker([]*ptpProcess{
+		{name: ptp4lProcessName, stopped: false, hasCollectedMetrics: true},
+		{name: phc2sysProcessName, stopped: true, skipInitialStartup: testSkipStartupReason},
+	})
+	ok, msg := rt.Ready()
+	assert.True(t, ok, msg)
+}
+
+func TestReady_NilProcessEntrySkipped(t *testing.T) {
+	// nil slots in the process slice must not panic.
+	rt := makeReadyTracker([]*ptpProcess{
+		{name: ptp4lProcessName, stopped: false, hasCollectedMetrics: true},
+		nil,
+	})
+	ok, msg := rt.Ready()
+	assert.True(t, ok, msg)
+}
+
+func TestReady_AllProcessesDelayed(t *testing.T) {
+	// If every process has skipInitialStartup set (e.g. a phc2sys-only HA profile
+	// where ptp4l lives in separate profiles), the pod must not report ready.
+	rt := makeReadyTracker([]*ptpProcess{
+		{name: phc2sysProcessName, stopped: true, skipInitialStartup: testSkipStartupReason},
+	})
+	ok, msg := rt.Ready()
+	assert.False(t, ok)
+	assert.Contains(t, msg, "No processes")
+}
+
 // --- /emit-logs handler unit tests ---
 
 func TestEmitLogsHandler_NotReady_OpensGateAndReturns204(t *testing.T) {
@@ -3210,4 +3303,165 @@ func TestSocketWriter_SuffixStrip(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("timeout: CEP did not finish reading")
 	}
+}
+
+func TestDelayedPhc2sysStartup(t *testing.T) {
+	profileName := "test-profile"
+	nodeProfile := ptpv1.PtpProfile{
+		Name: &profileName,
+	}
+
+	pm := &ProcessManager{
+		process: []*ptpProcess{},
+	}
+
+	dn := &Daemon{
+		processManager: pm,
+	}
+
+	phc2sys := &ptpProcess{
+		name:               phc2sysProcessName,
+		skipInitialStartup: testSkipStartupReason,
+		nodeProfile:        nodeProfile,
+		dn:                 dn,
+		execMutex:          sync.Mutex{},
+		stopped:            true, // Simulated stopped state
+	}
+
+	ts2phc := &ptpProcess{
+		name:        ts2phcProcessName,
+		nodeProfile: nodeProfile,
+		dn:          dn,
+		eventCh:     make(chan event.Event, 10),
+		ptpClockThreshold: &ptpv1.PtpClockThreshold{
+			MaxOffsetThreshold: 1000,
+			MinOffsetThreshold: -1000,
+		},
+	}
+
+	pm.process = append(pm.process, phc2sys, ts2phc)
+
+	// 1. Simulate large offset (> 1s)
+	dn.delayedPhc2sys.Store(true)
+	largeOffset := 37000000000.0 // 37s
+	ts2phc.ProcessTs2PhcEvents(largeOffset, ts2phcProcessName, "eth0", event.PTP_FREERUN, nil)
+
+	// Verify phc2sys is still delayed
+	assert.Equal(t, testSkipStartupReason, phc2sys.skipInitialStartup)
+
+	// 2. Exact boundary (== 1s): should NOT clear the delay (condition is strictly <)
+	phc2sys.skipInitialStartup = testSkipStartupReason
+	dn.delayedPhc2sys.Store(true)
+	boundaryOffset := 1000000000.0 // exactly 1s
+	ts2phc.ProcessTs2PhcEvents(boundaryOffset, ts2phcProcessName, "eth0", event.PTP_FREERUN, nil)
+	assert.Equal(t, testSkipStartupReason, phc2sys.skipInitialStartup, "At the 1s boundary phc2sys should remain delayed")
+	assert.True(t, dn.delayedPhc2sys.Load())
+
+	// 3. Negative sub-second offset (-0.5s): math.Abs should clear the delay
+	phc2sys.skipInitialStartup = testSkipStartupReason
+	dn.delayedPhc2sys.Store(true)
+	negSmallOffset := -500000000.0 // -0.5s
+	ts2phc.ProcessTs2PhcEvents(negSmallOffset, ts2phcProcessName, "eth0", event.PTP_LOCKED, nil)
+	assert.Equal(t, "", phc2sys.skipInitialStartup, "Negative sub-second offset should clear the delay")
+	assert.False(t, dn.delayedPhc2sys.Load())
+
+	// 4. Negative super-second offset (-2s): should NOT clear the delay
+	phc2sys.skipInitialStartup = testSkipStartupReason
+	dn.delayedPhc2sys.Store(true)
+	negLargeOffset := -2000000000.0 // -2s
+	ts2phc.ProcessTs2PhcEvents(negLargeOffset, ts2phcProcessName, "eth0", event.PTP_FREERUN, nil)
+	assert.Equal(t, testSkipStartupReason, phc2sys.skipInitialStartup, "Negative super-second offset should keep the delay")
+	assert.True(t, dn.delayedPhc2sys.Load())
+
+	// 5. Simulate sub-second offset (< 1s): original passing case
+	phc2sys.skipInitialStartup = testSkipStartupReason
+	dn.delayedPhc2sys.Store(true)
+	smallOffset := 500000000.0 // 0.5s
+	ts2phc.ProcessTs2PhcEvents(smallOffset, ts2phcProcessName, "eth0", event.PTP_LOCKED, nil)
+	assert.Equal(t, "", phc2sys.skipInitialStartup)
+	assert.False(t, dn.delayedPhc2sys.Load())
+}
+
+// TestDelayedPhc2sysStartup_HAProfile verifies that a phc2sys process in a
+// dedicated HA profile (with no ptp4l of its own) is correctly started when
+// a sub-second offset is reported by a ptp4l in one of its haProfile entries.
+func TestDelayedPhc2sysStartup_HAProfile(t *testing.T) {
+	phc2sysProfileName := "test-dual-nic-bc-ha"
+	master1ProfileName := "test-bc-master1"
+	master2ProfileName := "test-bc-master2"
+
+	phc2sysNodeProfile := ptpv1.PtpProfile{Name: &phc2sysProfileName}
+	master1NodeProfile := ptpv1.PtpProfile{Name: &master1ProfileName}
+	master2NodeProfile := ptpv1.PtpProfile{Name: &master2ProfileName}
+
+	pm := &ProcessManager{process: []*ptpProcess{}}
+	dn := &Daemon{processManager: pm}
+
+	phc2sys := &ptpProcess{
+		name:               phc2sysProcessName,
+		skipInitialStartup: testSkipStartupReason,
+		nodeProfile:        phc2sysNodeProfile,
+		haProfile:          map[string][]string{master1ProfileName: {"ens1f1"}, master2ProfileName: {"ens2f0"}},
+		dn:                 dn,
+		execMutex:          sync.Mutex{},
+		stopped:            true,
+	}
+
+	ptp4lMaster1 := &ptpProcess{
+		name:        ptp4lProcessName,
+		nodeProfile: master1NodeProfile,
+		dn:          dn,
+		eventCh:     make(chan event.Event, 10),
+		ptpClockThreshold: &ptpv1.PtpClockThreshold{
+			MaxOffsetThreshold: 1000,
+			MinOffsetThreshold: -1000,
+		},
+	}
+
+	ptp4lMaster2 := &ptpProcess{
+		name:        ptp4lProcessName,
+		nodeProfile: master2NodeProfile,
+		dn:          dn,
+		eventCh:     make(chan event.Event, 10),
+		ptpClockThreshold: &ptpv1.PtpClockThreshold{
+			MaxOffsetThreshold: 1000,
+			MinOffsetThreshold: -1000,
+		},
+	}
+
+	pm.process = append(pm.process, phc2sys, ptp4lMaster1, ptp4lMaster2)
+
+	// A large offset from master1 must NOT start phc2sys.
+	dn.delayedPhc2sys.Store(true)
+	dn.HandleDelayedPhc2sysStartup(ptp4lProcessName, 37000000000.0, &master1ProfileName)
+	assert.Equal(t, testSkipStartupReason, phc2sys.skipInitialStartup,
+		"large offset from HA-linked profile should not start phc2sys")
+
+	// A sub-second offset from master2 (different profile from phc2sys) MUST start it.
+	dn.delayedPhc2sys.Store(true)
+	dn.HandleDelayedPhc2sysStartup(ptp4lProcessName, 500000000.0, &master2ProfileName)
+	assert.Equal(t, "", phc2sys.skipInitialStartup,
+		"sub-second offset from HA-linked profile should start phc2sys")
+	assert.False(t, dn.delayedPhc2sys.Load())
+}
+
+func TestFindProcessesByName(t *testing.T) {
+	pm := &ProcessManager{
+		process: []*ptpProcess{
+			{name: "ptp4l"},
+			{name: "phc2sys"},
+			{name: "ptp4l"},
+		},
+	}
+
+	procs := pm.findProcessesByName("ptp4l")
+	assert.Equal(t, 2, len(procs))
+	assert.Equal(t, "ptp4l", procs[0].name)
+	assert.Equal(t, "ptp4l", procs[1].name)
+
+	procs = pm.findProcessesByName("phc2sys")
+	assert.Equal(t, 1, len(procs))
+
+	procs = pm.findProcessesByName("nonexistent")
+	assert.Equal(t, 0, len(procs))
 }

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/testhelpers"
 	ptpv1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v1"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
 	"k8s.io/utils/pointer"
 
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/config"
@@ -909,5 +910,62 @@ func TestDaemon_PopulateAndRenderPtp4lConf(t *testing.T) {
 		conf.ExtendGlobalSection(tc.profileName, tc.messageTag, tc.socketPath, tc.pProcess)
 		actualOutput, _ := conf.RenderPtp4lConf()
 		assert.Equal(t, tc.expectedOutput, actualOutput, fmt.Sprintf("Rendered output doesn't match expected: %s", tc.testName))
+	}
+}
+
+func TestRenderPtp4lConf_IfaceSource(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         string
+		expectedIfaces []config.Iface
+	}{
+		{
+			name:   "ts2phc.master 0 with nmea GNSS master promotes to GNSS",
+			config: "[nmea]\nts2phc.master 1\n[global]\n[ens7f0]\nts2phc.master 0\n[ens4f0]\nts2phc.master 0",
+			expectedIfaces: []config.Iface{
+				{Name: "ens7f0", Source: event.GNSS},
+				{Name: "ens4f0", Source: event.GNSS}, //nolint:goconst
+			},
+		},
+		{
+			name:   "ts2phc.master 0 without nmea section stays PPS",
+			config: "[global]\n[ens7f0]\nts2phc.master 0\n[ens4f0]\nts2phc.master 0",
+			expectedIfaces: []config.Iface{
+				{Name: "ens7f0", Source: event.PPS},
+				{Name: "ens4f0", Source: event.PPS},
+			},
+		},
+		{
+			name:   "ts2phc.master omitted inherits nmea source",
+			config: "[nmea]\nts2phc.master 1\n[global]\n[ens7f0]\n[ens4f0]",
+			expectedIfaces: []config.Iface{
+				{Name: "ens7f0", Source: event.GNSS},
+				{Name: "ens4f0", Source: event.GNSS},
+			},
+		},
+		{
+			name:   "ts2phc.master 1 on interface is GNSS directly",
+			config: "[global]\n[ens7f0]\nts2phc.master 1\n[ens4f0]\nts2phc.master 0",
+			expectedIfaces: []config.Iface{
+				{Name: "ens7f0", Source: event.GNSS},
+				{Name: "ens4f0", Source: event.PPS},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := &daemon.Ptp4lConf{}
+			err := conf.PopulatePtp4lConf(&tt.config, nil)
+			require.NoError(t, err)
+			_, ifaces := conf.RenderPtp4lConf()
+
+			if assert.Equal(t, len(tt.expectedIfaces), len(ifaces), "iface count mismatch") {
+				for i, expected := range tt.expectedIfaces {
+					assert.Equal(t, expected.Name, ifaces[i].Name, "iface %d name", i)
+					assert.Equal(t, expected.Source, ifaces[i].Source, "iface %d source", i)
+				}
+			}
+		})
 	}
 }

--- a/pkg/daemon/gpsd.go
+++ b/pkg/daemon/gpsd.go
@@ -1,11 +1,9 @@
 package daemon
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"net"
 	"os"
 	"os/exec"
@@ -257,7 +255,7 @@ func (g *GPSD) MonitorGNSSEventsWithUblox() {
 					lines = append(lines, line)
 				}
 				if len(lines) > 0 {
-					g.processGNSSLines(strings.NewReader(strings.Join(lines, "\n")))
+					g.processGNSSLines(lines)
 				}
 			case <-g.monitorCtx.Done():
 				doneFn()
@@ -267,35 +265,30 @@ func (g *GPSD) MonitorGNSSEventsWithUblox() {
 	}
 }
 
-// processGNSSLines reads ubxtool-formatted lines from r, extracts
-// GNSS status and offset, determines the sync state, and emits an
-// event on the event channel and gnssNotifyCh.
-func (g *GPSD) processGNSSLines(r io.Reader) {
+// processGNSSLines parses ubxtool-formatted lines, extracts GNSS status and
+// offset, determines the sync state, and emits an event on the event channel.
+// Each element of lines is one ubxtool output line (trailing newline optional).
+func (g *GPSD) processGNSSLines(lines []string) {
 	const timeLsResultLines = 4
-	scanner := bufio.NewScanner(r)
 	nStatus := int64(0)
 	nOffset := int64(99999999)
 	var timeLs *ublox.TimeLs
 
-	for scanner.Scan() {
-		line := scanner.Text()
+	for i, line := range lines {
 		if strings.Contains(line, "UBX-NAV-CLOCK") {
-			if scanner.Scan() {
-				nOffset = ublox.ExtractOffset(scanner.Text())
+			if i+1 < len(lines) {
+				nOffset = ublox.ExtractOffset(lines[i+1])
 			}
 		} else if strings.Contains(line, "UBX-NAV-STATUS") {
-			if scanner.Scan() {
-				nStatus = ublox.ExtractNavStatus(scanner.Text())
+			if i+1 < len(lines) {
+				nStatus = ublox.ExtractNavStatus(lines[i+1])
 			}
 		} else if strings.Contains(line, "UBX-NAV-TIMELS") {
-			var lines []string
-			for i := 0; i < timeLsResultLines; i++ {
-				if !scanner.Scan() {
-					break
-				}
-				lines = append(lines, scanner.Text())
+			end := i + 1 + timeLsResultLines
+			if end > len(lines) {
+				end = len(lines)
 			}
-			timeLs = ublox.ExtractLeapSec(lines)
+			timeLs = ublox.ExtractLeapSec(lines[i+1 : end])
 		}
 	}
 

--- a/pkg/daemon/gpsd_test.go
+++ b/pkg/daemon/gpsd_test.go
@@ -3,13 +3,21 @@ package daemon
 import (
 	"context"
 	"os/exec"
-	"strings"
 	"testing"
 
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/config"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/event"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/leap"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/ublox"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+)
+
+// Common ubxtool line fixtures reused across multiple test cases.
+const (
+	navStatusHeader = "UBX-NAV-STATUS:\n"
+	navStatus3DFix  = "  iTOW 437000 gpsFix 3 flags 0xdd fixStat 0 flags2 0x08\n"
+	navClockHeader  = "UBX-NAV-CLOCK:\n"
 )
 
 func TestResetSerialPort(t *testing.T) {
@@ -90,19 +98,36 @@ func TestResetSerialPortPassesCorrectArgs(t *testing.T) {
 func TestProcessGNSSLines(t *testing.T) {
 	tests := []struct {
 		name           string
-		input          string
+		lines          []string
 		maxOffset      int64
 		minOffset      int64
 		wantSourceLost bool
 		wantOffset     int64
 		wantGPSStatus  int64
+		wantTimeLs     *ublox.TimeLs // non-nil: assert TimeLs dispatched to leap manager
 	}{
 		{
 			name: "locked with good fix and offset in range",
-			input: "UBX-NAV-STATUS:\n" +
-				"  iTOW 437000 gpsFix 3 flags 0xdd fixStat 0 flags2 0x08\n" +
-				"UBX-NAV-CLOCK:\n" +
+			lines: []string{
+				navStatusHeader,
+				navStatus3DFix,
+				navClockHeader,
 				"  iTOW 437000 clkBias 42 clkDrift 0 tAcc 23 fAcc 0\n",
+			},
+			maxOffset:      100,
+			minOffset:      -100,
+			wantSourceLost: false,
+			wantOffset:     23,
+			wantGPSStatus:  3,
+		},
+		{
+			name: "lines without trailing newline are also handled",
+			lines: []string{
+				"UBX-NAV-STATUS:",
+				"  iTOW 437000 gpsFix 3 flags 0xdd fixStat 0 flags2 0x08",
+				"UBX-NAV-CLOCK:",
+				"  iTOW 437000 clkBias 42 clkDrift 0 tAcc 23 fAcc 0",
+			},
 			maxOffset:      100,
 			minOffset:      -100,
 			wantSourceLost: false,
@@ -111,10 +136,12 @@ func TestProcessGNSSLines(t *testing.T) {
 		},
 		{
 			name: "freerun with no fix",
-			input: "UBX-NAV-STATUS:\n" +
-				"  iTOW 437000 gpsFix 0 flags 0x00 fixStat 0 flags2 0x00\n" +
-				"UBX-NAV-CLOCK:\n" +
+			lines: []string{
+				navStatusHeader,
+				"  iTOW 437000 gpsFix 0 flags 0x00 fixStat 0 flags2 0x00\n",
+				navClockHeader,
 				"  iTOW 437000 clkBias 42 clkDrift 0 tAcc 50 fAcc 0\n",
+			},
 			maxOffset:      100,
 			minOffset:      -100,
 			wantSourceLost: true,
@@ -123,20 +150,74 @@ func TestProcessGNSSLines(t *testing.T) {
 		},
 		{
 			name: "freerun when offset out of range despite good fix",
-			input: "UBX-NAV-STATUS:\n" +
-				"  iTOW 437000 gpsFix 3 flags 0xdd fixStat 0 flags2 0x08\n" +
-				"UBX-NAV-CLOCK:\n" +
+			lines: []string{
+				navStatusHeader,
+				navStatus3DFix,
+				navClockHeader,
 				"  iTOW 437000 clkBias 42 clkDrift 0 tAcc 5000 fAcc 0\n",
+			},
 			maxOffset:      100,
 			minOffset:      -100,
 			wantSourceLost: true,
 			wantOffset:     5000,
 			wantGPSStatus:  3,
 		},
+		{
+			name: "TIMELS dispatched alongside normal fix",
+			lines: []string{
+				navStatusHeader,
+				navStatus3DFix,
+				navClockHeader,
+				"  iTOW 437000 clkBias 0 clkDrift 0 tAcc 23 fAcc 0\n",
+				"UBX-NAV-TIMELS:\n",
+				"  iTOW 376008000 version 0 reserved2 0 0 0 srcOfCurrLs 2\n",
+				"  currLs 18 srcOfLsChange 2 lsChange 0 timeToLsEvent 77643210\n",
+				"  dateOfLsGpsWn 2441 dateOfLsGpsDn 7 reserved2 0 0 0\n",
+				"  valid x3\n",
+			},
+			maxOffset:      100,
+			minOffset:      -100,
+			wantSourceLost: false,
+			wantOffset:     23,
+			wantGPSStatus:  3,
+			wantTimeLs: &ublox.TimeLs{
+				SrcOfCurrLs:   2,
+				CurrLs:        18,
+				SrcOfLsChange: 2,
+				TimeToLsEvent: 77643210,
+				DateOfLsGpsWn: 2441,
+				DateOfLsGpsDn: 7,
+				Valid:         3,
+			},
+		},
+		{
+			// Exercises the end > len(lines) bounds clamp: fewer than 4 data
+			// lines follow the TIMELS header. No NAV-CLOCK so offset stays at
+			// the default sentinel (99999999), which is out of range.
+			name: "truncated TIMELS does not panic",
+			lines: []string{
+				navStatusHeader,
+				navStatus3DFix,
+				"UBX-NAV-TIMELS:\n",
+				"  iTOW 376008000 version 0 reserved2 0 0 0 srcOfCurrLs 2\n",
+			},
+			maxOffset:      100,
+			minOffset:      -100,
+			wantSourceLost: true,
+			wantOffset:     99999999,
+			wantGPSStatus:  3,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			var leapCh chan ublox.TimeLs
+			if tt.wantTimeLs != nil {
+				leapCh = make(chan ublox.TimeLs, 1)
+				leap.LeapMgr = &leap.LeapManager{UbloxLsInd: leapCh}
+				defer func() { leap.LeapMgr = nil }()
+			}
+
 			eventCh := make(chan event.Event, 10)
 			g := &GPSD{
 				processConfig: config.ProcessConfig{
@@ -148,7 +229,7 @@ func TestProcessGNSSLines(t *testing.T) {
 				gmInterface: "ens2f0",
 			}
 
-			g.processGNSSLines(strings.NewReader(tt.input))
+			g.processGNSSLines(tt.lines)
 
 			assert.Equal(t, tt.wantSourceLost, g.sourceLost)
 			assert.Equal(t, tt.wantOffset, g.offset)
@@ -162,6 +243,15 @@ func TestProcessGNSSLines(t *testing.T) {
 			assert.Equal(t, tt.wantOffset, gnssData.Offset)
 			assert.Equal(t, tt.wantSourceLost, gnssData.SourceLost)
 			assert.Equal(t, "ens2f0", ev.IFace)
+
+			if tt.wantTimeLs != nil {
+				select {
+				case ts := <-leapCh:
+					assert.Equal(t, *tt.wantTimeLs, ts)
+				default:
+					t.Error("expected TimeLs to be sent to leap.LeapMgr.UbloxLsInd but channel was empty")
+				}
+			}
 		})
 	}
 }

--- a/pkg/daemon/log_parsing.go
+++ b/pkg/daemon/log_parsing.go
@@ -117,8 +117,14 @@ func processParsedMetrics(process *ptpProcess, ptpMetrics *parser.Metrics) {
 		if ptpMetrics.Iface != "" && configName != "" {
 			masterOffsetIface.set(configName, ptpMetrics.Iface)
 		}
+		if ptpMetrics.Source == "master" && process.dn != nil {
+			process.dn.HandleDelayedPhc2sysStartup(process.name, ptpMetrics.Offset, process.nodeProfile.Name)
+		}
 		process.sendPtp4lOffsetEvent()
 	case ts2phcProcessName:
+		if process.dn != nil {
+			process.dn.HandleDelayedPhc2sysStartup(process.name, ptpMetrics.Offset, process.nodeProfile.Name)
+		}
 		// Send event for ts2phc
 		eventSource := process.ifaces.GetEventSource(process.ifaces.GetPhcID2IFace(ptpMetrics.Iface))
 		values := map[event.ValueType]interface{}{

--- a/pkg/daemon/ready.go
+++ b/pkg/daemon/ready.go
@@ -34,7 +34,12 @@ func (rt *ReadyTracker) Ready() (bool, string) {
 
 	notRunning := strings.Builder{}
 	noMetrics := strings.Builder{}
+	activeCount := 0
 	for _, p := range rt.processManager.process {
+		if p == nil || p.skipInitialStartup != "" {
+			continue
+		}
+		activeCount++
 		if p.Stopped() {
 			if notRunning.Len() > 0 {
 				notRunning.WriteString(", ")
@@ -48,6 +53,10 @@ func (rt *ReadyTracker) Ready() (bool, string) {
 		}
 
 	}
+	if activeCount == 0 {
+		return false, "No processes have started"
+	}
+
 	if notRunning.Len() > 0 {
 		return false, "Stopped process(es): " + notRunning.String()
 	}

--- a/pkg/daemon/testdata/profile-tbc-tr.yaml
+++ b/pkg/daemon/testdata/profile-tbc-tr.yaml
@@ -6,30 +6,31 @@ ptpSettings:
   clockId[ens8f0]: 5799633565432596448
   inSyncConditionThreshold: 10
   inSyncConditionTimes: 2
+  clockType: "T-BC"
 phc2sysOpts: -r -n 24 -N 8 -u 0 -s ens4f0
 plugins:
   e810:
     enableDefaultConfig: false
     interconnections:
-    - id: ens4f0
-      part: E810-XXVDA4T
-      gnssInput: false
-      upstreamPort: ens4f0
-      phaseOutputConnectors:
-      - SMA1
-      - SMA2
-    - id: ens5f0
-      part: E810-XXVDA4T
-      inputConnector:
-        connector: SMA1
-        delayPs: 920
-    - id: ens8f0
-      part: E810-XXVDA4T
-      inputConnector:
-        connector: SMA1
-        delayPs: 920
-      phaseOutputConnectors:
-      - U.FL1
+      - id: ens4f0
+        part: E810-XXVDA4T
+        gnssInput: false
+        upstreamPort: ens4f0
+        phaseOutputConnectors:
+          - SMA1
+          - SMA2
+      - id: ens5f0
+        part: E810-XXVDA4T
+        inputConnector:
+          connector: SMA1
+          delayPs: 920
+      - id: ens8f0
+        part: E810-XXVDA4T
+        inputConnector:
+          connector: SMA1
+          delayPs: 920
+        phaseOutputConnectors:
+          - U.FL1
     pins:
       ens4f0:
         SMA1: 2 1
@@ -173,4 +174,4 @@ ts2phcConf: |
   ts2phc.extts_polarity rising
   ts2phc.extts_correction 0
   ts2phc.master 0
-ts2phcOpts: '-s generic -a --ts2phc.rh_external_pps 1'
+ts2phcOpts: "-s generic -a --ts2phc.rh_external_pps 1"

--- a/pkg/daemon/testdata/profile-tbc-tt.yaml
+++ b/pkg/daemon/testdata/profile-tbc-tt.yaml
@@ -5,6 +5,7 @@ ptpSettings:
   clockId[ens5f0]: 5799633565433967128
   clockId[ens8f0]: 5799633565432596448
   controllingProfile: 01-tbc-tr
+  clockType: "T-BC"
 ptp4lConf: |
   [ens4f0]
   masterOnly 1

--- a/pkg/daemon/testdata/profile-tgm.yaml
+++ b/pkg/daemon/testdata/profile-tgm.yaml
@@ -214,6 +214,8 @@ ptp4lOpts: -2 --summary_interval -4
 ptpSchedulingPolicy: SCHED_FIFO
 ptpSchedulingPriority: 10
 ts2phcConf: |
+  [nmea]
+  ts2phc.master 1
   [global]
   use_syslog  0
   verbose 1
@@ -221,15 +223,15 @@ ts2phcConf: |
   ts2phc.pulsewidth 100000000
   leapfile  /usr/share/zoneinfo/leap-seconds.list
   [ens7f0]
+  ts2phc.master 0
   ts2phc.extts_polarity rising
   ts2phc.extts_correction 0
-  ts2phc.master 0
   [ens4f0]
+  ts2phc.master 0
   ts2phc.extts_polarity rising
   ts2phc.extts_correction 0
-  ts2phc.master 0
   [ens2f0]
+  ts2phc.master 0
   ts2phc.extts_polarity rising
   ts2phc.extts_correction 0
-  ts2phc.master 0
 ts2phcOpts: ' '

--- a/pkg/dpll/dpll.go
+++ b/pkg/dpll/dpll.go
@@ -649,45 +649,29 @@ func (d *DpllConfig) stateDecision() {
 
 	case DPLL_HOLDOVER:
 		switch {
-		case d.hasPPSAsSource():
+		case !d.hasLeadingSource():
 			d.state = event.PTP_FREERUN
 			d.phaseOffset = FaultyPhaseOffset
-			glog.Infof("Follower card DPLL is on holdover - hardware failure or pins misconfigured")
-		case d.hasGNSSAsSource():
-			if !d.inSpec { // d.inSpec is updated by the holdover routine
-				glog.Infof("dpll is not in spec, state is DPLL_HOLDOVER, offset is out of range, state is FREERUN(%s)", d.iface)
-				d.state = event.PTP_FREERUN
-				d.phaseOffset = FaultyPhaseOffset
-				select {
-				case d.holdoverCloseCh <- true:
-					glog.Infof("closing holdover for %s since offset if out of spec", d.iface)
-				default:
-				}
-			} else if !d.onHoldover {
-				d.holdoverCloseCh = make(chan bool)
-				d.onHoldover = true
-				d.state = event.PTP_HOLDOVER
-				glog.Infof("starting holdover (%s)", d.iface)
-				go d.holdover()
+			glog.Infof("non-leading DPLL %s is in holdover, reporting FREERUN", d.iface)
+		// TODO: GNSS holdover currently doesn't offer holdover out of spec. Tech Debt: should work the same as T-BC
+		// making transitions programmable by users
+		case !d.inSpec || (d.hasPTPAsSource() && math.Abs(float64(d.PhaseOffset())) > float64(LocalMaxHoldoverOffSet)):
+			glog.Infof("leading DPLL %s holdover out of spec (inSpec=%v, offset=%d, max=%d), state is FREERUN",
+				d.iface, d.inSpec, d.PhaseOffset(), LocalMaxHoldoverOffSet)
+			d.state = event.PTP_FREERUN
+			d.phaseOffset = FaultyPhaseOffset
+			d.sourceLost = true
+			select {
+			case d.holdoverCloseCh <- true:
+				glog.Infof("closing holdover for %s since holdover is out of spec", d.iface)
+			default:
 			}
-		case d.hasPTPAsSource():
-			if d.PhaseOffset() > LocalMaxHoldoverOffSet {
-				glog.Infof("dpll offset is above MaxHoldoverOffSet, state is FREERUN(%s)", d.iface)
-				d.state = event.PTP_FREERUN
-				d.phaseOffset = FaultyPhaseOffset
-				d.sourceLost = true
-				select {
-				case d.holdoverCloseCh <- true:
-					glog.Infof("closing holdover for %s since offset if above MaxHoldoverOffSet", d.iface)
-				default:
-				}
-			} else if !d.onHoldover && !d.closing {
-				d.holdoverCloseCh = make(chan bool)
-				d.onHoldover = true
-				d.state = event.PTP_HOLDOVER
-				glog.Infof("starting holdover (%s)", d.iface)
-				go d.holdover()
-			}
+		case !d.onHoldover && !d.closing:
+			d.holdoverCloseCh = make(chan bool)
+			d.onHoldover = true
+			d.state = event.PTP_HOLDOVER
+			glog.Infof("starting holdover (%s)", d.iface)
+			go d.holdover()
 		}
 
 	case DPLL_LOCKED_HO_ACQ, DPLL_LOCKED:

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -394,6 +394,9 @@ func (e *EventHandler) updateGMState(cfgName string) clockSyncState {
 			switch d.ProcessName {
 			case DPLL:
 				dpllState = d.State
+				if e.hasNonLeadingDPLLFault(cfgName, leadingInterface) {
+					dpllState = PTP_FREERUN
+				}
 			case GNSS:
 				gnssState = d.State
 				// expecting to have at least one interface
@@ -542,6 +545,34 @@ func (e *EventHandler) isSourceLost(cfgName string) bool {
 		for _, d := range data {
 			if d.ProcessName == GNSS && len(d.Details) > 0 && d.Details[0] != nil {
 				return d.Details[0].sourceLost
+			}
+		}
+	}
+	return false
+}
+
+// hasNonLeadingDPLLFault returns true when the leading DPLL is locked but at
+// least one non-leading DPLL is not locked, indicating a follower fault that
+// should force the composite clock to FREERUN.
+func (e *EventHandler) hasNonLeadingDPLLFault(cfgName, leadingInterface string) bool {
+	if leadingInterface == LEADING_INTERFACE_UNKNOWN {
+		return false
+	}
+	if data, ok := e.data[cfgName]; ok {
+		for _, d := range data {
+			if d.ProcessName != DPLL {
+				continue
+			}
+			leadingDetail := d.GetDataDetails(leadingInterface)
+			if leadingDetail == nil || leadingDetail.State != PTP_LOCKED {
+				return false
+			}
+			for _, dd := range d.Details {
+				if dd.IFace != leadingInterface && dd.State != PTP_LOCKED {
+					glog.Infof("non-leading DPLL %s is %s while leading %s is locked, composite DPLL forced to FREERUN",
+						dd.IFace, dd.State, leadingInterface)
+					return true
+				}
 			}
 		}
 	}

--- a/pkg/event/event_tbc.go
+++ b/pkg/event/event_tbc.go
@@ -145,7 +145,7 @@ func (e *EventHandler) updateBCState(event Event) (clockSyncState, bool, bool) {
 			updateDownstreamData = true
 		}
 	case PTP_LOCKED:
-		if e.freeRunCondition(cfgName) {
+		if e.freeRunCondition(cfgName) || e.hasNonLeadingDPLLFault(cfgName, leadingInterface) {
 			e.clkSyncState[cfgName].state = PTP_FREERUN
 			e.clkSyncState[cfgName].clockClass = protocol.ClockClassFreerun
 			glog.Info("BC FSM: LOCKED to FREERUN")
@@ -173,16 +173,18 @@ func (e *EventHandler) updateBCState(event Event) (clockSyncState, bool, bool) {
 			}
 		}
 	case PTP_HOLDOVER:
-		if e.inSyncCondition(cfgName) && !e.isSourceLostBC(cfgName) {
-			e.clkSyncState[cfgName].state = PTP_LOCKED
-			glog.Info("BC FSM: HOLDOVER to LOCKED")
-			updateDownstreamData = true
-		} else if e.freeRunCondition(cfgName) {
+		nonLeadingFault := e.hasNonLeadingDPLLFault(cfgName, leadingInterface)
+		switch {
+		case nonLeadingFault || e.freeRunCondition(cfgName):
 			e.clkSyncState[cfgName].state = PTP_FREERUN
 			e.clkSyncState[cfgName].clockClass = protocol.ClockClassFreerun
 			glog.Info("BC FSM: HOLDOVER to FREERUN")
 			updateDownstreamData = true
-		} else {
+		case e.inSyncCondition(cfgName) && !e.isSourceLostBC(cfgName):
+			e.clkSyncState[cfgName].state = PTP_LOCKED
+			glog.Info("BC FSM: HOLDOVER to LOCKED")
+			updateDownstreamData = true
+		default:
 			if event.IFace == leadingInterface {
 				inSpec := false
 				if e.LeadingClockData.lastInSpec {

--- a/pkg/event/stats.go
+++ b/pkg/event/stats.go
@@ -62,7 +62,14 @@ func (d *Data) UpdateState() {
 		}
 	}
 	d.State = state
-	glog.Infof("state updated for %s =%s", d.ProcessName, d.State)
+	if len(d.Details) > 1 {
+		for _, detail := range d.Details {
+			glog.Infof("state updated for %s: port %s state=%s offset=%d",
+				d.ProcessName, detail.IFace, detail.State, detail.Offset)
+		}
+	} else {
+		glog.Infof("state updated for %s =%s", d.ProcessName, d.State)
+	}
 }
 
 // GetDataDetails ...

--- a/pkg/event/stats.go
+++ b/pkg/event/stats.go
@@ -49,14 +49,14 @@ func (d *Data) UpdateState() {
 	state := PTP_UNKNOWN
 	for _, detail := range d.Details { // 2 ts2phc or 2 dpll etc
 		switch detail.State {
-		case PTP_FREERUN: // if its free run and main state is not holdover then this is the state
-			if state != PTP_HOLDOVER {
+		case PTP_FREERUN: // FREERUN is the worst state (S0) and always takes priority
+			state = detail.State
+		case PTP_HOLDOVER: // HOLDOVER (S1) takes priority over LOCKED but not FREERUN
+			if state != PTP_FREERUN {
 				state = detail.State
 			}
-		case PTP_HOLDOVER: // if one of them is in holdover then this is the state
-			state = detail.State
-		case PTP_LOCKED: // if this is locked and none of them are in UNKNOWN or FREE run then this is the state
-			if state != PTP_FREERUN && state != PTP_HOLDOVER { // previous state
+		case PTP_LOCKED: // LOCKED (S2) is best; only sets if nothing worse exists
+			if state != PTP_FREERUN && state != PTP_HOLDOVER {
 				state = detail.State
 			}
 		}

--- a/pkg/event/stats_test.go
+++ b/pkg/event/stats_test.go
@@ -101,8 +101,8 @@ func Test_updateStats(t *testing.T) {
 					},
 					State: event.PTP_UNKNOWN,
 				}}},
-		wantedState: event.PTP_HOLDOVER,
-		desc:        "3. GNSS is in HOLDOVER, PPS is in FREERUN",
+		wantedState: event.PTP_FREERUN,
+		desc:        "3. GNSS is in HOLDOVER, PPS is in FREERUN - FREERUN takes priority (worst state)",
 	}, {
 		data: map[string][]*event.Data{
 			"a.0.config": {
@@ -138,4 +138,94 @@ func Test_updateStats(t *testing.T) {
 
 	}
 
+}
+
+func Test_updateState_LeadingFollowerMatrix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc          string
+		leadingState  event.PTPState
+		followerState event.PTPState
+		wantedState   event.PTPState
+	}{
+		{
+			desc:          "both locked",
+			leadingState:  event.PTP_LOCKED,
+			followerState: event.PTP_LOCKED,
+			wantedState:   event.PTP_LOCKED,
+		},
+		{
+			desc:          "follower freerun, leader locked - follower degrades to S0",
+			leadingState:  event.PTP_LOCKED,
+			followerState: event.PTP_FREERUN,
+			wantedState:   event.PTP_FREERUN,
+		},
+		{
+			desc:          "follower freerun, leader holdover - FREERUN wins over HOLDOVER",
+			leadingState:  event.PTP_HOLDOVER,
+			followerState: event.PTP_FREERUN,
+			wantedState:   event.PTP_FREERUN,
+		},
+		{
+			desc:          "leader holdover, follower locked - HOLDOVER propagates",
+			leadingState:  event.PTP_HOLDOVER,
+			followerState: event.PTP_LOCKED,
+			wantedState:   event.PTP_HOLDOVER,
+		},
+		{
+			desc:          "both freerun",
+			leadingState:  event.PTP_FREERUN,
+			followerState: event.PTP_FREERUN,
+			wantedState:   event.PTP_FREERUN,
+		},
+		{
+			desc:          "leader freerun, follower locked - FREERUN wins",
+			leadingState:  event.PTP_FREERUN,
+			followerState: event.PTP_LOCKED,
+			wantedState:   event.PTP_FREERUN,
+		},
+		{
+			desc:          "both holdover",
+			leadingState:  event.PTP_HOLDOVER,
+			followerState: event.PTP_HOLDOVER,
+			wantedState:   event.PTP_HOLDOVER,
+		},
+		{
+			desc:          "leader locked, follower holdover",
+			leadingState:  event.PTP_LOCKED,
+			followerState: event.PTP_HOLDOVER,
+			wantedState:   event.PTP_HOLDOVER,
+		},
+		{
+			desc:          "leader freerun, follower holdover - FREERUN wins",
+			leadingState:  event.PTP_FREERUN,
+			followerState: event.PTP_HOLDOVER,
+			wantedState:   event.PTP_FREERUN,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+			d := &event.Data{
+				ProcessName: "dpll",
+				Details: []*event.DataDetails{
+					{
+						IFace:   "leading-nic",
+						State:   tt.leadingState,
+						Metrics: map[event.ValueType]event.DataMetric{},
+					},
+					{
+						IFace:   "follower-nic",
+						State:   tt.followerState,
+						Metrics: map[event.ValueType]event.DataMetric{},
+					},
+				},
+				State: event.PTP_UNKNOWN,
+			}
+			d.UpdateState()
+			assert.Equal(t, tt.wantedState, d.State, tt.desc)
+		})
+	}
 }

--- a/pkg/hardwareconfig/hardware-vendor/dell/XR8720t/defaults.yaml
+++ b/pkg/hardwareconfig/hardware-vendor/dell/XR8720t/defaults.yaml
@@ -1,0 +1,4 @@
+# Clock ID resolution method for this hardware (E825-based)
+# "devlinkPinChain" - trace NIC DPLL pin parent chain to external DPLL module
+clockIdTransformation:
+  method: devlinkPinChain

--- a/pkg/hardwareconfig/hardware-vendor/hpe/EL140-Gen12/defaults.yaml
+++ b/pkg/hardwareconfig/hardware-vendor/hpe/EL140-Gen12/defaults.yaml
@@ -1,0 +1,4 @@
+# Clock ID resolution method for this hardware (E825-based)
+# "devlinkPinChain" - trace NIC DPLL pin parent chain to external DPLL module
+clockIdTransformation:
+  method: devlinkPinChain

--- a/pkg/hardwareconfig/hardware-vendor/intel/e825/defaults.yaml
+++ b/pkg/hardwareconfig/hardware-vendor/intel/e825/defaults.yaml
@@ -1,9 +1,9 @@
-# Clock ID transformation method for this hardware
-# "direct" - use serial number bytes directly (keeps ff-ff in middle)
-# "eui64" - remove bytes 3-4 (ff-ff) and insert ff-fe (EUI-64 format)
-# Note: Based on actual hardware data from PERLA2 board, e825 uses direct transformation
+# Clock ID resolution method for this hardware
+# "direct" - use NIC PCI serial number bytes directly (E810)
+# "eui64" - EUI-64 transform of NIC PCI serial number
+# "devlinkPinChain" - trace NIC DPLL pin parent chain to external DPLL module (E825/zl3073x)
 clockIdTransformation:
-  method: direct
+  method: devlinkPinChain
 
 pinDefaults:
   # REF0P

--- a/pkg/hardwareconfig/hardwareconfig_gnrd_test.go
+++ b/pkg/hardwareconfig/hardwareconfig_gnrd_test.go
@@ -339,7 +339,7 @@ func validateGNRDVendorDefaults(t *testing.T) {
 
 	// Validate key fields from e825/defaults.yaml
 	assert.NotNil(t, hwSpec.ClockIDTransformation, "Clock ID transformation should be defined")
-	assert.Equal(t, "direct", hwSpec.ClockIDTransformation.Method, "Should use direct transformation (based on actual PERLA2 hardware)")
+	assert.Equal(t, "devlinkPinChain", hwSpec.ClockIDTransformation.Method, "E825 should use devlinkPinChain to resolve clock ID via NIC pin parent chain")
 	t.Logf("  ✓ Clock ID transformation method: %s", hwSpec.ClockIDTransformation.Method)
 
 	assert.NotEmpty(t, hwSpec.PinDefaults, "Pin defaults should not be empty")

--- a/pkg/hardwareconfig/pin_parent_chain_test.go
+++ b/pkg/hardwareconfig/pin_parent_chain_test.go
@@ -1,0 +1,370 @@
+package hardwareconfig
+
+import (
+	"fmt"
+	"testing"
+
+	dpll "github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/dpll-netlink"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testModuleIce     = "ice"
+	testModuleZl3073x = "zl3073x"
+	testIfaceE825     = "eno5"
+	testIfaceE810     = "ens4f0"
+	testBusE825       = "0000:51:00.0"
+	testBusE810       = "0000:13:00.0"
+)
+
+func TestGetClockIDFromPinParentChain(t *testing.T) {
+	const (
+		nicPinID         = uint32(5)
+		zlParentPinID    = uint32(18)
+		zlParentPinID2   = uint32(19)
+		expectedClockID  = uint64(3549816820761526005)
+		expectedClockID2 = uint64(9876543210123456789)
+	)
+
+	tests := []struct {
+		name             string
+		mockNetdevPin    func(string) (uint32, bool, error)
+		mockPinQuerier   func(uint32) (*dpll.PinInfo, error)
+		wantClockID      uint64
+		wantErr          bool
+		wantErrSubstring string
+	}{
+		{
+			name: "happy path: NIC pin has zl3073x parent",
+			mockNetdevPin: func(_ string) (uint32, bool, error) {
+				return nicPinID, true, nil
+			},
+			mockPinQuerier: func(pinID uint32) (*dpll.PinInfo, error) {
+				switch pinID {
+				case nicPinID:
+					return &dpll.PinInfo{
+						ID:         nicPinID,
+						ModuleName: testModuleIce,
+						ClockID:    13036154006041183120,
+						ParentPin: []dpll.PinParentPin{
+							{ParentID: zlParentPinID, State: dpll.PinStateDisconnected},
+							{ParentID: zlParentPinID2, State: dpll.PinStateDisconnected},
+						},
+					}, nil
+				case zlParentPinID:
+					return &dpll.PinInfo{
+						ID:         zlParentPinID,
+						ModuleName: testModuleZl3073x,
+						ClockID:    expectedClockID,
+					}, nil
+				case zlParentPinID2:
+					return &dpll.PinInfo{
+						ID:         zlParentPinID2,
+						ModuleName: testModuleZl3073x,
+						ClockID:    expectedClockID,
+					}, nil
+				default:
+					return nil, fmt.Errorf("unexpected pin ID %d", pinID)
+				}
+			},
+			wantClockID: expectedClockID,
+		},
+		{
+			name: "multiple parents: first non-ice parent wins",
+			mockNetdevPin: func(_ string) (uint32, bool, error) {
+				return nicPinID, true, nil
+			},
+			mockPinQuerier: func(pinID uint32) (*dpll.PinInfo, error) {
+				switch pinID {
+				case nicPinID:
+					return &dpll.PinInfo{
+						ID:         nicPinID,
+						ModuleName: testModuleIce,
+						ParentPin: []dpll.PinParentPin{
+							{ParentID: zlParentPinID},
+							{ParentID: zlParentPinID2},
+						},
+					}, nil
+				case zlParentPinID:
+					return &dpll.PinInfo{
+						ID:         zlParentPinID,
+						ModuleName: testModuleZl3073x,
+						ClockID:    expectedClockID,
+					}, nil
+				case zlParentPinID2:
+					return &dpll.PinInfo{
+						ID:         zlParentPinID2,
+						ModuleName: "other_dpll",
+						ClockID:    expectedClockID2,
+					}, nil
+				default:
+					return nil, fmt.Errorf("unexpected pin ID %d", pinID)
+				}
+			},
+			wantClockID: expectedClockID,
+		},
+		{
+			name: "non-zl3073x parent module still returns clock ID",
+			mockNetdevPin: func(_ string) (uint32, bool, error) {
+				return nicPinID, true, nil
+			},
+			mockPinQuerier: func(pinID uint32) (*dpll.PinInfo, error) {
+				switch pinID {
+				case nicPinID:
+					return &dpll.PinInfo{
+						ID:         nicPinID,
+						ModuleName: testModuleIce,
+						ParentPin: []dpll.PinParentPin{
+							{ParentID: zlParentPinID},
+						},
+					}, nil
+				case zlParentPinID:
+					return &dpll.PinInfo{
+						ID:         zlParentPinID,
+						ModuleName: "other_dpll",
+						ClockID:    expectedClockID2,
+					}, nil
+				default:
+					return nil, fmt.Errorf("unexpected pin ID %d", pinID)
+				}
+			},
+			wantClockID: expectedClockID2,
+		},
+		{
+			name: "no IFLA_DPLL_PIN on NIC",
+			mockNetdevPin: func(_ string) (uint32, bool, error) {
+				return 0, false, nil
+			},
+			wantErr:          true,
+			wantErrSubstring: "no DPLL pin found",
+		},
+		{
+			name: "netdev pin getter error",
+			mockNetdevPin: func(_ string) (uint32, bool, error) {
+				return 0, false, fmt.Errorf("netlink route failed")
+			},
+			wantErr:          true,
+			wantErrSubstring: "failed to get DPLL pin",
+		},
+		{
+			name: "DPLL pin query fails",
+			mockNetdevPin: func(_ string) (uint32, bool, error) {
+				return nicPinID, true, nil
+			},
+			mockPinQuerier: func(_ uint32) (*dpll.PinInfo, error) {
+				return nil, fmt.Errorf("DPLL netlink connection failed")
+			},
+			wantErr:          true,
+			wantErrSubstring: "failed to query DPLL pin",
+		},
+		{
+			name: "pin has no parent pins",
+			mockNetdevPin: func(_ string) (uint32, bool, error) {
+				return nicPinID, true, nil
+			},
+			mockPinQuerier: func(_ uint32) (*dpll.PinInfo, error) {
+				return &dpll.PinInfo{
+					ID:         nicPinID,
+					ModuleName: testModuleIce,
+					ParentPin:  nil,
+				}, nil
+			},
+			wantErr:          true,
+			wantErrSubstring: "has no parent pins",
+		},
+		{
+			name: "all parents share same module as NIC",
+			mockNetdevPin: func(_ string) (uint32, bool, error) {
+				return nicPinID, true, nil
+			},
+			mockPinQuerier: func(pinID uint32) (*dpll.PinInfo, error) {
+				return &dpll.PinInfo{
+					ID:         pinID,
+					ModuleName: testModuleIce,
+					ParentPin: []dpll.PinParentPin{
+						{ParentID: zlParentPinID},
+					},
+				}, nil
+			},
+			wantErr:          true,
+			wantErrSubstring: "no external DPLL parent found",
+		},
+		{
+			name: "parent pin query fails but next parent succeeds",
+			mockNetdevPin: func(_ string) (uint32, bool, error) {
+				return nicPinID, true, nil
+			},
+			mockPinQuerier: func(pinID uint32) (*dpll.PinInfo, error) {
+				switch pinID {
+				case nicPinID:
+					return &dpll.PinInfo{
+						ID:         nicPinID,
+						ModuleName: testModuleIce,
+						ParentPin: []dpll.PinParentPin{
+							{ParentID: zlParentPinID},
+							{ParentID: zlParentPinID2},
+						},
+					}, nil
+				case zlParentPinID:
+					return nil, fmt.Errorf("transient error")
+				case zlParentPinID2:
+					return &dpll.PinInfo{
+						ID:         zlParentPinID2,
+						ModuleName: testModuleZl3073x,
+						ClockID:    expectedClockID,
+					}, nil
+				default:
+					return nil, fmt.Errorf("unexpected pin ID %d", pinID)
+				}
+			},
+			wantClockID: expectedClockID,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origNetdev := netdevDpllPinGetter
+			origQuerier := dpllPinQuerier
+			defer func() {
+				netdevDpllPinGetter = origNetdev
+				dpllPinQuerier = origQuerier
+			}()
+
+			netdevDpllPinGetter = tt.mockNetdevPin
+			if tt.mockPinQuerier != nil {
+				dpllPinQuerier = tt.mockPinQuerier
+			}
+
+			clockID, err := getClockIDFromPinParentChain("eno8303")
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.wantErrSubstring != "" {
+					assert.Contains(t, err.Error(), tt.wantErrSubstring)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantClockID, clockID)
+		})
+	}
+}
+
+func TestGetClockIDFromInterfaceWithCache_E825Derivation(t *testing.T) {
+	const expectedClockID = uint64(3549816820761526005)
+
+	origNetdev := netdevDpllPinGetter
+	origQuerier := dpllPinQuerier
+	origCmd := commandExecutor
+	defer func() {
+		netdevDpllPinGetter = origNetdev
+		dpllPinQuerier = origQuerier
+		commandExecutor = origCmd
+	}()
+
+	setupE825PinMocks := func() {
+		netdevDpllPinGetter = func(_ string) (uint32, bool, error) {
+			return 5, true, nil
+		}
+		dpllPinQuerier = func(pinID uint32) (*dpll.PinInfo, error) {
+			if pinID == 5 {
+				return &dpll.PinInfo{
+					ID: 5, ModuleName: testModuleIce,
+					ParentPin: []dpll.PinParentPin{{ParentID: 18}},
+				}, nil
+			}
+			return &dpll.PinInfo{
+				ID: 18, ModuleName: testModuleZl3073x, ClockID: expectedClockID,
+			}, nil
+		}
+	}
+
+	t.Run("legacy detection: E825 via lspci uses pin chain when no hwDefPath", func(t *testing.T) {
+		mockCmd := NewMockCommandExecutor()
+		mockCmd.SetResponse("ethtool", []string{"-i", testIfaceE825}, "driver: ice\nbus-info: "+testBusE825)
+		mockCmd.SetResponse("lspci", []string{"-s", testBusE825}, testBusE825+" Ethernet controller: Intel Corporation Ethernet Controller E825-C")
+		commandExecutor = mockCmd
+		setupE825PinMocks()
+
+		clockID, err := GetClockIDFromInterfaceWithCache(testIfaceE825, "", nil)
+		require.NoError(t, err)
+		assert.Equal(t, expectedClockID, clockID)
+	})
+
+	t.Run("config-driven: hwDefPath with devlinkPinChain method", func(t *testing.T) {
+		mockCmd := NewMockCommandExecutor()
+		mockCmd.SetResponse("ethtool", []string{"-i", testIfaceE825}, "driver: ice\nbus-info: "+testBusE825)
+		commandExecutor = mockCmd
+		setupE825PinMocks()
+
+		clockID, err := GetClockIDFromInterfaceWithCache(testIfaceE825, HwDefIntelE825, nil)
+		require.NoError(t, err)
+		assert.Equal(t, expectedClockID, clockID)
+	})
+
+	t.Run("fallback to module-name scan on derivation failure", func(t *testing.T) {
+		mockCmd := NewMockCommandExecutor()
+		mockCmd.SetResponse("ethtool", []string{"-i", testIfaceE825}, "driver: ice\nbus-info: "+testBusE825)
+		commandExecutor = mockCmd
+
+		netdevDpllPinGetter = func(_ string) (uint32, bool, error) {
+			return 0, false, fmt.Errorf("IFLA_DPLL_PIN not supported")
+		}
+
+		mockPins := []*dpll.PinInfo{
+			{ID: 10, ModuleName: testModuleZl3073x, ClockID: expectedClockID, BoardLabel: "REF1P"},
+		}
+		SetupMockDpllPinsForTestsWithData(mockPins)
+		defer TeardownMockDpllPinsForTests()
+
+		clockID, err := GetClockIDFromInterfaceWithCache(testIfaceE825, HwDefIntelE825, nil)
+		require.NoError(t, err)
+		assert.Equal(t, expectedClockID, clockID)
+	})
+
+	t.Run("config-driven: direct method uses serial number", func(t *testing.T) {
+		mockCmd := NewMockCommandExecutor()
+		mockCmd.SetResponse("ethtool", []string{"-i", testIfaceE810}, "driver: ice\nbus-info: "+testBusE810)
+		mockCmd.SetResponse("devlink", []string{"dev", "info", "pci/" + testBusE810}, //nolint:goconst
+			"pci/"+testBusE810+":\n  serial_number 50-7c-6f-ff-ff-1f-b5-80")
+		commandExecutor = mockCmd
+
+		clockID, err := GetClockIDFromInterfaceWithCache(testIfaceE810, HwDefIntelE810, nil)
+		require.NoError(t, err)
+		assert.Equal(t, uint64(0x507c6fffff1fb580), clockID)
+	})
+}
+
+func TestGetClockIDResolutionMethod(t *testing.T) {
+	origCmd := commandExecutor
+	defer func() { commandExecutor = origCmd }()
+
+	t.Run("hwDefPath with devlinkPinChain returns devlinkPinChain", func(t *testing.T) {
+		method := getClockIDResolutionMethod(HwDefIntelE825, testBusE825)
+		assert.Equal(t, ClockIDMethodDevlinkPinChain, method)
+	})
+
+	t.Run("hwDefPath with direct returns direct", func(t *testing.T) {
+		method := getClockIDResolutionMethod(HwDefIntelE810, testBusE810)
+		assert.Equal(t, ClockIDMethodDirect, method)
+	})
+
+	t.Run("no hwDefPath with E825 lspci falls back to devlinkPinChain", func(t *testing.T) {
+		mockCmd := NewMockCommandExecutor()
+		mockCmd.SetResponse("lspci", []string{"-s", testBusE825}, "E825-C controller")
+		commandExecutor = mockCmd
+
+		method := getClockIDResolutionMethod("", testBusE825)
+		assert.Equal(t, ClockIDMethodDevlinkPinChain, method)
+	})
+
+	t.Run("no hwDefPath with non-E825 lspci falls back to direct", func(t *testing.T) {
+		mockCmd := NewMockCommandExecutor()
+		mockCmd.SetResponse("lspci", []string{"-s", testBusE810}, "E810-XXVDA4T controller")
+		commandExecutor = mockCmd
+
+		method := getClockIDResolutionMethod("", testBusE810)
+		assert.Equal(t, ClockIDMethodDirect, method)
+	})
+}

--- a/pkg/hardwareconfig/utils.go
+++ b/pkg/hardwareconfig/utils.go
@@ -1,7 +1,9 @@
 package hardwareconfig
 
 import (
+	"encoding/binary"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -10,9 +12,19 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	"github.com/mdlayher/netlink"
 
 	dpll "github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/dpll-netlink"
 	ptpv2alpha1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v2alpha1"
+)
+
+// Stable kernel UAPI constants for DPLL pin resolution via RTM_GETLINK.
+const (
+	netlinkRoute    = 0  // NETLINK_ROUTE
+	rtmGetLink      = 18 // RTM_GETLINK
+	rtmNewLink      = 16 // RTM_NEWLINK
+	sizeofIfInfomsg = 16 // sizeof(struct ifinfomsg)
+	iflaDpllPin     = 65 // IFLA_DPLL_PIN
 )
 
 // DpllPinsGetter is a function type for getting DPLL pins
@@ -204,6 +216,144 @@ func GetClockIDFromInterface(iface string, hwDefPath string) (uint64, error) {
 	return GetClockIDFromInterfaceWithCache(iface, hwDefPath, nil)
 }
 
+// getNetdevDpllPin retrieves the DPLL pin ID associated with a network interface
+// via the kernel's IFLA_DPLL_PIN netlink attribute.
+func getNetdevDpllPin(ifname string) (uint32, bool, error) {
+	iface, err := net.InterfaceByName(ifname)
+	if err != nil {
+		return 0, false, fmt.Errorf("could not find interface %s: %w", ifname, err)
+	}
+
+	conn, err := netlink.Dial(netlinkRoute, nil)
+	if err != nil {
+		return 0, false, fmt.Errorf("failed to dial netlink route: %w", err)
+	}
+	defer conn.Close()
+
+	b := make([]byte, sizeofIfInfomsg)
+	binary.NativeEndian.PutUint32(b[4:8], uint32(iface.Index))
+
+	msg := netlink.Message{
+		Header: netlink.Header{
+			Type:  rtmGetLink,
+			Flags: netlink.Request,
+		},
+		Data: b,
+	}
+
+	replyMsgs, err := conn.Execute(msg)
+	if err != nil {
+		return 0, false, fmt.Errorf("failed to execute netlink request for %s: %w", ifname, err)
+	}
+
+	if len(replyMsgs) != 1 {
+		return 0, false, fmt.Errorf("expected 1 reply message for %s, got %d", ifname, len(replyMsgs))
+	}
+	reply := replyMsgs[0]
+
+	if reply.Header.Type != rtmNewLink {
+		return 0, false, fmt.Errorf("expected RTM_NEWLINK for %s, got %d", ifname, reply.Header.Type)
+	}
+	if len(reply.Data) < sizeofIfInfomsg {
+		return 0, false, fmt.Errorf("reply too short for %s", ifname)
+	}
+
+	ad, err := netlink.NewAttributeDecoder(reply.Data[sizeofIfInfomsg:])
+	if err != nil {
+		return 0, false, fmt.Errorf("failed to create attribute decoder: %w", err)
+	}
+
+	var dpllPinID uint32
+	var found bool
+
+	for ad.Next() {
+		if ad.Type() == iflaDpllPin {
+			ad.Nested(func(nad *netlink.AttributeDecoder) error {
+				for nad.Next() {
+					if nad.Type() == dpll.DpllPinID {
+						dpllPinID = nad.Uint32()
+						found = true
+						return nil
+					}
+				}
+				return nad.Err()
+			})
+			if found {
+				break
+			}
+		}
+	}
+
+	if adErr := ad.Err(); adErr != nil {
+		return 0, false, fmt.Errorf("attribute decoding failed for %s: %w", ifname, adErr)
+	}
+
+	return dpllPinID, found, nil
+}
+
+// netdevDpllPinGetter is swappable for testing.
+var netdevDpllPinGetter = getNetdevDpllPin
+
+// queryDpllPin queries a single DPLL pin by ID using a new DPLL netlink connection.
+func queryDpllPin(pinID uint32) (*dpll.PinInfo, error) {
+	conn, err := dpll.Dial(nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to dial DPLL: %w", err)
+	}
+	defer conn.Close()
+	return conn.DoPinGet(dpll.DoPinGetRequest{ID: pinID})
+}
+
+// dpllPinQuerier is swappable for testing.
+var dpllPinQuerier = queryDpllPin
+
+// getClockIDFromPinParentChain derives the external DPLL clock ID for a NIC
+// by tracing the DPLL pin parentage chain: NIC → DPLL pin → parent pins →
+// external DPLL module → clock ID.
+func getClockIDFromPinParentChain(ifname string) (uint64, error) {
+	glog.Infof("Attempting NIC-to-DPLL derivation for interface %s", ifname)
+
+	pinID, found, err := netdevDpllPinGetter(ifname)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get DPLL pin for %s: %w", ifname, err)
+	}
+	if !found {
+		return 0, fmt.Errorf("no DPLL pin found for interface %s", ifname)
+	}
+	glog.Infof("NIC %s DPLL pin ID: %d", ifname, pinID)
+
+	nicPin, err := dpllPinQuerier(pinID)
+	if err != nil {
+		return 0, fmt.Errorf("failed to query DPLL pin %d: %w", pinID, err)
+	}
+
+	if len(nicPin.ParentPin) == 0 {
+		return 0, fmt.Errorf("DPLL pin %d for %s has no parent pins", pinID, ifname)
+	}
+
+	parentIDs := make([]uint32, len(nicPin.ParentPin))
+	for i, p := range nicPin.ParentPin {
+		parentIDs[i] = p.ParentID
+	}
+	glog.Infof("DPLL pin %d has %d parent pins: %v", pinID, len(nicPin.ParentPin), parentIDs)
+
+	for _, parent := range nicPin.ParentPin {
+		parentPin, parentErr := dpllPinQuerier(parent.ParentID)
+		if parentErr != nil {
+			glog.Warningf("Failed to query parent pin %d: %v, trying next", parent.ParentID, parentErr)
+			continue
+		}
+		if parentPin.ModuleName != nicPin.ModuleName {
+			glog.Infof("Found external DPLL parent pin %d (module=%s) with clock ID %d for interface %s",
+				parent.ParentID, parentPin.ModuleName, parentPin.ClockID, ifname)
+			return parentPin.ClockID, nil
+		}
+	}
+
+	return 0, fmt.Errorf("no external DPLL parent found for pin %d on %s (all parents share module %q)",
+		pinID, ifname, nicPin.ModuleName)
+}
+
 func getPERLAClockIDFromPinCache(cache *PinCache) (uint64, error) {
 	if cache == nil {
 		var cacheErr error
@@ -230,16 +380,43 @@ func getPERLAClockIDFromPinCache(cache *PinCache) (uint64, error) {
 	return 0, fmt.Errorf("no zl3073x DPLL found in pin cache")
 }
 
+// Clock ID resolution methods configurable via defaults.yaml clockIdTransformation.method
+const (
+	ClockIDMethodDirect          = "direct"          // PCI serial number bytes used directly (E810)
+	ClockIDMethodEUI64           = "eui64"           // EUI-64 transform of serial number
+	ClockIDMethodDevlinkPinChain = "devlinkPinChain" // Trace NIC DPLL pin parent chain (E825/zl3073x)
+)
+
+// getClockIDResolutionMethod loads the hardware defaults and returns the configured method.
+// Falls back to lspci-based detection when no hwDefPath is provided (legacy compatibility).
+func getClockIDResolutionMethod(hwDefPath string, busAddr string) string {
+	if hwDefPath != "" {
+		spec, err := LoadHardwareDefaults(hwDefPath, nil)
+		if err == nil && spec != nil && spec.ClockIDTransformation != nil && spec.ClockIDTransformation.Method != "" {
+			return spec.ClockIDTransformation.Method
+		}
+	}
+
+	// Legacy fallback: detect E825 via lspci when no hwDefPath or no method configured
+	lspciOutput, err := commandExecutor.Execute("lspci", "-s", busAddr)
+	if err == nil && strings.Contains(lspciOutput, "E825") {
+		glog.Infof("Legacy detection: E825 device on %s, using devlinkPinChain method", busAddr)
+		return ClockIDMethodDevlinkPinChain
+	}
+
+	return ClockIDMethodDirect
+}
+
 // GetClockIDFromInterfaceWithCache resolves clock ID with an optional pre-loaded pin cache.
-// This avoids repeatedly fetching the pin cache for PERLA workaround.
+// The resolution method is determined by the hardware definition's clockIdTransformation.method:
+//   - "direct" / "eui64": derive clock ID from NIC's PCI serial number (devlink)
+//   - "devlinkPinChain": trace NIC's DPLL pin parent chain to external DPLL module
 func GetClockIDFromInterfaceWithCache(iface string, hwDefPath string, pinCache *PinCache) (uint64, error) {
-	// Step 1: Get bus address using ethtool
 	ethtoolOutput, err := commandExecutor.Execute("ethtool", "-i", iface)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get bus info for interface %s: %w", iface, err)
 	}
 
-	// Extract bus-info
 	busAddr := ""
 	for _, line := range strings.Split(ethtoolOutput, "\n") {
 		if strings.HasPrefix(line, "bus-info:") {
@@ -251,37 +428,47 @@ func GetClockIDFromInterfaceWithCache(iface string, hwDefPath string, pinCache *
 	}
 	glog.V(4).Infof("ClockID: iface=%s bus=%s hwDef=%s", iface, busAddr, hwDefPath)
 
-	// Step 2: PERLA workaround - Check if this is an E825 device
-	// For E825 devices, there's no direct NIC-DPLL association, so we look for the zl3073x DPLL
-	lspciOutput, err := commandExecutor.Execute("lspci", "-s", busAddr)
-	if err != nil {
-		return 0, fmt.Errorf("failed to run lspci -s %s, output: %s, err: %w", busAddr, lspciOutput, err)
-	}
+	method := getClockIDResolutionMethod(hwDefPath, busAddr)
+	glog.Infof("ClockID resolution for %s: method=%s (hwDef=%s)", iface, method, hwDefPath)
 
-	if strings.Contains(lspciOutput, "E825") {
-		glog.Infof("Detected E825 device on %s (interface %s), using PERLA workaround", busAddr, iface)
-		var clockID uint64
-		clockID, err = getPERLAClockIDFromPinCache(pinCache)
-		if err != nil {
-			return 0, fmt.Errorf("PERLA workaround: failed to get clock ID from pin cache: %v, falling back to serial number approach", err)
-		}
+	switch method {
+	case ClockIDMethodDevlinkPinChain:
+		return resolveClockIDViaPinChain(iface, pinCache)
+	default:
+		return resolveClockIDViaSerialNumber(iface, busAddr, hwDefPath)
+	}
+}
+
+// resolveClockIDViaPinChain traces the NIC's DPLL pin parent chain to find the
+// external DPLL clock ID. Falls back to module-name scan on failure.
+func resolveClockIDViaPinChain(iface string, pinCache *PinCache) (uint64, error) {
+	clockID, derivErr := getClockIDFromPinParentChain(iface)
+	if derivErr == nil {
 		return clockID, nil
 	}
+	glog.Warningf("NIC-to-DPLL derivation failed for %s: %v; falling back to module-name scan", iface, derivErr)
 
-	// Step 3: Standard approach - Get serial number using devlink
+	clockID, err := getPERLAClockIDFromPinCache(pinCache)
+	if err != nil {
+		return 0, fmt.Errorf("clock ID resolution failed for %s: derivation: %v, fallback: %w", iface, derivErr, err)
+	}
+	return clockID, nil
+}
+
+// resolveClockIDViaSerialNumber derives clock ID from the NIC's PCI serial number
+// using the hardware-specific transformer (direct or EUI-64).
+func resolveClockIDViaSerialNumber(iface, busAddr, hwDefPath string) (uint64, error) {
 	devlinkOutput, err := commandExecutor.Execute("devlink", "dev", "info", fmt.Sprintf("pci/%s", busAddr))
 	if err != nil {
 		return 0, fmt.Errorf("failed to get devlink info for bus %s: %w", busAddr, err)
 	}
 
-	// Extract serial number
 	serialNumber := ""
 	for _, line := range strings.Split(devlinkOutput, "\n") {
 		if strings.Contains(line, "serial_number") {
-			// Format is typically "  serial_number 64-4c-36-ff-ff-5c-4a-e8"
 			parts := strings.Fields(line)
 			if len(parts) >= 2 {
-				serialNumber = parts[len(parts)-1] // Get the last field
+				serialNumber = parts[len(parts)-1]
 				break
 			}
 		}
@@ -291,20 +478,13 @@ func GetClockIDFromInterfaceWithCache(iface string, hwDefPath string, pinCache *
 	}
 	glog.V(4).Infof("ClockID: iface=%s bus=%s serial=%s hwDef=%s", iface, busAddr, serialNumber, hwDefPath)
 
-	// Step 4: Select hardware-specific transformer based on hardware defaults (when provided)
-	if hwDefPath == "" {
-		glog.V(3).Infof("No hardware definition path provided for interface %s; using fallback transformer", iface)
-	}
 	transformer := getClockIDTransformer(hwDefPath)
-
-	// Step 5: Process serial number to get clock ID
 	clockID, err := transformer(serialNumber)
 	if err != nil {
 		return 0, fmt.Errorf("failed to parse serial number %s for interface %s: %w", serialNumber, iface, err)
 	}
 
 	glog.Infof("Resolved clock ID %#x for interface %s (bus: %s, serial: %s)", clockID, iface, busAddr, serialNumber)
-	glog.V(4).Infof("ClockID detail: iface=%s bus=%s serial=%s hwDef=%s clockID=%#x", iface, busAddr, serialNumber, hwDefPath, clockID)
 	return clockID, nil
 }
 

--- a/pkg/hardwareconfig/vendor_embedded.go
+++ b/pkg/hardwareconfig/vendor_embedded.go
@@ -4,6 +4,14 @@ import (
 	_ "embed"
 )
 
+// Hardware definition path constants used across the package.
+const (
+	HwDefIntelE810     = "intel/e810"
+	HwDefIntelE825     = "intel/e825"
+	HwDefDellXR8720t   = "dell/XR8720t"
+	HwDefHPEEL140Gen12 = "hpe/EL140-Gen12"
+)
+
 // Embedded hardware-vendor defaults baked into the binary.
 // Add new hardware models here as needed.
 
@@ -12,6 +20,12 @@ var intelE810DefaultsYAML []byte
 
 //go:embed hardware-vendor/intel/e825/defaults.yaml
 var intelE825DefaultsYAML []byte
+
+//go:embed hardware-vendor/dell/XR8720t/defaults.yaml
+var dellXR8720tDefaultsYAML []byte
+
+//go:embed hardware-vendor/hpe/EL140-Gen12/defaults.yaml
+var hpeEL140Gen12DefaultsYAML []byte
 
 //go:embed hardware-vendor/intel/e825/behavior-profiles.yaml
 var intelE825BehaviorProfilesYAML []byte
@@ -34,22 +48,24 @@ var hpeEL140Gen12DelaysYAML []byte
 // embeddedDefaults maps hwDefPath -> raw YAML contents.
 // Example key: "intel/e810"
 var embeddedDefaults = map[string][]byte{
-	"intel/e810": intelE810DefaultsYAML,
-	"intel/e825": intelE825DefaultsYAML,
+	HwDefIntelE810:     intelE810DefaultsYAML,
+	HwDefIntelE825:     intelE825DefaultsYAML,
+	HwDefDellXR8720t:   dellXR8720tDefaultsYAML,
+	HwDefHPEEL140Gen12: hpeEL140Gen12DefaultsYAML,
 }
 
 // embeddedBehaviorProfiles maps hwDefPath -> raw YAML contents for behavior profiles.
 // Example key: "intel/e825"
 var embeddedBehaviorProfiles = map[string][]byte{
-	"intel/e825":      intelE825BehaviorProfilesYAML,
-	"dell/XR8720t":    dellXR8720tBehaviorProfilesYAML,
-	"hpe/EL140-Gen12": hpeEL140Gen12BehaviorProfilesYAML,
+	HwDefIntelE825:     intelE825BehaviorProfilesYAML,
+	HwDefDellXR8720t:   dellXR8720tBehaviorProfilesYAML,
+	HwDefHPEEL140Gen12: hpeEL140Gen12BehaviorProfilesYAML,
 }
 
 // embeddedDelays maps hwDefPath -> raw YAML contents for delay compensation models.
 // Example key: "intel/e825"
 var embeddedDelays = map[string][]byte{
-	"intel/e825":      intelE825DelaysYAML,
-	"dell/XR8720t":    dellXR8720tDelaysYAML,
-	"hpe/EL140-Gen12": hpeEL140Gen12DelaysYAML,
+	HwDefIntelE825:     intelE825DelaysYAML,
+	HwDefDellXR8720t:   dellXR8720tDelaysYAML,
+	HwDefHPEEL140Gen12: hpeEL140Gen12DelaysYAML,
 }

--- a/pkg/ublox/ublox.go
+++ b/pkg/ublox/ublox.go
@@ -273,39 +273,40 @@ func (u *UBlox) UbloxPollStop() {
 	u.cmd.Wait()
 }
 
-// ExtractOffset extracts the tAcc offset from the incoming ubxtool data stream
-func ExtractOffset(output string) int64 {
-	// Find the line that contains "tAcc"
-	lines := strings.Split(output, "\n")
-	for _, line := range lines {
-		if strings.Contains(line, "tAcc") {
-			// Extract the offset value
-			fields := strings.Fields(line)
-			for i, field := range fields {
-				if field == "tAcc" {
-					ret, _ := strconv.ParseInt(fields[i+1], 10, 64)
-					return ret
+// ExtractOffset extracts the tAcc offset from a single ubxtool data line.
+func ExtractOffset(line string) int64 {
+	if strings.Contains(line, "tAcc") {
+		fields := strings.Fields(line)
+		for i, field := range fields {
+			if field == "tAcc" {
+				if i+1 >= len(fields) {
+					return -1
 				}
+				ret, err := strconv.ParseInt(fields[i+1], 10, 64)
+				if err != nil {
+					return -1
+				}
+				return ret
 			}
 		}
 	}
-
 	return -1
 }
 
-// ExtractNavStatus extracts the gpsFix state from the incoming ubxtool data stream
-func ExtractNavStatus(output string) int64 {
-	// Find the line that contains "gpsFix"
-	lines := strings.Split(output, "\n")
-	for _, line := range lines {
-		if strings.Contains(line, "gpsFix") {
-			// Extract the offset value
-			fields := strings.Fields(line)
-			for i, field := range fields {
-				if field == "gpsFix" {
-					ret, _ := strconv.ParseInt(fields[i+1], 10, 64)
-					return ret
+// ExtractNavStatus extracts the gpsFix state from a single ubxtool data line.
+func ExtractNavStatus(line string) int64 {
+	if strings.Contains(line, "gpsFix") {
+		fields := strings.Fields(line)
+		for i, field := range fields {
+			if field == "gpsFix" {
+				if i+1 >= len(fields) {
+					return -1
 				}
+				ret, err := strconv.ParseInt(fields[i+1], 10, 64)
+				if err != nil {
+					return -1
+				}
+				return ret
 			}
 		}
 	}

--- a/pkg/ublox/ublox_test.go
+++ b/pkg/ublox/ublox_test.go
@@ -92,6 +92,45 @@ func TestFindProtoVersion(t *testing.T) {
 
 }*/
 
+func TestExtractNavStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want int64
+	}{
+		{"3D fix", "  iTOW 218573000 gpsFix 3 flags 0xdd fixStat 0x0 flags2 0x8", 3},
+		{"no fix", "  iTOW 218573000 gpsFix 0 flags 0x00 fixStat 0x0 flags2 0x0", 0},
+		{"field missing value (truncated line)", "  iTOW 218573000 gpsFix", -1},
+		{"non-numeric value", "  iTOW 218573000 gpsFix bad", -1},
+		{"field absent", "  iTOW 218573000 flags 0xdd", -1},
+		{"empty line", "", -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ublox.ExtractNavStatus(tt.line))
+		})
+	}
+}
+
+func TestExtractOffset(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want int64
+	}{
+		{"normal", "  iTOW 218573000 clkBias 0 clkDrift 0 tAcc 23 fAcc 0", 23},
+		{"field missing value (truncated line)", "  iTOW 218573000 tAcc", -1},
+		{"non-numeric value", "  iTOW 218573000 tAcc bad", -1},
+		{"field absent", "  iTOW 218573000 clkBias 0", -1},
+		{"empty line", "", -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ublox.ExtractOffset(tt.line))
+		})
+	}
+}
+
 func Test_ExtractLeapSec(t *testing.T) {
 	data := []string{
 		"iTOW 376008000 version 0 reserved2 0 0 0 srcOfCurrLs 2",


### PR DESCRIPTION
## Upstream PRs included

- [#234](https://github.com/k8snetworkplumbingwg/linuxptp-daemon/pull/234) [CNF-22056](https://redhat.atlassian.net/browse/CNF-22056): Resolve zl3073x DPLL clock ID via pin parent chain ([CNF-22056](https://redhat.atlassian.net/browse/CNF-22056))
- [#232](https://github.com/k8snetworkplumbingwg/linuxptp-daemon/pull/232) OCPBUGS-93744: force freerun when non-leading DPLL loses lock (OCPBUGS-93744)
- [#231](https://github.com/k8snetworkplumbingwg/linuxptp-daemon/pull/231) [CNF-22693](https://redhat.atlassian.net/browse/CNF-22693): Support dynamic namespace for OLMv1 AllNamespaces ([CNF-22693](https://redhat.atlassian.net/browse/CNF-22693))
- [#230](https://github.com/k8snetworkplumbingwg/linuxptp-daemon/pull/230) Fix source identification in ptpconfigs
- [#229](https://github.com/k8snetworkplumbingwg/linuxptp-daemon/pull/229) Log per-port ptp4l state in UpdateState 
- [#227](https://github.com/k8snetworkplumbingwg/linuxptp-daemon/pull/227) Fix gnss_status always -1 due to double-newline in poll line join
- [#224](https://github.com/k8snetworkplumbingwg/linuxptp-daemon/pull/224) Track active TR port during dual-upstream T-BC switchover for correct event reporting ([CNF-25167](https://redhat.atlassian.net/browse/CNF-25167))
- [#215](https://github.com/k8snetworkplumbingwg/linuxptp-daemon/pull/215) Close GM ts2phc / phc2sys clock synchonization race condition