### PR TITLE
  OCPBUGS-105276: Delay T-BC ts2phc startup until offset qualified

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -332,8 +332,10 @@ type Daemon struct {
 	// Allow vendors to include plugins
 	pluginManager plugin.PluginManager
 
-	delayedPhc2sys   atomic.Bool
-	delayedPhc2sysMu sync.Mutex // protects skipInitialStartup on phc2sys processes
+	delayedPhc2sys        atomic.Bool
+	delayedTs2phc         atomic.Bool
+	ts2phcSourceQualified atomic.Bool // DPLL-enable / offset-filter gate has fired for T-BC
+	delayedStartupMu      sync.Mutex  // protects skipInitialStartup on delayed phc2sys/ts2phc processes
 }
 
 // New LinuxPTP is called by daemon to generate new linuxptp instance
@@ -533,13 +535,18 @@ func (dn *Daemon) applyNodePTPProfiles() error {
 			dn.pluginManager.AfterRunPTPCommand(&p.nodeProfile, p.name)
 		}
 	}
-	// Arm the delayed-phc2sys flag now that the startup loop is complete.
-	// Keeping it false during the loop ensures HandleDelayedPhc2sysStartup
-	// cannot clear skipInitialStartup and race with the loop's skip check.
+	// Arm delayed-startup flags now that the startup loop is complete.
+	// Keeping them false during the loop ensures release handlers cannot
+	// clear skipInitialStartup and race with the loop's skip check.
 	for _, p := range dn.processManager.process {
-		if p != nil && p.skipInitialStartup != "" {
+		if p == nil || p.skipInitialStartup == "" {
+			continue
+		}
+		switch p.name {
+		case phc2sysProcessName:
 			dn.delayedPhc2sys.Store(true)
-			break
+		case ts2phcProcessName:
+			dn.delayedTs2phc.Store(true)
 		}
 	}
 	dn.pluginManager.PopulateHwConfig(dn.hwconfigs)
@@ -836,11 +843,19 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 		if pProcess == phc2sysProcessName {
 			glog.Infof("Setting up phc2sys (%s)", clockType)
 			// Delay phc2sys startup until the clock source has synchronized.
-			dn.delayedPhc2sysMu.Lock()
+			dn.delayedStartupMu.Lock()
 			dprocess.skipInitialStartup = "waiting for PHC synchronization before adjusting system time"
-			dn.delayedPhc2sysMu.Unlock()
+			dn.delayedStartupMu.Unlock()
 			glog.Infof("Delaying phc2sys startup: %s", dprocess.skipInitialStartup)
 		} else if pProcess == ts2phcProcessName { //& if the x plugin is enabled
+			// T-BC: delay ts2phc until the same gate that enables DPLL inputs
+			// (offset filter / PTPSourceQualified). T-GM must start ts2phc first.
+			if profileClockType == TBC {
+				dn.delayedStartupMu.Lock()
+				dprocess.skipInitialStartup = "waiting for PTPSourceQualified (DPLL-enable) before disciplining follower PHCs"
+				dn.delayedStartupMu.Unlock()
+				glog.Infof("Delaying ts2phc startup: %s", dprocess.skipInitialStartup)
+			}
 			if clockType == event.GM {
 				if output.gnss_serial_port == "" {
 					output.gnss_serial_port = GPSPIPE_SERIALPORT
@@ -1366,7 +1381,7 @@ func (p *ptpProcess) cmdSetEnabled(enabled bool) {
 	p.cmdSetEnabledMutex.Lock()
 	defer p.cmdSetEnabledMutex.Unlock()
 	switch p.name {
-	case "chronyd":
+	case chronydProcessName, phc2sysProcessName, ts2phcProcessName:
 		if enabled {
 			if p.Stopped() && p.cmd != nil {
 				cmd := p.cmd
@@ -1374,17 +1389,8 @@ func (p *ptpProcess) cmdSetEnabled(enabled bool) {
 				p.cmd = newCmd
 				go p.cmdRun(p.dn.stdoutToSocket, &(p.dn.pluginManager))
 			}
-		} else {
+		} else if p.name == chronydProcessName {
 			go p.cmdStop()
-		}
-	case "phc2sys":
-		if enabled {
-			if p.Stopped() && p.cmd != nil {
-				cmd := p.cmd
-				newCmd := exec.Command(cmd.Args[0], cmd.Args[1:]...)
-				p.cmd = newCmd
-				go p.cmdRun(p.dn.stdoutToSocket, &(p.dn.pluginManager))
-			}
 		} else {
 			p.cmdStop()
 		}
@@ -1420,9 +1426,9 @@ func (dn *Daemon) HandleDelayedPhc2sysStartup(source string, offset float64, pro
 		return
 	}
 	if math.Abs(offset) < 1000000000 {
-		dn.delayedPhc2sysMu.Lock()
-		defer dn.delayedPhc2sysMu.Unlock()
+		dn.delayedStartupMu.Lock()
 		if !dn.delayedPhc2sys.Load() { // re-check under lock
+			dn.delayedStartupMu.Unlock()
 			return
 		}
 		for _, proc := range dn.processManager.findProcessesByName(phc2sysProcessName) {
@@ -1442,13 +1448,85 @@ func (dn *Daemon) HandleDelayedPhc2sysStartup(source string, offset float64, pro
 			}
 		}
 		// Only clear the daemon-wide flag once no phc2sys processes remain delayed.
+		phc2sysStillDelayed := false
 		for _, proc := range dn.processManager.findProcessesByName(phc2sysProcessName) {
 			if proc.skipInitialStartup != "" {
-				return
+				phc2sysStillDelayed = true
+				break
 			}
 		}
-		dn.delayedPhc2sys.Store(false)
+		if !phc2sysStillDelayed {
+			dn.delayedPhc2sys.Store(false)
+		}
+		dn.delayedStartupMu.Unlock()
+		// phc2sys may have been the last blocker for an already-qualified ts2phc.
+		dn.TryReleaseDelayedTs2phc(profileName)
 	}
+}
+
+// NotifyTs2phcSourceQualified records that the T-BC DPLL-enable / offset-filter
+// gate has been met and attempts to start any delayed ts2phc processes.
+func (dn *Daemon) NotifyTs2phcSourceQualified(profileName *string) {
+	dn.ts2phcSourceQualified.Store(true)
+	dn.TryReleaseDelayedTs2phc(profileName)
+}
+
+// TryReleaseDelayedTs2phc starts delayed T-BC ts2phc processes once the
+// DPLL-enable gate has fired and phc2sys (if present) is no longer delayed.
+func (dn *Daemon) TryReleaseDelayedTs2phc(profileName *string) {
+	if !dn.delayedTs2phc.Load() || !dn.ts2phcSourceQualified.Load() {
+		return
+	}
+	dn.delayedStartupMu.Lock()
+	defer dn.delayedStartupMu.Unlock()
+	if !dn.delayedTs2phc.Load() || !dn.ts2phcSourceQualified.Load() {
+		return
+	}
+	if dn.phc2sysBlocksTs2phcLocked(profileName) {
+		glog.Infof("ts2phc remains delayed: waiting for phc2sys release before starting")
+		return
+	}
+	for _, proc := range dn.processManager.findProcessesByName(ts2phcProcessName) {
+		if proc.skipInitialStartup == "" || proc.nodeProfile.Name == nil {
+			continue
+		}
+		if profileName != nil && *proc.nodeProfile.Name != *profileName {
+			_, linkedByHA := proc.haProfile[*profileName]
+			if !linkedByHA {
+				continue
+			}
+		}
+		glog.Infof("PTPSourceQualified (DPLL-enable) met; enabling %s", proc.name)
+		proc.skipInitialStartup = ""
+		proc.cmdSetEnabled(true)
+		dn.pluginManager.AfterRunPTPCommand(&proc.nodeProfile, proc.name)
+	}
+	for _, proc := range dn.processManager.findProcessesByName(ts2phcProcessName) {
+		if proc.skipInitialStartup != "" {
+			return
+		}
+	}
+	dn.delayedTs2phc.Store(false)
+}
+
+// phc2sysBlocksTs2phcLocked reports whether a still-delayed phc2sys should
+// prevent ts2phc release. Caller must hold delayedStartupMu.
+func (dn *Daemon) phc2sysBlocksTs2phcLocked(profileName *string) bool {
+	for _, proc := range dn.processManager.findProcessesByName(phc2sysProcessName) {
+		if proc.skipInitialStartup == "" {
+			continue
+		}
+		if profileName == nil || proc.nodeProfile.Name == nil {
+			return true
+		}
+		if *proc.nodeProfile.Name == *profileName {
+			return true
+		}
+		if _, linkedByHA := proc.haProfile[*profileName]; linkedByHA {
+			return true
+		}
+	}
+	return false
 }
 
 func (p *ptpProcess) ProcessTs2PhcEvents(ptpOffset float64, source string, iface string, state event.PTPState, extraValue map[event.ValueType]interface{}) {

--- a/pkg/daemon/daemon_internal_test.go
+++ b/pkg/daemon/daemon_internal_test.go
@@ -164,12 +164,15 @@ func Test_applyProfile_TBC(t *testing.T) {
 		err = dn.applyNodePtpProfile(0, profile)
 		assert.NoError(t, err)
 
-		// Ensure for T-BC that phc2sys is selected for delayed-start
+		// Ensure for T-BC that phc2sys and ts2phc are selected for delayed-start
 		actualProcesses := []string{}
 		for _, p := range dn.processManager.process {
 			actualProcesses = append(actualProcesses, p.name)
 			if p.name == phc2sysProcessName {
 				assert.NotEmpty(t, p.skipInitialStartup, "Ensure phc2sys is startup-delayed for T-BC")
+			}
+			if p.name == ts2phcProcessName {
+				assert.NotEmpty(t, p.skipInitialStartup, "Ensure ts2phc is startup-delayed for T-BC")
 			}
 		}
 		assert.ElementsMatch(t, test.expectedProcesses, actualProcesses, "Ensure T-BC has the required processes prepared (%s)", test.dataFile)
@@ -219,6 +222,7 @@ func Test_applyProfile_TGM(t *testing.T) {
 		switch p.name {
 		case ts2phcProcessName:
 			ts2phcProc = p
+			assert.Empty(t, p.skipInitialStartup, "T-GM ts2phc must not be startup-delayed")
 		case ptp4lProcessName:
 			ptp4lProc = p
 		case phc2sysProcessName:
@@ -561,6 +565,16 @@ func TestReady_DelayedPhc2sysNotReportedAsStopped(t *testing.T) {
 	assert.True(t, ok, msg)
 }
 
+func TestReady_DelayedTs2phcNotReportedAsStopped(t *testing.T) {
+	rt := makeReadyTracker([]*ptpProcess{
+		{name: ptp4lProcessName, stopped: false, hasCollectedMetrics: true},
+		{name: ts2phcProcessName, stopped: true, skipInitialStartup: testSkipStartupReason},
+		{name: phc2sysProcessName, stopped: true, skipInitialStartup: testSkipStartupReason},
+	})
+	ok, msg := rt.Ready()
+	assert.True(t, ok, msg)
+}
+
 func TestReady_NilProcessEntrySkipped(t *testing.T) {
 	// nil slots in the process slice must not panic.
 	rt := makeReadyTracker([]*ptpProcess{
@@ -720,6 +734,74 @@ func TestDelayedPhc2sysStartup_HAProfile(t *testing.T) {
 	assert.Equal(t, "", phc2sys.skipInitialStartup,
 		"sub-second offset from HA-linked profile should start phc2sys")
 	assert.False(t, dn.delayedPhc2sys.Load())
+}
+
+func TestDelayedTs2phcStartup(t *testing.T) {
+	profileName := "test-tbc-profile"
+	nodeProfile := ptpv1.PtpProfile{Name: &profileName}
+
+	pm := &ProcessManager{process: []*ptpProcess{}}
+	dn := &Daemon{processManager: pm}
+
+	phc2sys := &ptpProcess{
+		name:               phc2sysProcessName,
+		skipInitialStartup: testSkipStartupReason,
+		nodeProfile:        nodeProfile,
+		dn:                 dn,
+		stopped:            true,
+	}
+	ts2phc := &ptpProcess{
+		name:               ts2phcProcessName,
+		skipInitialStartup: testSkipStartupReason,
+		nodeProfile:        nodeProfile,
+		dn:                 dn,
+		stopped:            true,
+	}
+	pm.process = append(pm.process, phc2sys, ts2phc)
+
+	dn.delayedTs2phc.Store(true)
+
+	// 1. Without DPLL-enable qualification, ts2phc must stay delayed.
+	dn.TryReleaseDelayedTs2phc(&profileName)
+	assert.Equal(t, testSkipStartupReason, ts2phc.skipInitialStartup)
+	assert.True(t, dn.delayedTs2phc.Load())
+
+	// 2. Qualification met but phc2sys still delayed: ts2phc stays delayed.
+	dn.NotifyTs2phcSourceQualified(&profileName)
+	assert.Equal(t, testSkipStartupReason, ts2phc.skipInitialStartup,
+		"ts2phc must wait for phc2sys even after DPLL-enable qualification")
+	assert.True(t, dn.delayedTs2phc.Load())
+
+	// 3. Release phc2sys (1s gate), then ts2phc should start.
+	dn.delayedPhc2sys.Store(true)
+	dn.HandleDelayedPhc2sysStartup(ptp4lProcessName, 500000000.0, &profileName)
+	assert.Equal(t, "", phc2sys.skipInitialStartup)
+	assert.Equal(t, "", ts2phc.skipInitialStartup,
+		"ts2phc should start once qualified and phc2sys is released")
+	assert.False(t, dn.delayedTs2phc.Load())
+}
+
+func TestDelayedTs2phcStartup_NoPhc2sys(t *testing.T) {
+	profileName := "test-tbc-ts2phc-only"
+	nodeProfile := ptpv1.PtpProfile{Name: &profileName}
+
+	pm := &ProcessManager{process: []*ptpProcess{}}
+	dn := &Daemon{processManager: pm}
+
+	ts2phc := &ptpProcess{
+		name:               ts2phcProcessName,
+		skipInitialStartup: testSkipStartupReason,
+		nodeProfile:        nodeProfile,
+		dn:                 dn,
+		stopped:            true,
+	}
+	pm.process = append(pm.process, ts2phc)
+	dn.delayedTs2phc.Store(true)
+
+	dn.NotifyTs2phcSourceQualified(&profileName)
+	assert.Equal(t, "", ts2phc.skipInitialStartup,
+		"without phc2sys, ts2phc should start as soon as DPLL-enable fires")
+	assert.False(t, dn.delayedTs2phc.Load())
 }
 
 func TestFindProcessesByName(t *testing.T) {

--- a/pkg/daemon/log_parsing.go
+++ b/pkg/daemon/log_parsing.go
@@ -128,6 +128,9 @@ func processParsedMetrics(process *ptpProcess, ptpMetrics *parser.Metrics) {
 				process.dn.pluginManager.AfterRunPTPCommand(&process.nodeProfile, "tbc-ho-exit")
 				process.lastTransitionResult = event.PTP_LOCKED
 				process.sendPtp4lEvent()
+				if process.dn != nil {
+					process.dn.NotifyTs2phcSourceQualified(process.nodeProfile.Name)
+				}
 			})
 		}
 	case ts2phcProcessName:


### PR DESCRIPTION
Manual cherry-pick
Hold ts2phc behind skipInitialStartup on T-BC until the offset-filter gate that enables DPLL inputs fires (tbc-ho-exit), and only after phc2sys is released. Leave T-GM ts2phc-first ordering and the phc2sys 1s delay unchanged.

Backport of np-linuxptp-daemon 735e83a4 adapted for release-4.20's legacy log_parsing path (no hardwareconfig transition helpers).