### PR TITLE
OCPBUGS-97962: Backport ptp4l offset filter from 4.22

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -58,8 +58,13 @@ const (
 	TGM                             = "T-GM"
 	// Offset filter size is hardcoded to 64 for now. It covers 4 seconds with reporting rate 16x/second.
 	// TODO: consider making it configurable
-	offsetFilterSize  = 64
-	ChronydSocketPath = "/tmp/chrony/chronyd.sock"
+	offsetFilterSize = 64
+	// defaultPtp4lOffsetEventWindowSize is the sliding window size for averaging ptp4l offsets
+	// before sending them to the T-BC state machine. The window should cover ~1 second of
+	// offset data. Set via PtpSettings["ptp4lOffsetEventWindowSize"]. Tune according to
+	// the ptp4l message rate: 16 for 8275.1 (16 msg/s), 128 for 8275.2 (128 msg/s).
+	defaultPtp4lOffsetEventWindowSize = 16
+	ChronydSocketPath                 = "/tmp/chrony/chronyd.sock"
 )
 
 var (
@@ -234,6 +239,9 @@ type tBCProcessAttributes struct {
 	lastAppliedState  event.PTPState
 	offsetFilter      *utils.Window
 	offsetThreshold   float64
+	// offsetEventWindow averages ptp4l offsets and sends them to the T-BC state machine once per second
+	offsetEventWindow  *utils.Window
+	lastOffsetEventSec int64
 }
 
 type ptpProcess struct {
@@ -798,6 +806,15 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 				} else {
 					dprocess.tBCAttributes.offsetThreshold = float64(getPTPThreshold(nodeProfile).MaxOffsetThreshold)
 				}
+				offsetEventWindowSize := defaultPtp4lOffsetEventWindowSize
+				if sWindowSize, wsOk := (*nodeProfile).PtpSettings["ptp4lOffsetEventWindowSize"]; wsOk {
+					if ws, parseErr := strconv.Atoi(sWindowSize); parseErr == nil && ws > 0 {
+						offsetEventWindowSize = ws
+					} else {
+						glog.Warningf("invalid ptp4lOffsetEventWindowSize %q, using default %d", sWindowSize, defaultPtp4lOffsetEventWindowSize)
+					}
+				}
+				dprocess.tBCAttributes.offsetEventWindow = utils.NewWindow(offsetEventWindowSize)
 			}
 		}
 
@@ -1064,6 +1081,40 @@ func (p *ptpProcess) checkOffsetFilterAndTransition(transitionAction func()) {
 				p.tBCAttributes.lastAppliedState = event.PTP_LOCKED
 			}
 		}
+	}
+}
+
+// sendPtp4lOffsetEvent inserts the current ptp4l offset into a sliding window and,
+// once per second, sends the window average to the T-BC state machine via the event
+// channel. This gives event_tbc.go visibility into ptp4l-level offsets for
+// freeRunCondition and getLargestOffset calculations.
+func (p *ptpProcess) sendPtp4lOffsetEvent() {
+	if p.configName != p.tBCAttributes.trPortsConfigFile || p.tBCAttributes.offsetEventWindow == nil {
+		return
+	}
+	p.tBCAttributes.offsetEventWindow.Insert(p.offset)
+
+	nowSec := time.Now().Unix()
+	if nowSec == p.tBCAttributes.lastOffsetEventSec {
+		return
+	}
+	p.tBCAttributes.lastOffsetEventSec = nowSec
+
+	avgOffset := int64(p.tBCAttributes.offsetEventWindow.Mean())
+	glog.Infof("PTP4l offset event: %d", avgOffset)
+	select {
+	case p.eventCh <- event.EventChannel{
+		ProcessName: event.PTP4l,
+		State:       p.tBCAttributes.lastReportedState,
+		CfgName:     p.configName,
+		IFace:       p.tBCAttributes.trIfaceName,
+		ClockType:   p.clockType,
+		Time:        time.Now().UnixMilli(),
+		Values: map[event.ValueType]any{
+			event.OFFSET: avgOffset,
+		},
+	}:
+	default:
 	}
 }
 

--- a/pkg/daemon/log_parsing.go
+++ b/pkg/daemon/log_parsing.go
@@ -122,6 +122,7 @@ func processParsedMetrics(process *ptpProcess, ptpMetrics *parser.Metrics) {
 		if ptpMetrics.Source == "master" && process.dn != nil {
 			process.dn.HandleDelayedPhc2sysStartup(process.name, ptpMetrics.Offset, process.nodeProfile.Name)
 		}
+		process.sendPtp4lOffsetEvent()
 	case ts2phcProcessName:
 		if process.dn != nil {
 			process.dn.HandleDelayedPhc2sysStartup(process.name, ptpMetrics.Offset, process.nodeProfile.Name)

--- a/pkg/dpll/dpll.go
+++ b/pkg/dpll/dpll.go
@@ -433,8 +433,6 @@ func (d *DpllConfig) ActivePhaseOffsetPin(pin *nl.PinInfo) (int, bool) {
 		// New behavior: An input pin is the device synchronization source when its OperState is "active".
 		// Note: In this scenario, the administrative state never exceeds "selectable".
 		if (p.State != nl.PinStateConnected && p.Operstate != nl.PinOperstateActive) || p.Direction != nl.PinDirectionInput {
-			glog.Infof("pin id %d parentID=%d skipped: direction=%s adminState=%s operstate=%s",
-				pin.ID, p.ParentID, nl.GetPinDirection(p.Direction), nl.GetPinState(p.State), nl.GetPinOperstate(p.Operstate))
 			continue
 		}
 		for _, dev := range d.devices {

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -190,6 +190,7 @@ type EventHandler struct {
 	ReduceLog          bool // reduce logs for every announce
 	LeadingClockData   *LeadingClockParams
 	portRole           map[string]map[string]*parser.PTPEvent
+	downstreamCancel   map[string]context.CancelFunc
 }
 
 // getConn returns the current event socket connection under lock.
@@ -258,6 +259,7 @@ func Init(nodeName string, stdOutToSocket bool, socketName string, processChanne
 		ReduceLog:          true,
 		LeadingClockData:   newLeadingClockParams(),
 		portRole:           map[string]map[string]*parser.PTPEvent{},
+		downstreamCancel:   map[string]context.CancelFunc{},
 	}
 
 	StateRegisterer = NewStateNotifier()

--- a/pkg/event/event_tbc.go
+++ b/pkg/event/event_tbc.go
@@ -1,6 +1,7 @@
 package event
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"strings"
@@ -267,9 +268,19 @@ func (e *EventHandler) updateDownstreamData(cfgName string) {
 		return
 	}
 	state := data.state
+
+	// Cancel any in-flight downstream update for this config before launching
+	// a new one. This prevents stale goroutines from overwriting state that a
+	// newer transition has already set.
+	if cancel, exists := e.downstreamCancel[cfgName]; exists {
+		cancel()
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	e.downstreamCancel[cfgName] = cancel
 	e.Unlock()
+
 	if state == PTP_LOCKED {
-		go e.downstreamAnnounceIWF(cfgName)
+		go e.downstreamAnnounceIWF(ctx, cfgName)
 	} else {
 		go e.announceLocalData(cfgName)
 	}
@@ -366,8 +377,27 @@ func (e *EventHandler) announceLocalData(cfgName string) {
 	}()
 }
 
+// applyIfLockedBC acquires the lock, checks that the BC state is still
+// PTP_LOCKED, and if so runs fn under the lock. Returns false if the state
+// is no longer LOCKED (fn is not called). The lock is always released via defer.
+func (e *EventHandler) applyIfLockedBC(cfgName, callContext string, fn func()) bool {
+	e.Lock()
+	defer e.Unlock()
+	stateData, ok := e.clkSyncState[cfgName]
+	if !ok || stateData.state != PTP_LOCKED {
+		state := PTP_NOTSET
+		if ok {
+			state = stateData.state
+		}
+		glog.Infof("downstreamAnnounceIWF: BC state is %s (not LOCKED) %s, aborting", state, callContext)
+		return false
+	}
+	fn()
+	return true
+}
+
 // this function runs in a goroutine
-func (e *EventHandler) downstreamAnnounceIWF(cfgName string) {
+func (e *EventHandler) downstreamAnnounceIWF(ctx context.Context, cfgName string) {
 	ptpCfgName := strings.Replace(cfgName, "ts2phc", "ptp4l", 1)
 	glog.Infof("downstreamAnnounceIWF: %s", ptpCfgName)
 
@@ -382,12 +412,23 @@ func (e *EventHandler) downstreamAnnounceIWF(cfgName string) {
 		return
 	}
 
-	// Update LeadingClockData upstream fields under lock
-	e.Lock()
-	e.LeadingClockData.upstreamParentDataSet = &upsteamData.ParentDataSet
-	e.LeadingClockData.upstreamTimeProperties = &upsteamData.TimePropertiesDS
-	e.LeadingClockData.upstreamCurrentDSStepsRemoved = upsteamData.CurrentDS.StepsRemoved
-	e.Unlock()
+	if ctx.Err() != nil {
+		glog.Info("downstreamAnnounceIWF: cancelled after PMC fetch")
+		return
+	}
+
+	if !e.applyIfLockedBC(cfgName, "after PMC fetch", func() {
+		e.LeadingClockData.upstreamParentDataSet = &upsteamData.ParentDataSet
+		e.LeadingClockData.upstreamTimeProperties = &upsteamData.TimePropertiesDS
+		e.LeadingClockData.upstreamCurrentDSStepsRemoved = upsteamData.CurrentDS.StepsRemoved
+	}) {
+		return
+	}
+
+	if ctx.Err() != nil {
+		glog.Info("downstreamAnnounceIWF: cancelled before announce")
+		return
+	}
 
 	gs := protocol.GrandmasterSettings{
 		ClockQuality: fbprotocol.ClockQuality{
@@ -412,11 +453,15 @@ func (e *EventHandler) downstreamAnnounceIWF(cfgName string) {
 	}
 	glog.Infof("%++v", es)
 
-	// Update LeadingClockData downstream fields under lock
-	e.Lock()
-	e.LeadingClockData.downstreamParentDataSet = &upsteamData.ParentDataSet
-	e.LeadingClockData.downstreamTimeProperties = &upsteamData.TimePropertiesDS
-	e.Unlock()
+	if ctx.Err() != nil {
+		glog.Info("downstreamAnnounceIWF: cancelled before downstream update")
+		return
+	}
+
+	e.applyIfLockedBC(cfgName, "after downstream announce", func() {
+		e.LeadingClockData.downstreamParentDataSet = &upsteamData.ParentDataSet
+		e.LeadingClockData.downstreamTimeProperties = &upsteamData.TimePropertiesDS
+	})
 }
 
 func (e *EventHandler) inSyncCondition(cfgName string) bool {
@@ -445,6 +490,10 @@ func (e *EventHandler) isSourceLostBC(cfgName string) bool {
 	ptpLost := true
 	dpllLost := false
 	dpllLostIface := ""
+	leadingIFace := ""
+	if css, ok := e.clkSyncState[cfgName]; ok {
+		leadingIFace = css.leadingIFace
+	}
 	if data, ok := e.data[cfgName]; ok {
 		for _, d := range data {
 			if d.ProcessName == PTP4l {
@@ -456,6 +505,9 @@ func (e *EventHandler) isSourceLostBC(cfgName string) bool {
 			}
 			if d.ProcessName == DPLL {
 				for _, dd := range d.Details {
+					if leadingIFace != "" && dd.IFace != leadingIFace {
+						continue
+					}
 					if dd.State != PTP_LOCKED {
 						dpllLost = true
 						dpllLostIface = dd.IFace
@@ -480,14 +532,16 @@ func (e *EventHandler) getLargestOffset(cfgName string) int64 {
 	staleTime := (time.Now().Unix() - StaleEventAfter) * 1000
 	if data, ok := e.data[cfgName]; ok {
 		for _, d := range data {
+			if d.window.IsEmpty() {
+				continue
+			}
+			if !d.window.IsFull() {
+				glog.Infof("Largest offset %d (window not full for %s)", FaultyPhaseOffset, d.ProcessName)
+				return FaultyPhaseOffset
+			}
 			for _, dd := range d.Details {
-				// Skip stale data for all offsets, including the first one
 				if dd.time < staleTime {
 					continue
-				}
-				if !d.window.IsFull() {
-					glog.Info("Largest offset ", FaultyPhaseOffset)
-					return FaultyPhaseOffset
 				}
 				if worstOffset == FaultyPhaseOffset {
 					if dd.IFace == e.clkSyncState[cfgName].leadingIFace {
@@ -525,14 +579,24 @@ func (e *EventHandler) freeRunCondition(cfgName string) bool {
 	}
 	if data, ok := e.data[cfgName]; ok {
 		for _, d := range data {
-			if d.ProcessName == DPLL {
+			switch d.ProcessName {
+			case DPLL:
 				for _, dd := range d.Details {
 					if dd.IFace == e.clkSyncState[cfgName].leadingIFace {
 						if math.Abs(float64(dd.Offset)) > float64(e.LeadingClockData.toFreeRunThreshold) {
-							glog.Infof("free-run condition on DPLL ", dd.IFace)
+							glog.Infof("free-run condition on DPLL %s", dd.IFace)
 							return true
 						}
 					}
+				}
+			case PTP4l:
+				if d.window.IsEmpty() {
+					continue
+				}
+				ptp4lAvgOffset := int64(d.window.Mean())
+				if math.Abs(float64(ptp4lAvgOffset)) > float64(e.LeadingClockData.toFreeRunThreshold) {
+					glog.Infof("free-run condition on PTP4l, avg offset %d", ptp4lAvgOffset)
+					return true
 				}
 			}
 		}

--- a/pkg/utils/window.go
+++ b/pkg/utils/window.go
@@ -138,6 +138,11 @@ func (w *Window) IsFull() bool {
 	return w.full
 }
 
+// IsEmpty returns true if no values have been inserted into the window
+func (w *Window) IsEmpty() bool {
+	return w.nextIndex == 0 && !w.full
+}
+
 // SetWeights sets the weights for the window values.
 // Returns an error if the weights slice is larger than the window size.
 func (w *Window) SetWeights(weights []float64) error {


### PR DESCRIPTION
Manually adapts relevant changes from iseveral commits on release-4.22 to the release-4.21 branch, excluding all hardware config controller code.

Changes:
- Add sendPtp4lOffsetEvent: feeds 1-second averaged ptp4l offsets to the T-BC state machine via a configurable sliding window (ptp4lOffsetEventWindowSize PtpSetting, default 16)
- Fix getLargestOffset: skip empty windows so unfilled ptp4l data does not return FaultyPhaseOffset and block state transitions
- Fix freeRunCondition: add PTP4l case so large ptp4l offsets trigger free-run transitions (previously only DPLL offsets were checked)
- Fix isSourceLostBC race: AddEvent now propagates SourceLost to all LOCKED DataDetails, preventing stale ports from fooling the check
- Fix downstreamAnnounceIWF stale writes: context-based cancellation and applyIfLockedBC guards prevent goroutines from overwriting state after a newer transition has already occurred
- Add Window.IsEmpty() utility method